### PR TITLE
Patches Patch

### DIFF
--- a/src/pre_process/m_mpi_proxy.fpp
+++ b/src/pre_process/m_mpi_proxy.fpp
@@ -71,10 +71,12 @@ contains
         #:endfor
 
         do i = 1, num_patches_max
-            #:for VAR in [ 'geometry', 'smooth_patch_id', 'smoothen',          &
-                           'alter_patch' ]
+            #:for VAR in [ 'geometry', 'smooth_patch_id']
                 call MPI_BCAST(patch_icpp(i)%${VAR}$, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
             #:endfor
+            
+            call MPI_BCAST(patch_icpp(i)%smoothen, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+            call MPI_BCAST(patch_icpp(i)%alter_patch(0), num_patches_max, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
 
             #:for VAR in [ 'x_centroid', 'y_centroid', 'z_centroid',           &
                 & 'length_x', 'length_y', 'length_z', 'radius', 'epsilon',     &


### PR DESCRIPTION
This fixes a bug introduced in #181 where some patch variables were broadcasted incorrectly in `m_mpi_proxy` making it so that IC generation on multiple cores did not work when `patch_icpp%alter_patch` or `patch_icpp%smoothen` was used.