### PR TITLE
Move easily portable and repeated MPI calls to `common/` 

### DIFF
--- a/src/common/m_mpi_common.fpp
+++ b/src/common/m_mpi_common.fpp
@@ -1,0 +1,354 @@
+
+#:include 'macros.fpp'
+
+!> @brief The module serves as a proxy to the parameters and subroutines
+!!          available in the MPI implementation's MPI module. Specifically,
+!!          the purpose of the proxy is to harness basic MPI commands into
+!!          more complicated procedures as to accomplish the communication
+!!          goals for the simulation.
+module m_mpi_common
+
+    ! Dependencies =============================================================
+#ifdef MFC_MPI
+    use mpi                    !< Message passing interface (MPI) module
+#endif
+
+    use m_derived_types        !< Definitions of the derived types
+
+    use m_global_parameters    !< Definitions of the global parameters
+    ! ==========================================================================
+
+    implicit none
+
+    !> @name Generic flags used to identify and report MPI errors
+    !> @{
+    integer, private :: ierr
+    !> @}
+
+contains
+
+
+    !> The subroutine intializes the MPI execution environment
+        !!      and queries both the number of processors which will be
+        !!      available for the job and the local processor rank.
+    subroutine s_mpi_initialize() ! ----------------------------------------
+
+#ifndef MFC_MPI
+
+        ! Serial run only has 1 processor
+        num_procs = 1
+        ! Local processor rank is 0
+        proc_rank = 0
+
+#else
+
+        ! Initializing the MPI environment
+        call MPI_INIT(ierr)
+
+        ! Checking whether the MPI environment has been properly intialized
+        if (ierr /= MPI_SUCCESS) then
+            print '(A)', 'Unable to initialize MPI environment. Exiting ...'
+            call MPI_ABORT(MPI_COMM_WORLD, 1, ierr)
+        end if
+
+        ! Querying the number of processors available for the job
+        call MPI_COMM_SIZE(MPI_COMM_WORLD, num_procs, ierr)
+
+        ! Querying the rank of the local processor
+        call MPI_COMM_RANK(MPI_COMM_WORLD, proc_rank, ierr)
+
+#endif
+
+    end subroutine s_mpi_initialize ! --------------------------------------
+
+
+    subroutine s_initialize_mpi_data(q_cons_vf) ! --------------------------
+
+        type(scalar_field), &
+            dimension(sys_size), &
+            intent(IN) :: q_cons_vf
+
+        integer, dimension(num_dims) :: sizes_glb, sizes_loc
+        integer :: ierr
+
+#ifdef MFC_MPI
+
+        ! Generic loop iterator
+        integer :: i
+
+        do i = 1, sys_size
+#ifdef MPI_SIMULATION
+            MPI_IO_DATA%var(i)%sf => q_cons_vf(i)%sf
+#else
+            MPI_IO_DATA%var(i)%sf => q_cons_vf(i)%sf(0:m, 0:n, 0:p)
+#endif
+        end do
+
+        ! Define global(g) and local(l) sizes for flow variables
+        sizes_glb(1) = m_glb + 1; sizes_loc(1) = m + 1
+        if (n > 0) then
+            sizes_glb(2) = n_glb + 1; sizes_loc(2) = n + 1
+            if (p > 0) then
+                sizes_glb(3) = p_glb + 1; sizes_loc(3) = p + 1
+            end if
+        end if
+
+        ! Define the view for each variable
+        do i = 1, sys_size
+            call MPI_TYPE_CREATE_SUBARRAY(num_dims, sizes_glb, sizes_loc, start_idx, &
+                                          MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, MPI_IO_DATA%view(i), ierr)
+            call MPI_TYPE_COMMIT(MPI_IO_DATA%view(i), ierr)
+        end do
+
+#endif
+
+    end subroutine s_initialize_mpi_data ! ---------------------------------
+
+
+    subroutine mpi_bcast_time_step_values(proc_time, time_avg)
+
+        real(kind(0d0)), dimension(0:num_procs - 1), intent(INOUT) :: proc_time
+        real(kind(0d0)), intent(INOUT) :: time_avg
+
+#ifdef MFC_MPI
+
+        call MPI_GATHER(time_avg, 1, MPI_DOUBLE_PRECISION, proc_time(0), 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+
+#endif
+
+    end subroutine mpi_bcast_time_step_values
+
+
+    !>  The goal of this subroutine is to determine the global
+        !!      extrema of the stability criteria in the computational
+        !!      domain. This is performed by sifting through the local
+        !!      extrema of each stability criterion. Note that each of
+        !!      the local extrema is from a single process, within its
+        !!      assigned section of the computational domain. Finally,
+        !!      note that the global extrema values are only bookkeept
+        !!      on the rank 0 processor.
+        !!  @param icfl_max_loc Local maximum ICFL stability criterion
+        !!  @param vcfl_max_loc Local maximum VCFL stability criterion
+        !!  @param Rc_min_loc Local minimum Rc stability criterion
+        !!  @param icfl_max_glb Global maximum ICFL stability criterion
+        !!  @param vcfl_max_glb Global maximum VCFL stability criterion
+        !!  @param Rc_min_glb Global minimum Rc stability criterion
+    subroutine s_mpi_reduce_stability_criteria_extrema(icfl_max_loc, & ! --
+                                                       vcfl_max_loc, &
+                                                       ccfl_max_loc, &
+                                                       Rc_min_loc, &
+                                                       icfl_max_glb, &
+                                                       vcfl_max_glb, &
+                                                       ccfl_max_glb, &
+                                                       Rc_min_glb)
+
+        real(kind(0d0)), intent(IN) :: icfl_max_loc
+        real(kind(0d0)), intent(IN) :: vcfl_max_loc
+        real(kind(0d0)), intent(IN) :: ccfl_max_loc
+        real(kind(0d0)), intent(IN) :: Rc_min_loc
+
+        real(kind(0d0)), intent(OUT) :: icfl_max_glb
+        real(kind(0d0)), intent(OUT) :: vcfl_max_glb
+        real(kind(0d0)), intent(OUT) :: ccfl_max_glb
+        real(kind(0d0)), intent(OUT) :: Rc_min_glb
+
+#ifdef MFC_MPI
+#ifdef MFC_SIMULATION
+
+        ! Reducing local extrema of ICFL, VCFL, CCFL and Rc numbers to their
+        ! global extrema and bookkeeping the results on the rank 0 processor
+        call MPI_REDUCE(icfl_max_loc, icfl_max_glb, 1, &
+                        MPI_DOUBLE_PRECISION, MPI_MAX, 0, &
+                        MPI_COMM_WORLD, ierr)
+
+        if (any(Re_size > 0)) then
+            call MPI_REDUCE(vcfl_max_loc, vcfl_max_glb, 1, &
+                            MPI_DOUBLE_PRECISION, MPI_MAX, 0, &
+                            MPI_COMM_WORLD, ierr)
+            call MPI_REDUCE(Rc_min_loc, Rc_min_glb, 1, &
+                            MPI_DOUBLE_PRECISION, MPI_MIN, 0, &
+                            MPI_COMM_WORLD, ierr)
+        end if
+
+#endif
+#endif
+
+    end subroutine s_mpi_reduce_stability_criteria_extrema ! ---------------
+
+
+    !>  The following subroutine takes the input local variable
+        !!      from all processors and reduces to the sum of all
+        !!      values. The reduced variable is recorded back onto the
+        !!      original local variable on each processor.
+        !!  @param var_loc Some variable containing the local value which should be
+        !!  reduced amongst all the processors in the communicator.
+        !!  @param var_glb The globally reduced value
+    subroutine s_mpi_allreduce_sum(var_loc, var_glb) ! ---------------------
+
+        real(kind(0d0)), intent(IN) :: var_loc
+        real(kind(0d0)), intent(OUT) :: var_glb
+
+#ifdef MFC_MPI
+
+        ! Performing the reduction procedure
+        call MPI_ALLREDUCE(var_loc, var_glb, 1, MPI_DOUBLE_PRECISION, &
+                           MPI_SUM, MPI_COMM_WORLD, ierr)
+
+#endif
+
+    end subroutine s_mpi_allreduce_sum ! -----------------------------------
+
+    !>  The following subroutine takes the input local variable
+        !!      from all processors and reduces to the minimum of all
+        !!      values. The reduced variable is recorded back onto the
+        !!      original local variable on each processor.
+        !!  @param var_loc Some variable containing the local value which should be
+        !!  reduced amongst all the processors in the communicator.
+        !!  @param var_glb The globally reduced value
+    subroutine s_mpi_allreduce_min(var_loc, var_glb) ! ---------------------
+
+        real(kind(0d0)), intent(IN) :: var_loc
+        real(kind(0d0)), intent(OUT) :: var_glb
+
+#ifdef MFC_MPI
+
+        ! Performing the reduction procedure
+        call MPI_ALLREDUCE(var_loc, var_glb, 1, MPI_DOUBLE_PRECISION, &
+                           MPI_MIN, MPI_COMM_WORLD, ierr)
+
+#endif
+
+    end subroutine s_mpi_allreduce_min ! -----------------------------------
+
+    !>  The following subroutine takes the input local variable
+        !!      from all processors and reduces to the maximum of all
+        !!      values. The reduced variable is recorded back onto the
+        !!      original local variable on each processor.
+        !!  @param var_loc Some variable containing the local value which should be
+        !!  reduced amongst all the processors in the communicator.
+        !!  @param var_glb The globally reduced value
+    subroutine s_mpi_allreduce_max(var_loc, var_glb) ! ---------------------
+
+        real(kind(0d0)), intent(IN) :: var_loc
+        real(kind(0d0)), intent(OUT) :: var_glb
+
+#ifdef MFC_MPI
+
+        ! Performing the reduction procedure
+        call MPI_ALLREDUCE(var_loc, var_glb, 1, MPI_DOUBLE_PRECISION, &
+                           MPI_MAX, MPI_COMM_WORLD, ierr)
+
+#endif
+
+    end subroutine s_mpi_allreduce_max ! -----------------------------------
+
+
+    !>  The following subroutine takes the inputted variable and
+        !!      determines its minimum value on the entire computational
+        !!      domain. The result is stored back into inputted variable.
+        !!  @param var_loc holds the local value to be reduced among
+        !!      all the processors in communicator. On output, the variable holds
+        !!      the minimum value, reduced amongst all of the local values.
+    subroutine s_mpi_reduce_min(var_loc) ! ---------------------------------
+
+        real(kind(0d0)), intent(INOUT) :: var_loc
+
+#ifdef MFC_MPI
+
+        ! Temporary storage variable that holds the reduced minimum value
+        real(kind(0d0)) :: var_glb
+
+        ! Performing reduction procedure and eventually storing its result
+        ! into the variable that was initially inputted into the subroutine
+        call MPI_REDUCE(var_loc, var_glb, 1, MPI_DOUBLE_PRECISION, &
+                        MPI_MIN, 0, MPI_COMM_WORLD, ierr)
+
+        call MPI_BCAST(var_glb, 1, MPI_DOUBLE_PRECISION, &
+                       0, MPI_COMM_WORLD, ierr)
+
+        var_loc = var_glb
+
+#endif
+
+    end subroutine s_mpi_reduce_min ! --------------------------------------
+
+
+    !>  The following subroutine takes the first element of the
+        !!      2-element inputted variable and determines its maximum
+        !!      value on the entire computational domain. The result is
+        !!      stored back into the first element of the variable while
+        !!      the rank of the processor that is in charge of the sub-
+        !!      domain containing the maximum is stored into the second
+        !!      element of the variable.
+        !!  @param var_loc On input, this variable holds the local value and processor rank,
+        !!  which are to be reduced among all the processors in communicator.
+        !!  On output, this variable holds the maximum value, reduced amongst
+        !!  all of the local values, and the process rank to which the value
+        !!  belongs.
+    subroutine s_mpi_reduce_maxloc(var_loc) ! ------------------------------
+
+        real(kind(0d0)), dimension(2), intent(INOUT) :: var_loc
+
+#ifdef MFC_MPI
+
+        real(kind(0d0)), dimension(2) :: var_glb  !<
+            !! Temporary storage variable that holds the reduced maximum value
+            !! and the rank of the processor with which the value is associated
+
+        ! Performing reduction procedure and eventually storing its result
+        ! into the variable that was initially inputted into the subroutine
+        call MPI_REDUCE(var_loc, var_glb, 1, MPI_2DOUBLE_PRECISION, &
+                        MPI_MAXLOC, 0, MPI_COMM_WORLD, ierr)
+
+        call MPI_BCAST(var_glb, 1, MPI_2DOUBLE_PRECISION, &
+                       0, MPI_COMM_WORLD, ierr)
+
+        var_loc = var_glb
+
+#endif
+
+    end subroutine s_mpi_reduce_maxloc ! -----------------------------------
+
+    !> The subroutine terminates the MPI execution environment.
+    subroutine s_mpi_abort() ! ---------------------------------------------
+
+#ifndef MFC_MPI
+
+        stop 1
+
+#else
+
+        ! Terminating the MPI environment
+        call MPI_ABORT(MPI_COMM_WORLD, 1, ierr)
+
+#endif
+
+    end subroutine s_mpi_abort ! -------------------------------------------
+
+    !>Halts all processes until all have reached barrier.
+    subroutine s_mpi_barrier() ! -------------------------------------------
+
+#ifdef MFC_MPI
+
+        ! Calling MPI_BARRIER
+        call MPI_BARRIER(MPI_COMM_WORLD, ierr)
+
+#endif
+
+    end subroutine s_mpi_barrier ! -----------------------------------------
+
+
+    !> The subroutine finalizes the MPI execution environment.
+    subroutine s_mpi_finalize() ! ------------------------------------------
+
+#ifdef MFC_MPI
+
+        ! Finalizing the MPI environment
+        call MPI_FINALIZE(ierr)
+
+#endif
+
+    end subroutine s_mpi_finalize ! ----------------------------------------
+
+
+end module m_mpi_common

--- a/src/post_process/m_mpi_proxy.fpp
+++ b/src/post_process/m_mpi_proxy.fpp
@@ -17,6 +17,8 @@ module m_mpi_proxy
     use m_derived_types         !< Definitions of the derived types
 
     use m_global_parameters     !< Global parameters for the code
+
+    use m_mpi_common
     ! ==========================================================================
 
     implicit none
@@ -44,105 +46,6 @@ module m_mpi_proxy
 
 contains
 
-    !>  The subroutine intializes the MPI environment and queries
-        !!      both the number of processors that will be available for
-        !!      the job as well as the local processor rank.
-    subroutine s_mpi_initialize() ! ----------------------------
-
-#ifndef MFC_MPI
-
-        ! Serial run only has 1 processor
-        num_procs = 1
-        ! Local processor rank is 0
-        proc_rank = 0
-
-#else
-
-        ! Establishing the MPI environment
-        call MPI_INIT(ierr)
-
-        ! Checking whether the MPI environment has been properly intialized
-        if (ierr /= MPI_SUCCESS) then
-            print '(A)', 'Unable to initialize MPI environment. Exiting ...'
-            call MPI_ABORT(MPI_COMM_WORLD, 1, ierr)
-        end if
-
-        ! Querying number of processors available for the job
-        call MPI_COMM_SIZE(MPI_COMM_WORLD, num_procs, ierr)
-
-        ! Identifying the rank of the local processor
-        call MPI_COMM_RANK(MPI_COMM_WORLD, proc_rank, ierr)
-
-#endif
-
-    end subroutine s_mpi_initialize ! --------------------------
-
-    !> The subroutine terminates the MPI execution environment.
-    subroutine s_mpi_abort() ! ---------------------------------------------
-
-#ifndef MFC_MPI
-
-        stop 1
-
-#else
-
-        ! Terminating the MPI environment
-        call MPI_ABORT(MPI_COMM_WORLD, 1, ierr)
-
-#endif
-
-    end subroutine s_mpi_abort ! -------------------------------------------
-
-    !> This subroutine defines local and global sizes for the data
-    !> @name q_cons_vf Conservative variables
-    subroutine s_initialize_mpi_data(q_cons_vf) ! --------------------------
-
-        type(scalar_field), &
-            dimension(sys_size), &
-            intent(IN) :: q_cons_vf
-
-#ifdef MFC_MPI
-
-        integer, dimension(num_dims) :: sizes_glb, sizes_loc
-        integer :: ierr
-
-        integer :: i !< Generic loop iterator
-
-        do i = 1, sys_size
-            MPI_IO_DATA%var(i)%sf => q_cons_vf(i)%sf(0:m, 0:n, 0:p)
-        end do
-
-        ! Define global(g) and local(l) sizes for flow variables
-        sizes_glb(1) = m_glb + 1; sizes_loc(1) = m + 1
-        if (n > 0) then
-            sizes_glb(2) = n_glb + 1; sizes_loc(2) = n + 1
-            if (p > 0) then
-                sizes_glb(3) = p_glb + 1; sizes_loc(3) = p + 1
-            end if
-        end if
-
-        ! Define the view for each variable
-        do i = 1, sys_size
-            call MPI_TYPE_CREATE_SUBARRAY(num_dims, sizes_glb, sizes_loc, start_idx, &
-                                          MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, MPI_IO_DATA%view(i), ierr)
-            call MPI_TYPE_COMMIT(MPI_IO_DATA%view(i), ierr)
-        end do
-
-#endif
-
-    end subroutine s_initialize_mpi_data ! ---------------------------------
-
-    !>Halts all processes until all have reached barrier.
-    subroutine s_mpi_barrier() ! -------------------------------------------
-
-#ifdef MFC_MPI
-
-        ! Calling MPI_BARRIER
-        call MPI_BARRIER(MPI_COMM_WORLD, ierr)
-
-#endif
-
-    end subroutine s_mpi_barrier ! -----------------------------------------
 
     !>  Computation of parameters, allocation procedures, and/or
         !!      any other tasks needed to properly setup the module
@@ -1461,41 +1364,6 @@ contains
 
     end subroutine s_mpi_sendrecv_cons_vars_buffer_regions ! ---------------
 
-    !>  The following subroutine takes the first element of the
-        !!      2-element inputted variable and determines its maximum
-        !!      value on the entire computational domain. The result is
-        !!      stored back into the first element of the variable while
-        !!      the rank of the processor that is in charge of the sub-
-        !!      domain containing the maximum is stored into the second
-        !!      element of the variable.
-        !!  @param var_loc On input, this variable holds the local value and processor rank,
-        !!  which are to be reduced among all the processors in communicator.
-        !!  On output, this variable holds the maximum value, reduced amongst
-        !!  all of the local values, and the process rank to which the value
-        !!  belongs.
-    subroutine s_mpi_reduce_maxloc(var_loc) ! ------------------------------
-
-        real(kind(0d0)), dimension(2), intent(INOUT) :: var_loc
-
-#ifdef MFC_MPI
-
-        real(kind(0d0)), dimension(2) :: var_glb  !<
-            !! Temporary storage variable that holds the reduced maximum value
-            !! and the rank of the processor with which the value is associated
-
-        ! Performing reduction procedure and eventually storing its result
-        ! into the variable that was initially inputted into the subroutine
-        call MPI_REDUCE(var_loc, var_glb, 1, MPI_2DOUBLE_PRECISION, &
-                        MPI_MAXLOC, 0, MPI_COMM_WORLD, ierr)
-
-        call MPI_BCAST(var_glb, 1, MPI_2DOUBLE_PRECISION, &
-                       0, MPI_COMM_WORLD, ierr)
-
-        var_loc = var_glb
-
-#endif
-
-    end subroutine s_mpi_reduce_maxloc ! -----------------------------------
 
     !>  This subroutine gathers the Silo database metadata for
         !!      the spatial extents in order to boost the performance of
@@ -1733,16 +1601,5 @@ contains
 
     end subroutine s_finalize_mpi_proxy_module ! -------------------------
 
-    !> Finalization of all MPI related processes
-    subroutine s_mpi_finalize() ! ------------------------------
-
-#ifdef MFC_MPI
-
-        ! Terminating the MPI environment
-        call MPI_FINALIZE(ierr)
-
-#endif
-
-    end subroutine s_mpi_finalize ! ----------------------------
 
 end module m_mpi_proxy

--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -20,6 +20,8 @@ module m_mpi_proxy
     use m_derived_types        !< Definitions of the derived types
 
     use m_global_parameters    !< Definitions of the global parameters
+
+    use m_mpi_common
     ! ==========================================================================
 
     implicit none
@@ -46,106 +48,6 @@ module m_mpi_proxy
     !integer :: nCalls_time = 0
 
 contains
-
-    !> The subroutine intializes the MPI execution environment
-        !!      and queries both the number of processors which will be
-        !!      available for the job and the local processor rank.
-    subroutine s_mpi_initialize() ! ----------------------------------------
-
-#ifndef MFC_MPI
-
-        ! Serial run only has 1 processor
-        num_procs = 1
-        ! Local processor rank is 0
-        proc_rank = 0
-
-#else
-
-        ! Initializing the MPI environment
-        call MPI_INIT(ierr)
-
-        ! Checking whether the MPI environment has been properly intialized
-        if (ierr /= MPI_SUCCESS) then
-            print '(A)', 'Unable to initialize MPI environment. Exiting ...'
-            call MPI_ABORT(MPI_COMM_WORLD, 1, ierr)
-        end if
-
-        ! Querying the number of processors available for the job
-        call MPI_COMM_SIZE(MPI_COMM_WORLD, num_procs, ierr)
-
-        ! Querying the rank of the local processor
-        call MPI_COMM_RANK(MPI_COMM_WORLD, proc_rank, ierr)
-
-#endif
-
-    end subroutine s_mpi_initialize ! --------------------------------------
-
-    !> The subroutine terminates the MPI execution environment.
-    subroutine s_mpi_abort() ! ---------------------------------------------
-
-#ifndef MFC_MPI
-
-        stop 1
-
-#else
-
-        ! Terminating the MPI environment
-        call MPI_ABORT(MPI_COMM_WORLD, 1, ierr)
-
-#endif
-
-    end subroutine s_mpi_abort ! -------------------------------------------
-
-    !> The subroutine that initializes MPI data structures
-        !!  @param q_cons_vf Conservative variables
-    subroutine s_initialize_mpi_data(q_cons_vf) ! --------------------------
-
-        type(scalar_field), &
-            dimension(sys_size), &
-            intent(IN) :: q_cons_vf
-
-        integer, dimension(num_dims) :: sizes_glb, sizes_loc
-        integer :: ierr
-
-        integer :: i !< Generic loop iterator
-
-#ifdef MFC_MPI
-
-        do i = 1, sys_size
-            MPI_IO_DATA%var(i)%sf => q_cons_vf(i)%sf(0:m, 0:n, 0:p)
-        end do
-
-        ! Define global(g) and local(l) sizes for flow variables
-        sizes_glb(1) = m_glb + 1; sizes_loc(1) = m + 1
-        if (n > 0) then
-            sizes_glb(2) = n_glb + 1; sizes_loc(2) = n + 1
-            if (p > 0) then
-                sizes_glb(3) = p_glb + 1; sizes_loc(3) = p + 1
-            end if
-        end if
-
-        ! Define the view for each variable
-        do i = 1, sys_size
-            call MPI_TYPE_CREATE_SUBARRAY(num_dims, sizes_glb, sizes_loc, start_idx, &
-                                          MPI_ORDER_FORTRAN, MPI_DOUBLE_PRECISION, MPI_IO_DATA%view(i), ierr)
-            call MPI_TYPE_COMMIT(MPI_IO_DATA%view(i), ierr)
-        end do
-
-#endif
-
-    end subroutine s_initialize_mpi_data ! ---------------------------------
-
-    !> Halts all processes until all have reached barrier.
-    subroutine s_mpi_barrier() ! -------------------------------------------
-
-#ifdef MFC_MPI
-
-        ! Calling MPI_BARRIER
-        call MPI_BARRIER(MPI_COMM_WORLD, ierr)
-
-#endif
-
-    end subroutine s_mpi_barrier ! -----------------------------------------
 
     !> The computation of parameters, the allocation of memory,
         !!      the association of pointers and/or the execution of any
@@ -252,21 +154,6 @@ contains
 #endif
 
     end subroutine s_mpi_bcast_user_inputs ! -------------------------------
-
-    subroutine mpi_bcast_time_step_values(proc_time, time_avg)
-
-        real(kind(0d0)), dimension(0:num_procs - 1), intent(INOUT) :: proc_time
-        real(kind(0d0)), intent(INOUT) :: time_avg
-
-#ifdef MFC_MPI
-
-        integer :: j
-
-        call MPI_GATHER(time_avg, 1, MPI_DOUBLE_PRECISION, proc_time(0), 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-
-#endif
-
-    end subroutine mpi_bcast_time_step_values
 
     !>  The purpose of this procedure is to optimally decompose
         !!      the computational domain among the available processors.
@@ -834,127 +721,6 @@ contains
 
     end subroutine s_mpi_sendrecv_grid_variables_buffers ! -----------------
 
-    !>  The goal of this subroutine is to determine the global
-        !!      extrema of the stability criteria in the computational
-        !!      domain. This is performed by sifting through the local
-        !!      extrema of each stability criterion. Note that each of
-        !!      the local extrema is from a single process, within its
-        !!      assigned section of the computational domain. Finally,
-        !!      note that the global extrema values are only bookkeept
-        !!      on the rank 0 processor.
-        !!  @param icfl_max_loc Local maximum ICFL stability criterion
-        !!  @param vcfl_max_loc Local maximum VCFL stability criterion
-        !!  @param ccfl_max_loc Local maximum CCFL stability criterion
-        !!  @param Rc_min_loc Local minimum Rc stability criterion
-        !!  @param icfl_max_glb Global maximum ICFL stability criterion
-        !!  @param vcfl_max_glb Global maximum VCFL stability criterion
-        !!  @param ccfl_max_glb Global maximum CCFL stability criterion
-        !!  @param Rc_min_glb Global minimum Rc stability criterion
-    subroutine s_mpi_reduce_stability_criteria_extrema(icfl_max_loc, & ! --
-                                                       vcfl_max_loc, &
-                                                       ccfl_max_loc, &
-                                                       Rc_min_loc, &
-                                                       icfl_max_glb, &
-                                                       vcfl_max_glb, &
-                                                       ccfl_max_glb, &
-                                                       Rc_min_glb)
-
-        real(kind(0d0)), intent(IN) :: icfl_max_loc
-        real(kind(0d0)), intent(IN) :: vcfl_max_loc
-        real(kind(0d0)), intent(IN) :: ccfl_max_loc
-        real(kind(0d0)), intent(IN) :: Rc_min_loc
-
-        real(kind(0d0)), intent(OUT) :: icfl_max_glb
-        real(kind(0d0)), intent(OUT) :: vcfl_max_glb
-        real(kind(0d0)), intent(OUT) :: ccfl_max_glb
-        real(kind(0d0)), intent(OUT) :: Rc_min_glb
-
-#ifdef MFC_MPI
-
-        ! Reducing local extrema of ICFL, VCFL, CCFL and Rc numbers to their
-        ! global extrema and bookkeeping the results on the rank 0 processor
-        call MPI_REDUCE(icfl_max_loc, icfl_max_glb, 1, &
-                        MPI_DOUBLE_PRECISION, MPI_MAX, 0, &
-                        MPI_COMM_WORLD, ierr)
-
-        if (any(Re_size > 0)) then
-            call MPI_REDUCE(vcfl_max_loc, vcfl_max_glb, 1, &
-                            MPI_DOUBLE_PRECISION, MPI_MAX, 0, &
-                            MPI_COMM_WORLD, ierr)
-            call MPI_REDUCE(Rc_min_loc, Rc_min_glb, 1, &
-                            MPI_DOUBLE_PRECISION, MPI_MIN, 0, &
-                            MPI_COMM_WORLD, ierr)
-        end if
-
-#endif
-
-    end subroutine s_mpi_reduce_stability_criteria_extrema ! ---------------
-
-    !>  The following subroutine takes the input local variable
-        !!      from all processors and reduces to the sum of all
-        !!      values. The reduced variable is recorded back onto the
-        !!      original local variable on each processor.
-        !!  @param var_loc Some variable containing the local value which should be
-        !!  reduced amongst all the processors in the communicator.
-        !!  @param var_glb The globally reduced value
-    subroutine s_mpi_allreduce_sum(var_loc, var_glb) ! ---------------------
-
-        real(kind(0d0)), intent(IN) :: var_loc
-        real(kind(0d0)), intent(OUT) :: var_glb
-
-#ifdef MFC_MPI
-
-        ! Performing the reduction procedure
-        call MPI_ALLREDUCE(var_loc, var_glb, 1, MPI_DOUBLE_PRECISION, &
-                           MPI_SUM, MPI_COMM_WORLD, ierr)
-
-#endif
-
-    end subroutine s_mpi_allreduce_sum ! -----------------------------------
-
-    !>  The following subroutine takes the input local variable
-        !!      from all processors and reduces to the minimum of all
-        !!      values. The reduced variable is recorded back onto the
-        !!      original local variable on each processor.
-        !!  @param var_loc Some variable containing the local value which should be
-        !!  reduced amongst all the processors in the communicator.
-        !!  @param var_glb The globally reduced value
-    subroutine s_mpi_allreduce_min(var_loc, var_glb) ! ---------------------
-
-        real(kind(0d0)), intent(IN) :: var_loc
-        real(kind(0d0)), intent(OUT) :: var_glb
-
-#ifdef MFC_MPI
-
-        ! Performing the reduction procedure
-        call MPI_ALLREDUCE(var_loc, var_glb, 1, MPI_DOUBLE_PRECISION, &
-                           MPI_MIN, MPI_COMM_WORLD, ierr)
-
-#endif
-
-    end subroutine s_mpi_allreduce_min ! -----------------------------------
-
-    !>  The following subroutine takes the input local variable
-        !!      from all processors and reduces to the maximum of all
-        !!      values. The reduced variable is recorded back onto the
-        !!      original local variable on each processor.
-        !!  @param var_loc Some variable containing the local value which should be
-        !!  reduced amongst all the processors in the communicator.
-        !!  @param var_glb The globally reduced value
-    subroutine s_mpi_allreduce_max(var_loc, var_glb) ! ---------------------
-
-        real(kind(0d0)), intent(IN) :: var_loc
-        real(kind(0d0)), intent(OUT) :: var_glb
-
-#ifdef MFC_MPI
-
-        ! Performing the reduction procedure
-        call MPI_ALLREDUCE(var_loc, var_glb, 1, MPI_DOUBLE_PRECISION, &
-                           MPI_MAX, MPI_COMM_WORLD, ierr)
-
-#endif
-
-    end subroutine s_mpi_allreduce_max ! -----------------------------------
 
     !>  The goal of this procedure is to populate the buffers of
         !!      the cell-average conservative variables by communicating
@@ -1885,16 +1651,5 @@ contains
 
     end subroutine s_finalize_mpi_proxy_module ! ---------------------------
 
-    !> The subroutine finalizes the MPI execution environment.
-    subroutine s_mpi_finalize() ! ------------------------------------------
-
-#ifdef MFC_MPI
-
-        ! Finalizing the MPI environment
-        call MPI_FINALIZE(ierr)
-
-#endif
-
-    end subroutine s_mpi_finalize ! ----------------------------------------
 
 end module m_mpi_proxy


### PR DESCRIPTION
This PR moves portable MPI calls to the common directory. All of these calls were shared across all 3 sub-codes and only a couple `ifdef`s were needed. Clean change that reduces SLOC. I think the other MPI calls can also be moved, but will require more care. 