### PR TITLE
[#162] Continue CI when runs fails (matrix & jobs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
           - os:  macos-latest
             debug: --debug
             gcc: 11
+      fail-fast: false
+    continue-on-error: true
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone
@@ -105,6 +107,7 @@ jobs:
       group: phoenix
       labels: self-hosted
     if: github.repository == 'MFlowCode/MFC'
+    continue-on-error: true
     steps:
       - name: Clone
         uses: actions/checkout@v3
@@ -131,6 +134,7 @@ jobs:
       group: phoenix
       labels: self-hosted
     if: github.repository == 'MFlowCode/MFC'
+    continue-on-error: true
     steps:
       - name: Clone
         uses: actions/checkout@v3


### PR DESCRIPTION
According to my understanding of [these docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions), these modifications to .github/workflows/ci.yml should let the CI run jobs until their completion and still display the correct pass/fail status for each (matrix & non-matrix) job as well as the entire CI run. Note that in the docs, there is a significant semantic difference between the job and step-level uses of `continue-on-error`.