### PR TITLE
fix Bridges2 load

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -88,7 +88,7 @@ if [ "$1" == "load" ]; then
             MODULES=("allocations/1.0" "gcc/10.2.0" "python/3.8.6"
                      "openmpi/4.0.5-gcc10.2.0")
         elif [ "$u_cg" == "g" ]; then
-            MODULES=("nvhpc/22.9" "openmpi/4.0.5-nvhpc22.9")
+            MODULES=("openmpi/4.0.5-nvhpc22.9" "nvhpc/22.9")
         fi
 
         MODULES=("${MODULES[@]}" "python/3.8.6")


### PR DESCRIPTION
MFC was not building on GPUs on Bridges2 for me. This was because loading `openmpi/4.0.5-nvhpc22.9` automatically unloaded `nvhpc`, which then removes the declaration of `FC` and `CC`, and cmake dies because it automatically finds old GNU compilers intead.
