### PR TITLE
Add support for counting lines of code via `./mfc.sh count`, remove `./mfc.sh cloc`

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -230,17 +230,6 @@ elif [ "$1" == "format" ]; then
     ok "MFC has been fprettify'ied."
 
     exit 0
-elif [ "$1" == "cloc" ]; then
-    if ! command -v cloc > /dev/null 2>&1; then
-        error "cloc (github.com/AlDanial/cloc) is not installed."
-
-        exit 1
-    fi
-
-    cloc .          --exclude-dir=build,tests,examples,.vscode,.github \
-         --fullpath --not-match-d=src/*/*/autogen
-
-    exit $?
 elif [ "$1" == "docker" ]; then
     shift;
 

--- a/src/pre_process/m_checker.f90
+++ b/src/pre_process/m_checker.f90
@@ -29,44 +29,57 @@ contains
         bub_fac = 0
         if (bubbles .and. (num_fluids == 1)) bub_fac = 1
         ! Startup checks for bubbles and bubble variables
-        if (bubbles .and. (model_eqns /= 4 .and. model_eqns /= 2)) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'bubbles and model_eqns. '// &
-                'Exiting ...')
-        elseif (bubbles .and. nb < 1) then
-            call s_mpi_abort('The Ensemble-Averaged Bubble Model requires nb >= 1' // &
-                'Exotomg ...')
-        elseif (bubbles .and. polydisperse .and. (nb == 1)) then
-            call s_mpi_abort('Polydisperse bubble dynamics requires nb > 1 '// &
-                'Exiting ...')
-        elseif (bubbles .and. polydisperse .and. (mod(nb, 2) == 0)) then
-            call s_mpi_abort('nb must be odd '// &
-                'Exiting ...')
-        elseif (model_eqns == 4 .and. (rhoref == dflt_real)) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'bubbles and rhoref. '// &
-                'Exiting ...')
-        elseif (model_eqns == 4 .and. (pref == dflt_real)) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'bubbles and pref. '// &
-                'Exiting ...')
-        elseif (model_eqns == 4 .and. (num_fluids > 1)) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'model_eqns and num_fluids. '// &
-                'Exiting ...')
-        elseif (bubbles .and. (R0ref == dflt_real)) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'bubbles and R0ref. '// &
-                'Exiting ...')
-        elseif (bubbles .and. (nb == dflt_int)) then
-            call s_mpi_abort('unsupported combination of values of '// &
-                'bubbles and nb. '// &
-                'exiting ...')
-        elseif (bubbles .and. (thermal > 3)) then
-            call s_mpi_abort('unsupported combination of values of '// &
-                'bubbles and thermal. '// &
-                'exiting ...')
-        elseif (hypoelasticity .and. (model_eqns /= 2)) then
+        if (bubbles) then
+            if (model_eqns /= 4 .and. model_eqns /= 2) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'bubbles and model_eqns. '// &
+                    'Exiting ...')
+            elseif (nb < 1) then
+                call s_mpi_abort('The Ensemble-Averaged Bubble Model requires nb >= 1' // &
+                    'Exiting ...')
+            elseif (polydisperse .and. (nb == 1)) then
+                call s_mpi_abort('Polydisperse bubble dynamics requires nb > 1 '// &
+                    'Exiting ...')
+            elseif (polydisperse .and. (mod(nb, 2) == 0)) then
+                call s_mpi_abort('nb must be odd '// &
+                    'Exiting ...')
+            elseif (model_eqns == 4 .and. (rhoref == dflt_real)) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'bubbles and rhoref. '// &
+                    'Exiting ...')
+            elseif (model_eqns == 4 .and. (pref == dflt_real)) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'bubbles and pref. '// &
+                    'Exiting ...')
+            elseif (model_eqns == 4 .and. (num_fluids > 1)) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'model_eqns and num_fluids. '// &
+                    'Exiting ...')
+            elseif (R0ref == dflt_real) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'bubbles and R0ref. '// &
+                    'Exiting ...')
+            elseif (nb == dflt_int) then
+                call s_mpi_abort('unsupported combination of values of '// &
+                    'bubbles and nb. '// &
+                    'exiting ...')
+            elseif (thermal > 3) then
+                call s_mpi_abort('unsupported combination of values of '// &
+                    'bubbles and thermal. '// &
+                    'exiting ...')
+            end if
+
+        end if
+
+        if (qbmm .and. dist_type == dflt_int) then
+            call s_mpi_abort('Dist type must be set if using QBMM. Exiting ...')
+        else if (qbmm .and. (dist_type /= 1) .and. rhoRV > 0d0) then
+            call s_mpi_abort('rhoRV cannot be used with dist_type \ne 1. Exiting ...')
+        else if (polydisperse .and. R0_type == dflt_int) then
+            call s_mpi_abort('R0 type must be set if using Polydisperse. Exiting ...')
+        end if
+
+        if (hypoelasticity .and. (model_eqns /= 2)) then
             call s_mpi_abort('hypoelasticity requires model_eqns = 2'// &
                 'exiting ...')
         end if
