### PR TITLE
Added example case for Lax shock tube problem (1D)

### DIFF
--- a/examples/1D_laxshocktube/README.md
+++ b/examples/1D_laxshocktube/README.md
@@ -1,0 +1,3 @@
+# Lax shock tube problem (1D)
+
+Reference: P. D. Lax, Weak solutions of nonlinear hyperbolic equations and their numerical computation, Communications on pure and applied mathematics 7 (1) (1954) 159–193.

--- a/examples/1D_laxshocktube/case.py
+++ b/examples/1D_laxshocktube/case.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import math
+import json
+
+# Numerical setup
+Nx = 399
+dx = 1./(1.*(Nx+1))
+
+Tend, Nt = 0.14, 1000
+mydt     = Tend/(1.*Nt)
+
+# Configuring case dictionary
+print(json.dumps({
+    # Logistics ================================================================
+    'run_time_info'                : 'T',
+    # ==========================================================================
+
+    # Computational Domain Parameters ==========================================
+    'x_domain%beg'                 : 0.E+00,
+    'x_domain%end'                 : 1.E+00,
+    'm'                            : Nx,
+    'n'                            : 0,
+    'p'                            : 0,
+    'dt'                           : mydt,
+    't_step_start'                 : 0,
+    't_step_stop'                  : int(Nt),
+    't_step_save'                  : int(math.ceil(Nt/10.)),
+    # ==========================================================================
+
+    # Simulation Algorithm Parameters ==========================================
+    'num_patches'                  : 2,
+    'model_eqns'                   : 2,
+    'alt_soundspeed'               : 'F',
+    'num_fluids'                   : 1,
+    'adv_alphan'                   : 'T',
+    'mpp_lim'                      : 'F',
+    'mixture_err'                  : 'F',
+    'time_stepper'                 : 3,
+    'weno_order'                   : 5,
+    'weno_eps'                     : 1.E-16,
+    'mapped_weno'                  : 'T',
+    'null_weights'                 : 'F',
+    'mp_weno'                      : 'F',
+    'riemann_solver'               : 2,
+    'wave_speeds'                  : 1,
+    'avg_state'                    : 2,
+    'bc_x%beg'                     : -3,
+    'bc_x%end'                     : -3,
+    # ==========================================================================
+
+    # Formatted Database Files Structure Parameters ============================
+    'format'                       : 1,
+    'precision'                    : 2,
+    'prim_vars_wrt'                :'T',
+    'parallel_io'                  :'T',
+    # ==========================================================================
+                                                            
+    # Patch 1 L ================================================================
+    'patch_icpp(1)%geometry'       : 1,
+    'patch_icpp(1)%x_centroid'     : 0.25,
+    'patch_icpp(1)%length_x'       : 0.5,
+    'patch_icpp(1)%vel(1)'         : 0.698,
+    'patch_icpp(1)%pres'           : 3.528,
+    'patch_icpp(1)%alpha_rho(1)'   : 0.445E+00,
+    'patch_icpp(1)%alpha(1)'       : 1.,
+    # ==========================================================================
+
+    # Patch 2 R ================================================================
+    'patch_icpp(2)%geometry'       : 1,
+    'patch_icpp(2)%x_centroid'     : 0.75,
+    'patch_icpp(2)%length_x'       : 0.5,
+    'patch_icpp(2)%vel(1)'         : 0.0,
+    'patch_icpp(2)%pres'           : 0.571,
+    'patch_icpp(2)%alpha_rho(1)'   : 0.5E+00,
+    'patch_icpp(2)%alpha(1)'       : 1.,
+    # ==========================================================================
+
+    # Fluids Physical Parameters ===============================================
+    'fluid_pp(1)%gamma'            : 1.E+00/(1.4-1.E+00),
+    'fluid_pp(1)%pi_inf'           : 0.0,
+    # ==========================================================================
+}))
+
+# ==============================================================================

--- a/examples/1D_laxshocktube/case.py
+++ b/examples/1D_laxshocktube/case.py
@@ -4,7 +4,7 @@ import math
 import json
 
 # Numerical setup
-Nx = 399
+Nx = 200
 dx = 1./(1.*(Nx+1))
 
 Tend, Nt = 0.14, 1000

--- a/misc/viz.py
+++ b/misc/viz.py
@@ -40,7 +40,7 @@ for name, cfg in VARS.items():
     print(f"  * Reading data files...")
 
     dfs = {}
-    for f in glob.glob(os.path.join(DIRPATH, 'D', f'{cfg[0]}.*.*.dat')):     
+    for f in glob.glob(os.path.join(DIRPATH, 'D', f'{cfg[0]}.*.*.dat')):
         proc, t_step = int(f.split('.')[-3]), int(f.split('.')[-2])
         
         if t_step != dfs:


### PR DESCRIPTION
Added a case file for the 1D Lax shock tube problem to the 'examples' directory, based on Example 4.1 + eqn. 59 in [https://arxiv.org/pdf/2106.01738.pdf](https://arxiv.org/pdf/2106.01738.pdf) as mentioned in #174, and referenced original paper by Lax in example README.