### PR TITLE
add 1D and quasi-1D hypoelastic examples

### DIFF
--- a/examples/1D_hypo_2materials/case.py
+++ b/examples/1D_hypo_2materials/case.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+import math
+import json
+
+#Numerical setup
+Nx      = 399
+dx      = 1./(1.*(Nx+1))
+
+Tend    = 240E-06
+Nt      = 1000
+mydt    = Tend/(1.*Nt)
+
+# Configuring case dictionary
+print(json.dumps({
+                    # Logistics ================================================
+                    'case_dir'                     : '\'.\'',                   
+                    'run_time_info'                : 'T',                       
+                    # ==========================================================
+                                                                                
+                    # Computational Domain Parameters ==========================
+                    'x_domain%beg'                 : 0.E+00,                    
+                    'x_domain%end'                 : 1.E+00,                    
+                    'm'                            : Nx,                        
+                    'n'                            : 0,                         
+                    'p'                            : 0,                         
+                    'dt'                           : mydt,                      
+                    't_step_start'                 : 0,                         
+                    't_step_stop'                  : int(Nt),                        
+                    't_step_save'                  : int(math.ceil(Nt/1.)),    
+		    # ==========================================================
+                                                                                
+                    # Simulation Algorithm Parameters ==========================
+                    'num_patches'                  : 2,                        
+                    'model_eqns'                   : 2,                        
+                    'alt_soundspeed'               : 'F',                      
+                    'num_fluids'                   : 2,                        
+		    'adv_alphan'                   : 'T',                      
+		    'mpp_lim'                      : 'F',                      
+		    'mixture_err'                  : 'F',                      
+		    'time_stepper'                 : 3,                        
+                    'weno_vars'                    : 2,                        
+                    'weno_order'                   : 3,                        
+                    'weno_eps'                     : 1.E-16,                   
+                    'mapped_weno'                  : 'F',                      
+                    'null_weights'                 : 'F',                      
+                    'mp_weno'                      : 'F',                      
+		    'riemann_solver'               : 1,                        
+                    'wave_speeds'                  : 1,                        
+                    'avg_state'                    : 2,                        
+                    'bc_x%beg'                     : -3,                       
+                    'bc_x%end'                     : -3,                       
+                    # ==========================================================
+
+                    # Turning on Hypoelasticity ================================
+                    'hypoelasticity'               : 'T',                      
+                    # ==========================================================
+                                                                               
+                    # Formatted Database Files Structure Parameters ============
+                    'format'                       : 1,                        
+                    'precision'                    : 2,                        
+                    'prim_vars_wrt'                :'T',                       
+		    'parallel_io'                  :'F',                       
+		    # ==========================================================
+                                                                                
+		    # Patch 1 L ================================================
+                    'patch_icpp(1)%geometry'       : 1,                        
+                    'patch_icpp(1)%x_centroid'     : 0.35,                     
+                    'patch_icpp(1)%length_x'       : 0.7,                      
+                    'patch_icpp(1)%vel(1)'         : 0.0,                      
+                    'patch_icpp(1)%pres'           : 1E+09,                    
+                    'patch_icpp(1)%alpha_rho(1)'   : 1000,                     
+                    'patch_icpp(1)%alpha_rho(2)'   : 0.,                        
+                    'patch_icpp(1)%alpha(1)'       : 1,                       
+                    'patch_icpp(1)%alpha(2)'       : 0.,                         
+                    'patch_icpp(1)%tau_e(1)'       : 0.0,                      
+                    # ==========================================================
+
+                    # Patch 2 R ================================================
+                    'patch_icpp(2)%geometry'       : 1,                     
+                    'patch_icpp(2)%x_centroid'     : 0.85,                   
+                    'patch_icpp(2)%length_x'       : 0.3,                    
+                    'patch_icpp(2)%vel(1)'         : 0,                    
+                    'patch_icpp(2)%pres'           : 1E+05,                    
+                    'patch_icpp(2)%alpha_rho(1)'   : 0.,                    
+                    'patch_icpp(2)%alpha_rho(2)'   : 50.,               
+                    'patch_icpp(2)%alpha(1)'       : 0,                
+                    'patch_icpp(2)%alpha(2)'       : 1,
+                    'patch_icpp(2)%tau_e(1)'       : 0.0,                
+                    # ==========================================================
+
+                    # Fluids Physical Parameters ===============================
+                    'fluid_pp(1)%gamma'            : 1.E+00/(4.4E+00-1.E+00),   
+                    'fluid_pp(1)%pi_inf'           : 4.4E+00*6.E+08/(4.4E+00 - 1.E+00), 
+                    'fluid_pp(1)%G'                : 1.E+09,                       
+                    'fluid_pp(2)%gamma'            : 1.E+00/(1.4E+00-1.E+00),   
+                    'fluid_pp(2)%pi_inf'           : 0.,                          
+                    'fluid_pp(2)%G'                : 0.,                        
+	            # ==========================================================
+}))
+# ==============================================================================