@@ -80,7 +93,7 @@ contains
             call s_mpi_abort('Unsupported choice of the combination of '// &
                 'values for old_grid and old_ic and t_step_old. Exiting ...')
 
-            ! Constraints on dimensionality and the number of cells for the grid
+        ! Constraints on dimensionality and the number of cells for the grid
         elseif (m <= 0) then
             call s_mpi_abort('Unsupported choice for the value of m. '// &
                 'Exiting ...')
@@ -104,7 +117,7 @@ contains
                 'values for num_procs, m, n and p. '// &
                 'Exiting ...')
 
-            ! Constraints on domain boundaries locations in the x-direction
+        ! Constraints on domain boundaries locations in the x-direction
         elseif ((old_grid .and. x_domain%beg /= dflt_real) &
                 .or. &
                 ((old_grid .neqv. .true.) .and. &
@@ -125,15 +138,38 @@ contains
             call s_mpi_abort('Unsupported choice of the combination of '// &
                 'values for old_grid, x_domain%beg and '// &
                 'x_domain%end. Exiting ...')
-        else if (qbmm .and. dist_type == dflt_int) then
-            call s_mpi_abort('Dist type must be set if using QBMM. Exiting ...')
-        else if (qbmm .and. (dist_type /= 1) .and. rhoRV > 0d0) then
-            call s_mpi_abort('rhoRV cannot be used with dist_type \ne 1. Exiting ...')
-        else if (polydisperse .and. R0_type == dflt_int) then
-            call s_mpi_abort('R0 type must be set if using Polydisperse. Exiting ...')
         end if
 
-        if (cyl_coord .neqv. .true.) then ! Cartesian coordinates
+        if (cyl_coord) then ! Cartesian coordinates
+
+            ! Constraints on domain boundaries for cylindrical coordinates
+            if (n == 0 &
+                .or. &
+                y_domain%beg /= 0d0 &
+                .or. &
+                y_domain%end == dflt_real &
+                .or. &
+                y_domain%end < 0d0 &
+                .or. &
+                y_domain%beg >= y_domain%end) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'cyl_coord and n, y_domain%beg, or         '// &
+                    'y_domain%end. Exiting ...')
+            elseif ((p == 0 .and. z_domain%beg /= dflt_real) &
+                    .or. &
+                    (p == 0 .and. z_domain%end /= dflt_real)) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'cyl_coord and p, z_domain%beg, or '// &
+                    'z_domain%end. Exiting ...')
+            elseif (p > 0 .and. (z_domain%beg /= 0d0 &
+                                 .or. &
+                                 z_domain%end /= 2d0*pi)) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'cyl_coord and p, z_domain%beg, or '// &
+                    'z_domain%end. Exiting ...')
+            end if
+
+        else 
 
             ! Constraints on domain boundaries locations in the y-direction
             if ((n == 0 .and. y_domain%beg /= dflt_real) &
@@ -199,164 +235,133 @@ contains
                     'values for old_grid, p, z_domain%beg and '// &
                     'z_domain%end. Exiting ...')
             end if
-
-        else ! Cylindrical coordinates
-
-            ! Constraints on domain boundaries for cylindrical coordinates
-            if (n == 0 &
-                .or. &
-                y_domain%beg /= 0d0 &
-                .or. &
-                y_domain%end == dflt_real &
-                .or. &
-                y_domain%end < 0d0 &
-                .or. &
-                y_domain%beg >= y_domain%end) then
-                call s_mpi_abort('Unsupported choice of the combination of '// &
-                    'cyl_coord and n, y_domain%beg, or         '// &
-                    'y_domain%end. Exiting ...')
-            elseif ((p == 0 .and. z_domain%beg /= dflt_real) &
-                    .or. &
-                    (p == 0 .and. z_domain%end /= dflt_real)) then
-                call s_mpi_abort('Unsupported choice of the combination of '// &
-                    'cyl_coord and p, z_domain%beg, or '// &
-                    'z_domain%end. Exiting ...')
-            elseif (p > 0 .and. (z_domain%beg /= 0d0 &
-                                 .or. &
-                                 z_domain%end /= 2d0*pi)) then
-                call s_mpi_abort('Unsupported choice of the combination of '// &
-                    'cyl_coord and p, z_domain%beg, or '// &
-                    'z_domain%end. Exiting ...')
-            end if
-
         end if
 
