### PR TITLE
Fix idx

### DIFF
--- a/src/common/m_variables_conversion.fpp
+++ b/src/common/m_variables_conversion.fpp
@@ -349,9 +349,9 @@ contains
 
         ! Post process requires rho_sf/gamma_sf/pi_inf_sf to also be updated
 #ifdef MFC_POST_PROCESS
-        rho_sf   (j, k, l) = rho
-        gamma_sf (j, k, l) = gamma
-        pi_inf_sf(j, k, l) = pi_inf
+        rho_sf   (k, l, r) = rho
+        gamma_sf (k, l, r) = gamma
+        pi_inf_sf(k, l, r) = pi_inf
 #endif
 
     end subroutine s_convert_species_to_mixture_variables ! ----------------

--- a/src/simulation/m_riemann_solvers.fpp
+++ b/src/simulation/m_riemann_solvers.fpp
@@ -592,9 +592,6 @@ contains
                             @:compute_speed_of_sound(pres_L, rho_L, gamma_L, pi_inf_L, H_L, alpha_L, &
                                     vel_L_rms, qL_prim_rs${XYZ}$_vf, j, k, l, 2, c_L)
 
-                            @:compute_speed_of_sound(pres_L, rho_L, gamma_L, pi_inf_L, H_L, alpha_L, &
-                                    vel_L_rms, qL_prim_rs${XYZ}$_vf, j, k, l, 2, c_L)
-
                             @:compute_speed_of_sound(pres_R, rho_R, gamma_R, pi_inf_R, H_R, alpha_R, &
                                     vel_R_rms, qR_prim_rs${XYZ}$_vf, j + 1, k, l, 2, c_R)
 


### PR DESCRIPTION
Fixes indices in `s_convert_species_to_mixture_variables` and deletes duplicate code in `m_riemann_solvers`.

Tested w/ examples/2D_shockbubble on Bridges2 GPU