--- a/examples/1D_impact/case.py
+++ b/examples/1D_impact/case.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+import math
+import json
+
+#Numerical setup
+Nx      = 399
+dx      = 1./(1.*(Nx+1))
+
+Tend    = 6.4E-05
+Nt      = 200
+mydt    = Tend/(1.*Nt)
+
+# Configuring case dictionary
+print(json.dumps({
+                    # Logistics ================================================
+                    'case_dir'                     : '\'.\'',                   
+                    'run_time_info'                : 'T',                       
+                    # ==========================================================
+                                                                                
+                    # Computational Domain Parameters ==========================
+                    'x_domain%beg'                 : 0.E+00,                    
+                    'x_domain%end'                 : 1.E+00,                    
+                    'm'                            : Nx,                        
+                    'n'                            : 0,                         
+                    'p'                            : 0,                         
+                    'dt'                           : mydt,                      
+                    't_step_start'                 : 0,                         
+                    't_step_stop'                  : int(Nt),                        
+                    't_step_save'                  : int(math.ceil(Nt/1.)),    
+		    # ==========================================================
+                                                                                
+                    # Simulation Algorithm Parameters ==========================
+                    'num_patches'                  : 2,                        
+                    'model_eqns'                   : 2,                        
+                    'alt_soundspeed'               : 'F',                      
+                    'num_fluids'                   : 1,                        
+		    'adv_alphan'                   : 'T',                      
+		    'mpp_lim'                      : 'F',                      
+		    'mixture_err'                  : 'F',                      
+		    'time_stepper'                 : 3,                        
+                    'weno_vars'                    : 2,                        
+                    'weno_order'                   : 3,                        
+                    'weno_eps'                     : 1.E-16,                   
+                    'mapped_weno'                  : 'F',                      
+                    'null_weights'                 : 'F',                      
+                    'mp_weno'                      : 'F',                      
+		    'riemann_solver'               : 1,                        
+                    'wave_speeds'                  : 1,                        
+                    'avg_state'                    : 2,                        
+                    'bc_x%beg'                     : -3,                       
+                    'bc_x%end'                     : -3,                       
+                    # ==========================================================
+
+                    # Turning on Hypoelasticity ================================
+                    'hypoelasticity'               : 'T',                      
+                    # ==========================================================
+                                                                               
+                    # Formatted Database Files Structure Parameters ============
+                    'format'                       : 1,                        
+                    'precision'                    : 2,                        
+                    'prim_vars_wrt'                :'T',                       
+		    'parallel_io'                  :'F',                       
+		    # ==========================================================
+                                                                                
+		    # Patch 1 L ================================================
+                    'patch_icpp(1)%geometry'       : 1,                     
+                    'patch_icpp(1)%x_centroid'     : 0.25,                   
+                    'patch_icpp(1)%length_x'       : 0.5,                    
+                    'patch_icpp(1)%vel(1)'         : 10.0,   
+                    'patch_icpp(1)%pres'           : 1E+05,                    
+                    'patch_icpp(1)%alpha_rho(1)'   : 1000,                    
+                    'patch_icpp(1)%alpha(1)'       : 1.,                
+                    'patch_icpp(1)%tau_e(1)'       : 0.0,               
+                    # ==========================================================
+
+                    # Patch 2 R ================================================
+                    'patch_icpp(2)%geometry'       : 1,                     
+                    'patch_icpp(2)%x_centroid'     : 0.75,                   
+                    'patch_icpp(2)%length_x'       : 0.5,                    
+                    'patch_icpp(2)%vel(1)'         : -10.0,                    
+                    'patch_icpp(2)%pres'           : 1E+05,                    
+                    'patch_icpp(2)%alpha_rho(1)'   : 1000,                    
+                    'patch_icpp(2)%alpha(1)'       : 1.,                
+                    'patch_icpp(2)%tau_e(1)'       : 0.0,                
+                    # ==========================================================
+
+                    # Fluids Physical Parameters ===============================
+                    'fluid_pp(1)%gamma'            : 1.E+00/(4.4E+00-1.E+00),   
+                    'fluid_pp(1)%pi_inf'           : 4.4E+00*6.E+08/(4.4E+00 - 1.E+00), 
+                    'fluid_pp(1)%G'                : 0.5E+09,                       
+	            # ==========================================================
+}))
+# ==============================================================================