-        ! Constraints on the grid stretching in the x-direction
-        if (old_grid .and. stretch_x) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for old_grid and stretch_x. '// &
-                'Exiting ...')
-        elseif (stretch_x .and. a_x == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_x and a_x. Exiting ...')
-        elseif (stretch_x .and. x_a == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_x and x_a. Exiting ...')
-        elseif (stretch_x .and. x_b == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_x and x_b. Exiting ...')
-        elseif (stretch_x .and. x_a >= x_b) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_x, x_a and x_b. '// &
-                'Exiting ...')
-        elseif (stretch_x &
-                .and. &
-                (a_x + log(cosh(a_x*(x_domain%beg - x_a))) &
-                 + log(cosh(a_x*(x_domain%beg - x_b))) &
-                 - 2d0*log(cosh(0.5d0*a_x*(x_b - x_a))))/a_x <= 0d0) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for x_domain%beg, stretch_x, a_x, '// &
-                'x_a, and x_b. Exiting ...')
-        elseif (stretch_x &
-                .and. &
-                (a_x + log(cosh(a_x*(x_domain%end - x_a))) &
-                 + log(cosh(a_x*(x_domain%end - x_b))) &
-                 - 2d0*log(cosh(0.5d0*a_x*(x_b - x_a))))/a_x <= 0d0) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for x_domain%end, stretch_x, a_x, '// &
-                'x_a, and x_b. Exiting ...')
-        elseif (loops_z < 1) then
+        if (loops_z < 1) then
             call s_mpi_abort('Unsupported choice for the value of loops_z. '// &
                 'Exiting ...')
-
-            ! Constraints on the grid stretching in the y-direction
-        elseif (old_grid .and. stretch_y) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for old_grid and stretch_y. '// &
-                'Exiting ...')
-        elseif (n == 0 .and. stretch_y) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for n and stretch_y. Exiting ...')
-        elseif (stretch_y .and. a_y == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-            'values for stretch_y and a_y. Exiting ...')
-        elseif (stretch_y .and. y_a == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_y and y_a. Exiting ...')
-        elseif (stretch_y .and. y_b == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_y and y_b. Exiting ...')
-        elseif (stretch_y .and. y_a >= y_b) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_y, y_a and y_b. '// &
-                'Exiting ...')
-        elseif (stretch_y &
-                .and. &
-                (a_y + log(cosh(a_y*(y_domain%beg - y_a))) &
-                 + log(cosh(a_y*(y_domain%beg - y_b))) &
-                 - 2d0*log(cosh(0.5d0*a_y*(y_b - y_a))))/a_y <= 0d0) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for y_domain%beg, stretch_y, a_y, '// &
-                'y_a, and y_b. Exiting ...')
-        elseif (stretch_y &
-                .and. &
-                (a_y + log(cosh(a_y*(y_domain%end - y_a))) &
-                 + log(cosh(a_y*(y_domain%end - y_b))) &
-                 - 2d0*log(cosh(0.5d0*a_y*(y_b - y_a))))/a_y <= 0d0) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for y_domain%end, stretch_y, a_y, '// &
-                'y_a, and y_b. Exiting ...')
         elseif (loops_y < 1) then
             call s_mpi_abort('Unsupported choice for the value of loops_y. '// &
                 'Exiting ...')
+        end if
 
-            ! Constraints on the grid stretching in the z-direction
-        elseif (old_grid .and. stretch_z) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for old_grid and stretch_z. '// &
-                'Exiting ...')
-        elseif (cyl_coord .and. stretch_z) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for cyl_coord and stretch_z. '// &
-                'Exiting ...')
-        elseif (p == 0 .and. stretch_z) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for p and stretch_z. Exiting ...')
-        elseif (stretch_z .and. a_z == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_z and a_z. Exiting ...')
-        elseif (stretch_z .and. z_a == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_z and z_a. Exiting ...')
-        elseif (stretch_z .and. z_b == dflt_real) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_z and z_b. Exiting ...')
-        elseif (stretch_z .and. z_a >= z_b) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for stretch_z, z_a and z_b. '// &
-                'Exiting ...')
-        elseif (stretch_z &
-                .and. &
-                (a_z + log(cosh(a_z*(z_domain%beg - z_a))) &
-                 + log(cosh(a_z*(z_domain%beg - z_b))) &
-                 - 2d0*log(cosh(0.5d0*a_z*(z_b - z_a))))/a_z <= 0d0) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for z_domain%beg, stretch_z, a_z, '// &
-                'z_a, and z_b. Exiting ...')
-        elseif (stretch_z &
-                .and. &
-                (a_z + log(cosh(a_z*(z_domain%end - z_a))) &
-                 + log(cosh(a_z*(z_domain%end - z_b))) &
-                 - 2d0*log(cosh(0.5d0*a_z*(z_b - z_a))))/a_z <= 0d0) then
-            call s_mpi_abort('Unsupported choice of the combination of '// &
-                'values for z_domain%end, stretch_z, a_z, '// &
-                'z_a, and z_b. Exiting ...')
-        elseif (loops_z < 1) then
-            call s_mpi_abort('Unsupported choice for the value of loops_z. '// &
-                'Exiting ...')
 
