### PR TITLE
Add iostat check when reading .inp files

### DIFF
--- a/src/post_process/m_start_up.f90
+++ b/src/post_process/m_start_up.f90
@@ -32,6 +32,9 @@ contains
             !! Generic logical used for the purpose of asserting whether a file
             !! is or is not present in the designated location
 
+        integer :: iostatus
+            !! Integer to check iostat of file read
+
         ! Namelist for all of the parameters to be inputed by the user
         namelist /user_inputs/ case_dir, m, n, p, t_step_start, &
             t_step_stop, t_step_save, model_eqns, &
@@ -60,7 +63,14 @@ contains
         if (file_check) then
             open (1, FILE=trim(file_loc), FORM='formatted', &
                   STATUS='old', ACTION='read')
-            read (1, NML=user_inputs)
+            read (1, NML=user_inputs, iostat=iostatus)
+
+            if (iostatus /= 0) then
+                print '(A)', 'Invalid line in post_process.inp. It is '// &
+                'likely due to a datatype mismatch. Exiting ...'
+                call s_mpi_abort()
+            end if
+
             close (1)
             ! Store m,n,p into global m,n,p
             m_glb = m

--- a/src/pre_process/m_start_up.fpp
+++ b/src/pre_process/m_start_up.fpp
@@ -84,6 +84,9 @@ contains
             !! Generic logical used for the purpose of asserting whether a file
             !! is or is not present in the designated location
 
+        integer :: iostatus
+            !! Integer to check iostat of file read
+
         ! Namelist for all of the parameters to be inputed by the user
         namelist /user_inputs/ case_dir, old_grid, old_ic, &
             t_step_old, m, n, p, x_domain, y_domain, z_domain, &
@@ -111,7 +114,12 @@ contains
         if (file_check) then
             open (1, FILE=trim(file_loc), FORM='formatted', &
                   STATUS='old', ACTION='read')
-            read (1, NML=user_inputs)
+            read (1, NML=user_inputs, iostat=iostatus)
+            if (iostatus /= 0) then
+                print '(A)', 'Invalid line in pre_process.inp. It is '// &
+                'likely due to a datatype mismatch. Exiting ...'
+                call s_mpi_abort()
+            end if
             close (1)
             ! Store m,n,p into global m,n,p
             m_glb = m

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -72,6 +72,9 @@ contains
         logical :: file_exist !<
             !! Logical used to check the existence of the input file
 
+        integer :: iostatus
+            !! Integer to check iostat of file read
+
         ! Namelist of the global parameters which may be specified by user
         namelist /user_inputs/ case_dir, run_time_info, m, n, p, dt, &
             t_step_start, t_step_stop, t_step_save, &
@@ -107,7 +110,15 @@ contains
                   FORM='formatted', &
                   ACTION='read', &
                   STATUS='old')
-            read (1, NML=user_inputs); close (1)
+            read (1, NML=user_inputs, iostat=iostatus)
+
+            if (iostatus /= 0) then
+                print '(A)', 'Invalid line in simulation.inp. It is '// &
+                'likely due to a datatype mismatch. Exiting ...'
+                call s_mpi_abort()
+            end if
+
+            close (1)
 
             ! Store BC information into global BC
             bc_x_glb%beg = bc_x%beg


### PR DESCRIPTION
Resolves #51. Tested on Bridges2 with `mfc.sh test`.