--- a/examples/1D_sodHypo/case.py
+++ b/examples/1D_sodHypo/case.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import math
+import json
+
+#Numerical setup
+Nx      = 201
+dx      = 1./(1.*(Nx+1))
+
+Tend    = 64E-06
+Nt      = 200
+mydt    = Tend/(1.*Nt)
+
+# Configuring case dictionary
+print(json.dumps({
+                    # Logistics ================================================
+                    'case_dir'                     : '\'.\'',                   
+                    'run_time_info'                : 'F',                       
+                    # ==========================================================
+                                                                                
+                    # Computational Domain Parameters ==========================
+                    'x_domain%beg'                 : 0.E+00,                    
+                    'x_domain%end'                 : 1.E+00,                    
+                    'm'                            : Nx,                        
+                    'n'                            : 0,                         
+                    'p'                            : 0,                         
+                    'dt'                           : mydt,                      
+                    't_step_start'                 : 0,                         
+                    't_step_stop'                  : int(Nt),
+                    't_step_save'                  : int(Nt),
+		    # ==========================================================
+                                                                                
+                    # Simulation Algorithm Parameters ==========================
+                    'num_patches'                  : 2,                        
+                    'model_eqns'                   : 2,                        
+                    'alt_soundspeed'               : 'F',                      
+                    'num_fluids'                   : 1,                        
+		    'adv_alphan'                   : 'T',                      
+		    'mpp_lim'                      : 'F',                      
+		    'mixture_err'                  : 'F',                      
+		    'time_stepper'                 : 3,                        
+                    'weno_vars'                    : 2,                        
+                    'weno_order'                   : 5,                        
+                    'weno_eps'                     : 1.E-16,                   
+                    'mapped_weno'                  : 'F',                     
+                    'null_weights'                 : 'F',                      
+                    'mp_weno'                      : 'F',                      
+		    'riemann_solver'               : 1,                        
+                    'wave_speeds'                  : 1,                        
+                    'avg_state'                    : 2,                        
+                    'bc_x%beg'                     : -3,                       
+                    'bc_x%end'                     : -3,                       
+                    # ==========================================================
+
+                    # Turning on Hypoelasticity ================================
+                    'hypoelasticity'               : 'T',                      
+                    # ==========================================================
+                                                                               
+                    # Formatted Database Files Structure Parameters ============
+                    'format'                       : 1,                        
+                    'precision'                    : 2,                        
+                    'prim_vars_wrt'                :'T',                       
+		    'parallel_io'                  :'F',                       
+		    # ==========================================================
+                                                                                
+		    # Patch 1 L ================================================
+                    'patch_icpp(1)%geometry'       : 1,                     
+                    'patch_icpp(1)%x_centroid'     : 0.25,                   
+                    'patch_icpp(1)%length_x'       : 0.5,                    
+                    'patch_icpp(1)%vel(1)'         : 0.0,   
+                    'patch_icpp(1)%pres'           : 1.E+8,                    
+                    'patch_icpp(1)%alpha_rho(1)'   : 1000,                    
+                    'patch_icpp(1)%alpha(1)'       : 1.,                
+                    'patch_icpp(1)%tau_e(1)'       : 0.0,                
+                    # ==========================================================
+
+                    # Patch 2 R ================================================
+                    'patch_icpp(2)%geometry'       : 1,                     
+                    'patch_icpp(2)%x_centroid'     : 0.75,                  
+                    'patch_icpp(2)%length_x'       : 0.5,                   
+                    'patch_icpp(2)%vel(1)'         : 0,                    
+                    'patch_icpp(2)%pres'           : 1.E+05,               
+                    'patch_icpp(2)%alpha_rho(1)'   : 1000,                 
+                    'patch_icpp(2)%alpha(1)'       : 1.,                
+                    'patch_icpp(2)%tau_e(1)'       : 0.0,               
+                    # ==========================================================
+
+                    # Fluids Physical Parameters ===============================
+                    'fluid_pp(1)%gamma'            : 1.E+00/(4.4E+00-1.E+00),   
+                    'fluid_pp(1)%pi_inf'           : 4.4E+00*6.E+08/(4.4E+00 - 1.E+00), 
+                    'fluid_pp(1)%G'                : 10E+09,                       
+	            # ==========================================================
+}))
+# ==============================================================================