-            ! Constraints on model equations and number of fluids in the flow
-        elseif (all(model_eqns /= (/1, 2, 3, 4/))) then
+        ! Constraints on the grid stretching in the x-direction
+        if (stretch_x) then
+            if (old_grid) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for old_grid and stretch_x. '// &
+                    'Exiting ...')
+            elseif (a_x == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_x and a_x. Exiting ...')
+            elseif (x_a == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_x and x_a. Exiting ...')
+            elseif (x_b == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_x and x_b. Exiting ...')
+            elseif (x_a >= x_b) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_x, x_a and x_b. '// &
+                    'Exiting ...')
+            elseif ((a_x + log(cosh(a_x*(x_domain%beg - x_a))) &
+                     + log(cosh(a_x*(x_domain%beg - x_b))) &
+                     - 2d0*log(cosh(0.5d0*a_x*(x_b - x_a))))/a_x <= 0d0) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for x_domain%beg, stretch_x, a_x, '// &
+                    'x_a, and x_b. Exiting ...')
+            elseif ( (a_x + log(cosh(a_x*(x_domain%end - x_a))) &
+                     + log(cosh(a_x*(x_domain%end - x_b))) &
+                     - 2d0*log(cosh(0.5d0*a_x*(x_b - x_a))))/a_x <= 0d0) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for x_domain%end, stretch_x, a_x, '// &
+                    'x_a, and x_b. Exiting ...')
+            end if
+        end if
+
+        if (stretch_y) then
+            ! Constraints on the grid stretching in the y-direction
+            if (old_grid) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for old_grid and stretch_y. '// &
+                    'Exiting ...')
+            elseif (n == 0) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for n and stretch_y. Exiting ...')
+            elseif (a_y == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                'values for stretch_y and a_y. Exiting ...')
+            elseif (y_a == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_y and y_a. Exiting ...')
+            elseif (y_b == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_y and y_b. Exiting ...')
+            elseif (y_a >= y_b) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_y, y_a and y_b. '// &
+                    'Exiting ...')
+            elseif ((a_y + log(cosh(a_y*(y_domain%beg - y_a))) &
+                     + log(cosh(a_y*(y_domain%beg - y_b))) &
+                     - 2d0*log(cosh(0.5d0*a_y*(y_b - y_a))))/a_y <= 0d0) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for y_domain%beg, stretch_y, a_y, '// &
+                    'y_a, and y_b. Exiting ...')
+            elseif ((a_y + log(cosh(a_y*(y_domain%end - y_a))) &
+                     + log(cosh(a_y*(y_domain%end - y_b))) &
+                     - 2d0*log(cosh(0.5d0*a_y*(y_b - y_a))))/a_y <= 0d0) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for y_domain%end, stretch_y, a_y, '// &
+                    'y_a, and y_b. Exiting ...')
+            end if
+        end if
+
+
+        ! Constraints on the grid stretching in the z-direction
+        if (stretch_z) then
+            if (old_grid) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for old_grid and stretch_z. '// &
+                    'Exiting ...')
+            elseif (cyl_coord) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for cyl_coord and stretch_z. '// &
+                    'Exiting ...')
+            elseif (p == 0) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for p and stretch_z. Exiting ...')
+            elseif (a_z == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_z and a_z. Exiting ...')
+            elseif (z_a == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_z and z_a. Exiting ...')
+            elseif (z_b == dflt_real) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_z and z_b. Exiting ...')
+            elseif (z_a >= z_b) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for stretch_z, z_a and z_b. '// &
+                    'Exiting ...')
+            elseif ((a_z + log(cosh(a_z*(z_domain%beg - z_a))) &
+                     + log(cosh(a_z*(z_domain%beg - z_b))) &
+                     - 2d0*log(cosh(0.5d0*a_z*(z_b - z_a))))/a_z <= 0d0) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for z_domain%beg, stretch_z, a_z, '// &
+                    'z_a, and z_b. Exiting ...')
+            elseif ((a_z + log(cosh(a_z*(z_domain%end - z_a))) &
+                     + log(cosh(a_z*(z_domain%end - z_b))) &
+                     - 2d0*log(cosh(0.5d0*a_z*(z_b - z_a))))/a_z <= 0d0) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for z_domain%end, stretch_z, a_z, '// &
+                    'z_a, and z_b. Exiting ...')
+            end if
+        end if
+
+
+        ! Constraints on model equations and number of fluids in the flow
+        if (all(model_eqns /= (/1, 2, 3, 4/))) then
             call s_mpi_abort('Unsupported value of model_eqns. Exiting ...')
         elseif (num_fluids /= dflt_int &
                 .and. &
@@ -366,7 +371,7 @@ contains
             call s_mpi_abort('Unsupported combination of values of '// &
                 'model_eqns and adv_alphan. '// &
                 'Exiting ...')
-            ! Constraints on the order of the WENO scheme
+        ! Constraints on the order of the WENO scheme
         elseif (weno_order /= 1 .and. weno_order /= 3 &
                 .and. &
                 weno_order /= 5) then
@@ -404,7 +409,60 @@ contains
                 'Exiting ...')
         end if
 
