### PR TITLE
Fix #143, --wait, and mpi-autodetecting template files

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -132,7 +132,7 @@ if [ "$1" == "load" ]; then
         MODULES=("${MODULES[@]}" "python/3.8.5")
     elif [ "$u_computer" == "p" ]; then # Phoenix
         if [ "$u_cg" == "c" ]; then
-            MODULES=("gcc/10.3.0-o57x6h" "mvapich2/2.3.6-ouywal")
+            MODULES=("gcc/10.3.0-o57x6h" "openmpi/4.1.4")
         elif [ "$u_cg" == "g" ]; then
             MODULES=("cuda/11.7.0-7sdye3" "nvhpc/22.11")
         fi

--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -95,6 +95,7 @@ started, run ./mfc.sh build -h.""",
     run.add_argument(      "--dry-run",        action="store_true",                       default=False,      help="(Batch) Run without submitting batch file.")
     run.add_argument("--case-optimization",    action="store_true",                       default=False,      help="(GPU Optimization) Compile MFC targets with some case parameters hard-coded.")
     run.add_argument(      "--no-build",       action="store_true",                       default=False,      help="(Testing) Do not rebuild MFC.")
+    run.add_argument("--wait",                 action="store_true",                       default=False,      help="(Batch) Wait for the job to finish.")
 
     # === BENCH ===
     add_common_arguments(bench, "t")

--- a/toolchain/mfc/run/queues.py
+++ b/toolchain/mfc/run/queues.py
@@ -1,7 +1,7 @@
 import os, typing, dataclasses
 
 from .. import common
-
+from ..state import ARG
 
 @dataclasses.dataclass
 class QueueSystem:
@@ -27,6 +27,9 @@ class PBSSystem(QueueSystem):
         return common.does_command_exist("qsub")
 
     def gen_submit_cmd(self, filename: str) -> typing.List[str]:
+        if ARG("wait"):
+            raise common.MFCException("PBS Queue: Sorry, --wait is unimplemented.")
+
         return ["qsub", filename]
 
 
@@ -38,7 +41,12 @@ class LSFSystem(QueueSystem):
         return common.does_command_exist("bsub") and common.does_command_exist("bqueues")
 
     def gen_submit_cmd(self, filename: str) -> None:
-        return ["bsub", filename]
+        cmd = ["bsub"]
+
+        if ARG("wait"):
+            cmd += ["--wait"]        
+
+        return cmd + [filename]
 
 
 class SLURMSystem(QueueSystem):
@@ -49,7 +57,12 @@ class SLURMSystem(QueueSystem):
         return common.does_command_exist("sbatch")
 
     def gen_submit_cmd(self, filename: str) -> None:
-        return ["sbatch", filename]
+        cmd = ["sbatch"]
+    
+        if ARG("wait"):
+            cmd += ["--wait"]
+
+        return cmd + [filename]
 
 
 QUEUE_SYSTEMS = [ LSFSystem(), SLURMSystem(), PBSSystem() ]

--- a/toolchain/templates/pbs.sh
+++ b/toolchain/templates/pbs.sh
@@ -65,19 +65,21 @@ for binpath in {MFC::BINARIES}; do
 
     echo -e ":) Running $binpath:"
 
-    srun                                    \
-         --nodes={nodes}                    \
-         --ntasks-per-node {tasks_per_node} \
-         {MFC::PROFILER} "$binpath"
-
-    #>
-    #> srun --mpi=pmix \
-    #>      {MFC::PROFILER} "$binpath"
-    #>
-    #> mpirun                            \
-    #>        -np {tasks_per_node*nodes} \
-    #>        {MFC::PROFILER} "$binpath"
-    #>
+    if command -v srun > /dev/null 2>&1; then
+        srun                                   \
+            --nodes           {nodes}          \
+            --ntasks-per-node {tasks_per_node} \
+            {MFC::PROFILER} "$binpath"
+        
+        #>
+        #> srun --mpi=pmix \
+        #>      {MFC::PROFILER} "$binpath"
+    else
+        mpirun                         \
+            -np {tasks_per_node*nodes} \
+            {MFC::PROFILER} "$binpath"
+    
+    fi
 
 done
 

--- a/toolchain/templates/slurm.sh
+++ b/toolchain/templates/slurm.sh
@@ -74,24 +74,21 @@ for binpath in {MFC::BINARIES}; do
 
     echo -e ":) Running $binpath:"
 
-#>
-#> Note: This MPI executable might not be well supported
-#>       on your system - if at all. {MFC::BIN} refers to
-#>       the path the MFC executable.
-#>
-#>srun                                   \
-#>     --nodes={nodes}                   \
-#>     --ntasks-per-node {cpus_per_node} \
-#>     --mpi=pmi2		                 \
-#>     {MFC::PROFILER} "{MFC::BIN}"
-#>
-#> srun --mpi=pmix                   \
-#>      {MFC::PROFILER} "{MFC::BIN}"
-#>
+    if command -v srun > /dev/null 2>&1; then
+        srun                                   \
+            --nodes           {nodes}          \
+            --ntasks-per-node {tasks_per_node} \
+            {MFC::PROFILER} "$binpath"
 
-    mpirun                         \
-        -np {nodes*tasks_per_node} \
-        {MFC::PROFILER} "$binpath"
+        #>
+        #> srun --mpi=pmix                 \
+        #>      {MFC::PROFILER} "$binpath"
+        #>
+    else
+        mpirun                         \
+            -np {nodes*tasks_per_node} \
+            {MFC::PROFILER} "$binpath"
+    fi
 
 done
 


### PR DESCRIPTION
This Pull Request:
- *Fixes* #143 by loading OMPI on GT Phoenix instead of MVAPICH. If we only specified `-n` (number of jobs) instead of `-N` (number of nodes) and `--tasks-per-node` then the issue would be resolved for SRUN. Since the user specifically requests nodes and tasks per node when invoking `mfc.sh` we did not opt for this solution. `srun` never seems to work for our purposes when running interactively anyway.
- Introduces the `--wait` option to `./mfc.sh run` (when `-e batch` is ON) to wait for the batch job to complete.
- Batch files select whether to use `srun` or `mpirun` based on which are present. This will reduce the likelihood that a file in `toolchain/templates` has to be modified by a user.

@sbryngelson I found that `sbatch --wait` on SLURM correctly waits for jobs to complete and does exit with a non-zero code if the job fails. As a bonus, you can queue multiple jobs in CI like this:

```bash
for ...; do
    sbatch --wait ... &
do
wait
```

I checked `wait`'s documentation and it will always exit with a 0 exit code. I'm not sure if the CI will fail whenever one `sbatch` process exits with a non-zero exit code. If it does, we can always use bash (or Python) threads to solve this issue. Also, if you want to use `mfc.sh run .. -e batch` on GT Phoenix (with OMPI), you have to modify the template file, removing the check for `srun`. It is a reasonable to assume that if `srun` is present, `srun` should be used, in the general case (not here).