--- a/examples/2D_5wave_quasi1D/case.py
+++ b/examples/2D_5wave_quasi1D/case.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python
+import math
+import json
+
+#Numerical setup
+Nx      = 399
+dx      = 1./(1.*(Nx+1))
+
+Ny = 19
+dy = 1./(1.*(Ny+1))
+
+Tend    = 6.4E-05
+Nt      = 200
+mydt    = Tend/(1.*Nt)
+
+# Configuring case dictionary
+print(json.dumps({
+                    # Logistics ================================================
+                    'case_dir'                     : '\'.\'',                   
+                    'run_time_info'                : 'T',                       
+                    # ==========================================================
+                                                                                
+                    # Computational Domain Parameters ==========================
+                    'x_domain%beg'                 : 0.E+00,                    
+                    'x_domain%end'                 : 1.E+00,                    
+                    'y_domain%beg'                 : -1.E-01,                   
+                    'y_domain%end'                 : 1.E-01,                    
+                    'm'                            : Nx,                        
+                    'n'                            : Ny,                        
+                    'p'                            : 0,                         
+                    'dt'                           : mydt,                      
+                    't_step_start'                 : 0,                         
+                    't_step_stop'                  : int(Nt),                   
+                    't_step_save'                  : int(math.ceil(Nt/1)),    
+		    # ==========================================================
+                                                                               
+                    # Simulation Algorithm Parameters ==========================
+                    'num_patches'                  : 2,                        
+                    'model_eqns'                   : 2,                        
+                    'alt_soundspeed'               : 'F',                      
+                    'num_fluids'                   : 1,                        
+		    'adv_alphan'                   : 'T',                      
+		    'mpp_lim'                      : 'F',                      
+		    'mixture_err'                  : 'F',                      
+		    'time_stepper'                 : 3,                        
+                    'weno_vars'                    : 2,                        
+                    'weno_order'                   : 3,                        
+                    'weno_eps'                     : 1.E-16,                   
+                    'mapped_weno'                  : 'F',                      
+                    'null_weights'                 : 'F',                      
+                    'mp_weno'                      : 'F',                      
+		    'riemann_solver'               : 1,                        
+                    'wave_speeds'                  : 1,                        
+                    'avg_state'                    : 2,                        
+                    'bc_x%beg'                     : -3,                       
+                    'bc_x%end'                     : -3,                       
+                    'bc_y%beg'                     : -3,                       
+                    'bc_y%end'                     : -3,                       
+                    # ==========================================================
+
+                    # Turning on Hypoelasticity ================================
+                    'hypoelasticity'               : 'T',                      
+                    # ==========================================================
+                                                                               
+                    # Formatted Database Files Structure Parameters ============
+                    'format'                       : 1,                        
+                    'precision'                    : 2,                        
+                    'prim_vars_wrt'                :'T',                       
+		    'parallel_io'                  :'F',                       
+		    # ==========================================================
+                                                                                
+		    # Patch 1 L ================================================
+                    'patch_icpp(1)%geometry'       : 3,                     
+                    'patch_icpp(1)%x_centroid'     : 0.25,                  
+                    'patch_icpp(1)%y_centroid'     : 0.0,                   
+                    'patch_icpp(1)%length_x'       : 0.5,                   
+                    'patch_icpp(1)%length_y'       : 0.2,                   
+                    'patch_icpp(1)%vel(1)'         : 0.0,   
+                    'patch_icpp(1)%vel(2)'         : 100,                      
+                    'patch_icpp(1)%pres'           : 1E+08,                    
+                    'patch_icpp(1)%alpha_rho(1)'   : 1000,                    
+                    'patch_icpp(1)%alpha(1)'       : 1.,                
+                    'patch_icpp(1)%tau_e(1)'       : 0.0,                
+                    # ==========================================================
+
+                    # Patch 2 R ================================================
+                    'patch_icpp(2)%geometry'       : 3,                     
+                    'patch_icpp(2)%x_centroid'     : 0.75,                  
+                    'patch_icpp(2)%y_centroid'     : 0.0,                   
+                    'patch_icpp(2)%length_x'       : 0.5,                    
+                    'patch_icpp(2)%length_y'       : 0.2,                   
+                    'patch_icpp(2)%vel(1)'         : 0.0,                   
+                    'patch_icpp(2)%vel(2)'         : -100,                       
+                    'patch_icpp(2)%pres'           : 1E+05,                    
+                    'patch_icpp(2)%alpha_rho(1)'   : 1000,                    
+                    'patch_icpp(2)%alpha(1)'       : 1.,                
+                    'patch_icpp(2)%tau_e(1)'       : 0.0,                
+                    # ==========================================================
+
+                    # Fluids Physical Parameters ===============================
+                    'fluid_pp(1)%gamma'            : 1.E+00/(4.4E+00-1.E+00),   
+                    'fluid_pp(1)%pi_inf'           : 4.4E+00*6.E+08/(4.4E+00 - 1.E+00), 
+                    'fluid_pp(1)%G'                : 10.E+9,                       
+	            # ==========================================================
+}))
+# ==============================================================================


### PR DESCRIPTION
Added example cases for hypoelasticity in 1D and 2D (quasi-1D, meaning homogeneous in the y-direction). These examples are taken from Mauro Rodriguez and Eric Johnsen's 2019 JCP paper (https://www.sciencedirect.com/science/article/pii/S0021999118307022)