-        if (cyl_coord .neqv. .true.) then ! Cartesian coordinates
+        if (cyl_coord) then ! Cartesian coordinates
+
+            ! Constraints on the boundary conditions in the r-direction
+            if (bc_y%beg /= dflt_int &
+                .and. &
+                ((p > 0 .and. bc_y%beg /= -13) &
+                 .or. &
+                 (p == 0 .and. bc_y%beg /= -2))) then
+                call s_mpi_abort('Unsupported choice for the value of '// &
+                    'bc_y%beg. Exiting ...')
+            elseif (bc_y%end /= dflt_int &
+                    .and. &
+                    (bc_y%end < -12 .or. bc_y%end > -1)) then
+                call s_mpi_abort('Unsupported choice for the value of '// &
+                    'bc_y%end. Exiting ...')
+            elseif ((n > 0 .and. bc_y%beg == dflt_int)) then
+                call s_mpi_abort('Unsupported choice for the value of n and '// &
+                    'bc_y%beg. Exiting ...')
+            elseif ((n > 0 .and. bc_y%end == dflt_int)) then
+                call s_mpi_abort('Unsupported choice for the value of n and '// &
+                    'bc_y%end. Exiting ...')
+
+            ! Constraints on the boundary conditions in the theta-direction
+            elseif (bc_z%beg /= dflt_int &
+                    .and. &
+                    (bc_z%beg /= -1 .and. bc_z%beg /= -2)) then
+                call s_mpi_abort('Unsupported choice for the value of '// &
+                    'bc_z%beg. Exiting ...')
+            elseif (bc_z%end /= dflt_int &
+                    .and. &
+                    (bc_z%end /= -1 .and. bc_z%end /= -2)) then
+                call s_mpi_abort('Unsupported choice for the value of '// &
+                    'bc_z%end. Exiting ...')
+            elseif ((p == 0 .and. bc_z%beg /= dflt_int) &
+                    .or. &
+                    (p > 0 .and. bc_z%beg == dflt_int)) then
+                call s_mpi_abort('Unsupported choice for the value of p and '// &
+                    'bc_z%beg. Exiting ...')
+            elseif ((p == 0 .and. bc_z%end /= dflt_int) &
+                    .or. &
+                    (p > 0 .and. bc_z%end == dflt_int)) then
+                call s_mpi_abort('Unsupported choice for the value of p and '// &
+                    'bc_z%end. Exiting ...')
+            elseif (p > 0 &
+                    .and. &
+                    ((bc_z%beg == -1 .and. bc_z%end /= -1) &
+                     .or. &
+                     (bc_z%end == -1 .and. bc_z%beg /= -1))) then
+                call s_mpi_abort('Unsupported choice of the combination of '// &
+                    'values for p, bc_z%beg and bc_z%end. '// &
+                    'Exiting ...')
+            end if
+
+        else
 
             ! Constraints on the boundary conditions in the y-direction
             if (bc_y%beg /= dflt_int &
@@ -436,7 +494,7 @@ contains
                     'values for n, bc_y%beg and bc_y%end. '// &
                     'Exiting ...')
 
-                ! Constraints on the boundary conditions in the z-direction
+            ! Constraints on the boundary conditions in the z-direction
             elseif (bc_z%beg /= dflt_int &
                     .and. &
                     (bc_z%beg < -12 .or. bc_z%beg > -1)) then
@@ -447,59 +505,6 @@ contains
                     (bc_z%end < -12 .or. bc_z%end > -1)) then
                 call s_mpi_abort('Unsupported choice for the value of '// &
                 'bc_z%end. Exiting ...')
-            elseif ((p == 0 .and. bc_z%beg /= dflt_int) &
-                    .or. &
-                    (p > 0 .and. bc_z%beg == dflt_int)) then
-                call s_mpi_abort('Unsupported choice for the value of p and '// &
-                    'bc_z%beg. Exiting ...')
-            elseif ((p == 0 .and. bc_z%end /= dflt_int) &
-                    .or. &
-                    (p > 0 .and. bc_z%end == dflt_int)) then
-                call s_mpi_abort('Unsupported choice for the value of p and '// &
-                    'bc_z%end. Exiting ...')
-            elseif (p > 0 &
-                    .and. &
-                    ((bc_z%beg == -1 .and. bc_z%end /= -1) &
-                     .or. &
-                     (bc_z%end == -1 .and. bc_z%beg /= -1))) then
-                call s_mpi_abort('Unsupported choice of the combination of '// &
-                    'values for p, bc_z%beg and bc_z%end. '// &
-                    'Exiting ...')
-            end if
-
-        else ! Cylindrical coordinates
-
-            ! Constraints on the boundary conditions in the r-direction
-            if (bc_y%beg /= dflt_int &
-                .and. &
-                ((p > 0 .and. bc_y%beg /= -13) &
-                 .or. &
-                 (p == 0 .and. bc_y%beg /= -2))) then
-                call s_mpi_abort('Unsupported choice for the value of '// &
-                    'bc_y%beg. Exiting ...')
-            elseif (bc_y%end /= dflt_int &
-                    .and. &
-                    (bc_y%end < -12 .or. bc_y%end > -1)) then
-                call s_mpi_abort('Unsupported choice for the value of '// &
-                    'bc_y%end. Exiting ...')
-            elseif ((n > 0 .and. bc_y%beg == dflt_int)) then
-                call s_mpi_abort('Unsupported choice for the value of n and '// &
-                    'bc_y%beg. Exiting ...')
-            elseif ((n > 0 .and. bc_y%end == dflt_int)) then
-                call s_mpi_abort('Unsupported choice for the value of n and '// &
-                    'bc_y%end. Exiting ...')
-
-                ! Constraints on the boundary conditions in the theta-direction
-            elseif (bc_z%beg /= dflt_int &
-                    .and. &
-                    (bc_z%beg /= -1 .and. bc_z%beg /= -2)) then
-                call s_mpi_abort('Unsupported choice for the value of '// &
-                    'bc_z%beg. Exiting ...')
-            elseif (bc_z%end /= dflt_int &
-                    .and. &
-                    (bc_z%end /= -1 .and. bc_z%end /= -2)) then
-                call s_mpi_abort('Unsupported choice for the value of '// &
-                    'bc_z%end. Exiting ...')
             elseif ((p == 0 .and. bc_z%beg /= dflt_int) &
                     .or. &
                     (p > 0 .and. bc_z%beg == dflt_int)) then

--- a/src/simulation/m_checker.fpp
+++ b/src/simulation/m_checker.fpp
@@ -72,26 +72,38 @@ contains
         ! Simulation Algorithm Parameters ==================================
         if (all(model_eqns /= (/1, 2, 3, 4/))) then
             call s_mpi_abort('Unsupported value of model_eqns. Exiting ...')
-        elseif (model_eqns == 2 .and. bubbles .and. bubble_model == 1) then
-            call s_mpi_abort('The 5-equation bubbly flow model requires bubble_model = 2 (Keller--Miksis)')
-        elseif (bubbles .and. nb < 1) then
-            call s_mpi_abort('The Ensemble-Averaged Bubble Model requires nb >= 1')
-        elseif (bubbles .and. bubble_model == 3 .and. (polytropic .neqv. .true.)) then
-            call s_mpi_abort('RP bubbles require polytropic compression')
-        elseif (cyl_coord .and. bubbles) then 
-            call s_mpi_abort('Bubble models untested in cylindrical coordinates')
-        elseif (model_eqns == 3 .and. bubbles) then
-            call s_mpi_abort('Bubble models untested with 6-equation model')
-        elseif (model_eqns == 1 .and. bubbles) then
-            call s_mpi_abort('Bubble models untested with pi-gamma model')
-        elseif (model_eqns == 4 .and. num_fluids /= 1) then
-            call s_mpi_abort('The 4-equation model implementation is not a multi-component and requires num_fluids = 1')
-        elseif (bubbles .and. weno_vars /= 2) then
-            call s_mpi_abort('Bubble modeling requires weno_vars = 2')
+        end if
+
+        if (bubbles) then
+            if (model_eqns == 2 .and. bubble_model == 1) then
+                call s_mpi_abort('The 5-equation bubbly flow model requires bubble_model = 2 (Keller--Miksis)')
+            elseif (nb < 1) then
+                call s_mpi_abort('The Ensemble-Averaged Bubble Model requires nb >= 1')
+            elseif (bubble_model == 3 .and. (polytropic .neqv. .true.)) then
+                call s_mpi_abort('RP bubbles require polytropic compression')
+            elseif (cyl_coord) then 
+                call s_mpi_abort('Bubble models untested in cylindrical coordinates')
+            elseif (model_eqns == 3) then
+                call s_mpi_abort('Bubble models untested with 6-equation model')
+            elseif (model_eqns == 1) then
+                call s_mpi_abort('Bubble models untested with pi-gamma model')
+            elseif (weno_vars /= 2) then
+                call s_mpi_abort('Bubble modeling requires weno_vars = 2')
             !TODO: Comment this out when testing riemann with hll
-        elseif (bubbles .and. riemann_solver /= 2) then
-            call s_mpi_abort('Bubble modeling requires riemann_solver = 2')
-        elseif ((bubbles .neqv. .true.) .and. polydisperse) then
+            elseif (riemann_solver /= 2) then
+                call s_mpi_abort('Bubble modeling requires riemann_solver = 2')
+            elseif (avg_state == 1) then 
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'bubbles and Roe average (please use avg_state = 2). '// &
+                    'Exiting ...')
+            end if
+        end if
+
+        if (model_eqns == 4 .and. num_fluids /= 1) then
+            call s_mpi_abort('The 4-equation model implementation is not a multi-component and requires num_fluids = 1')
+        end if
+
+        if ((bubbles .neqv. .true.) .and. polydisperse) then
             call s_mpi_abort('Polydisperse bubble modeling requires the bubble switch to be activated')
         elseif (polydisperse .and. (poly_sigma == dflt_real)) then
             call s_mpi_abort('Polydisperse bubble modeling requires poly_sigma > 0')
@@ -99,31 +111,33 @@ contains
             call s_mpi_abort('QBMM requires bubbles')
         elseif (qbmm .and. (nnode /= 4)) then
             call s_mpi_abort('nnode not supported')
-        elseif (model_eqns == 3 .and. riemann_solver /= 2) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'model_eqns (6-eq) and riemann_solver (please use riemann_solver = 2). '// &
-                'Exiting ...')
-        elseif (model_eqns == 3 .and. alt_soundspeed) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'model_eqns (6-eq) and alt_soundspeed. '// &
-                'Exiting ...')
-        elseif (model_eqns == 3 .and. avg_state == 1) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'model_eqns (6-eq) and Roe average (please use avg_state = 2). '// &
-                'Exiting ...')
-       elseif (bubbles .and. avg_state == 1) then 
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'bubbles and Roe average (please use avg_state = 2). '// &
-                'Exiting ...')
-        elseif (model_eqns == 3 .and. wave_speeds == 2) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'model_eqns (6-eq) and wave_speeds (please use wave_speeds = 1). '// &
-                'Exiting ...')
-        elseif (model_eqns == 3 .and. (cyl_coord .and. p /= 0)) then
-            call s_mpi_abort('Unsupported combination of values of '// &
-                'model_eqns (6-eq) and cylindrical coordinates. '// &
-                'Exiting ...')
-        elseif (num_fluids /= dflt_int &
+        end if
+
+        if (model_eqns ==3 ) then
+            if (riemann_solver /= 2) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'model_eqns (6-eq) and riemann_solver (please use riemann_solver = 2). '// &
+                    'Exiting ...')
+            elseif (alt_soundspeed) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'model_eqns (6-eq) and alt_soundspeed. '// &
+                    'Exiting ...')
+            elseif (avg_state == 1) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'model_eqns (6-eq) and Roe average (please use avg_state = 2). '// &
+                    'Exiting ...')
+            elseif (wave_speeds == 2) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'model_eqns (6-eq) and wave_speeds (please use wave_speeds = 1). '// &
+                    'Exiting ...')
+            elseif (cyl_coord .and. p /= 0) then
+                call s_mpi_abort('Unsupported combination of values of '// &
+                    'model_eqns (6-eq) and cylindrical coordinates. '// &
+                    'Exiting ...')
+            end if
+        end if
+
+        if (num_fluids /= dflt_int &
                 .and. &
                 (num_fluids < 1 .or. num_fluids > num_fluids)) then
             call s_mpi_abort('Unsupported value of num_fluids. Exiting ...')

--- a/toolchain/mfc.py
+++ b/toolchain/mfc.py
@@ -2,7 +2,7 @@
 
 import signal, getpass, platform, itertools, dataclasses
 
-from mfc         import args, lock, build, bench, state
+from mfc         import args, lock, build, bench, state, count
 from mfc.state   import ARG
 from mfc.run     import run
 from mfc.test    import test
@@ -16,7 +16,7 @@ def __print_greeting():
 
     host_line    = f"{getpass.getuser()}@{platform.node()} [{platform.system()}]"
     targets_line = f"[bold]--targets {format_list_to_string(ARG('targets'), 'magenta', 'None')}[/bold]"
-    help_line    = "$ ./mfc.sh \[build, run, test, clean] --help"
+    help_line    = "$ ./mfc.sh \[build, run, test, clean, count] --help"
 
     MFC_SIDEBAR_LINES = [
         "",
@@ -49,7 +49,7 @@ def __checks():
 
 def __run():    
     {"test":  test.test,   "run":   run.run,    "build": build.build,
-     "clean": build.clean, "bench": bench.bench
+     "clean": build.clean, "bench": bench.bench, "count": count.count
     }[ARG("command")]()
 
 

--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -26,6 +26,7 @@ started, run ./mfc.sh build -h.""",
     build = parsers.add_parser(name="build", help="Build MFC and its dependencies.", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     clean = parsers.add_parser(name="clean", help="Clean build artifacts.",          formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     bench = parsers.add_parser(name="bench", help="Benchmark MFC (for CI).",         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    count = parsers.add_parser(name="count", help="Count LOC in MFC.",         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     def add_common_arguments(p, mask = None):
         if mask is None:
@@ -98,6 +99,9 @@ started, run ./mfc.sh build -h.""",
     # === BENCH ===
     add_common_arguments(bench, "t")
 
+    # === COUNT ===
+    add_common_arguments(count)
+
     args: dict = vars(parser.parse_args())
 
     # Add default arguments of other subparsers
@@ -109,7 +113,7 @@ started, run ./mfc.sh build -h.""",
                     args[key] = val
 
     for a, b in [("run",   run  ), ("test",  test ), ("build", build),
-                 ("clean", clean), ("bench", bench)]:
+                 ("clean", clean), ("bench", bench), ("count", count)]:
         append_defaults_to_data(a, b)
 
     if args["command"] is None:

--- a/toolchain/mfc/count.py
+++ b/toolchain/mfc/count.py
@@ -1,0 +1,36 @@
+import os, json, time, typing, datetime, subprocess
+
+import rich.table
+
+from .printer import cons
+from .state   import ARG
+from .build   import build_targets
+from .common  import system, MFC_SUBDIR
+from .        import sched
+
+import glob
+
+def count():
+    
+    cons.print("[bold]Counting lines of code in [magenta]MFC[/magenta][/bold] (including blank ones)")
+    cons.indent()
+  
+    dirs = ['common', 'pre_process', 'simulation', 'post_process']
+    for mydir in dirs:
+        cons.print(f"[bold]In [magenta]{mydir}[/magenta]:[/bold]")
+        dir_path = f'./src/{mydir}/*.*f*'
+        test_list = glob.glob(dir_path)
+        result = str(' '.join(test_list))
+        os.system("wc -l " + result + " | sort | sed \$d")
+        os.system("wc -l " + result + " | sort | tail -n 1")
+        cons.print()
+
+    cons.print("[bold]Total MFC lines:[/bold]")
+    dir_path = f'./src/*/*.*f*'
+    test_list = glob.glob(dir_path)
+    result = str(' '.join(test_list))
+    os.system("wc -l " + result + " | sort | tail -n 1")
+
+
+
+

--- a/toolchain/mfc/count.py
+++ b/toolchain/mfc/count.py
@@ -1,36 +1,44 @@
-import os, json, time, typing, datetime, subprocess
+import os, glob, typing, typing
+
+from .common  import MFC_ROOTDIR
+from .printer import cons
 
 import rich.table
 
-from .printer import cons
-from .state   import ARG
-from .build   import build_targets
-from .common  import system, MFC_SUBDIR
-from .        import sched
+def handle_dir(dirpath: str) -> typing.Tuple[typing.List[typing.Tuple[str, int]], int]:
+    files = []
+    total = 0
 
-import glob
+    for filepath in glob.glob(os.path.join(dirpath, '*.*f*')):
+        with open(filepath) as f:
+            count = sum(1 if not l.isspace() else 0 for l in f.read().split('\n'))
+            files.append((filepath, count))
+            total += count
+
+    files.sort(key=lambda x: x[1], reverse=True)
+
+    return (files, total)
 
 def count():
-    
-    cons.print("[bold]Counting lines of code in [magenta]MFC[/magenta][/bold] (including blank ones)")
+    cons.print("[bold]Counting lines of code in [magenta]MFC[/magenta][/bold] (excluding whitespace lines)")
+    cons.print()
     cons.indent()
   
-    dirs = ['common', 'pre_process', 'simulation', 'post_process']
-    for mydir in dirs:
-        cons.print(f"[bold]In [magenta]{mydir}[/magenta]:[/bold]")
-        dir_path = f'./src/{mydir}/*.*f*'
-        test_list = glob.glob(dir_path)
-        result = str(' '.join(test_list))
-        os.system("wc -l " + result + " | sort | sed \$d")
-        os.system("wc -l " + result + " | sort | tail -n 1")
-        cons.print()
+    total = 0
+    for codedir in ['common', 'pre_process', 'simulation', 'post_process']:
+        dirfiles, dircount = handle_dir(os.path.join(MFC_ROOTDIR, 'src', codedir))        
+        table = rich.table.Table(show_header=True, box=rich.table.box.SIMPLE)
+        table.add_column(f"File (in [magenta]{codedir}[/magenta])", justify="left")
+        table.add_column(f"Lines ([cyan]{dircount}[/cyan])", justify="right")
+        
+        for filepath, count in dirfiles:
+            table.add_row(f"{os.path.basename(filepath)}", f"[bold cyan]{count}[/bold cyan]")
+        
+        total += dircount
 
-    cons.print("[bold]Total MFC lines:[/bold]")
-    dir_path = f'./src/*/*.*f*'
-    test_list = glob.glob(dir_path)
-    result = str(' '.join(test_list))
-    os.system("wc -l " + result + " | sort | tail -n 1")
+        cons.raw.print(table)
 
-
-
+    cons.print(f"[bold]Total MFC lines: [bold cyan]{total}[/bold cyan].[/bold]")
+    cons.print()
+    cons.unindent()
 


### PR DESCRIPTION
Add support for counting lines of code via `./mfc.sh count`, remove `./mfc.sh cloc` since it didn't support `.fpp` files. This PR still isn't great because it counts empty lines, but better than what we had before.