### PR TITLE
Batch & Interactive bugfixes

### DIFF
--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -66,7 +66,7 @@ started, run ./mfc.sh build -h.""",
                 p.add_argument(f"--no-{target.name}", action="store_true", help=f"Do not build the {target.name} dependency. Use the system's instead.")
 
         if "g" not in mask:
-            p.add_argument("-g", "--gpus", nargs="+", type=int, default=[0], help="(GPU) List of GPU #s to use.")
+            p.add_argument("-g", "--gpus", nargs="+", type=int, default=None, help="(Optional GPU override) List of GPU #s to use (environment default if unspecified).")
 
     # === BUILD ===
     add_common_arguments(build, "g")

--- a/toolchain/mfc/test/case.py
+++ b/toolchain/mfc/test/case.py
@@ -100,7 +100,11 @@ class TestCase(case.Case):
         super().__init__({**BASE_CFG.copy(), **mods})
 
     def run(self, targets: typing.List[str], gpus: typing.Set[int]) -> subprocess.CompletedProcess:
-        gpu_select        = f"CUDA_VISIBLE_DEVICES={','.join([str(_) for _ in gpus])}"
+        if gpus is not None and len(gpus) != 0:
+            gpus_select = f"--gpus {' '.join([str(_) for _ in gpus])}"
+        else:
+            gpus_select = ""
+        
         filepath          = f'"{self.get_dirpath()}/case.py"'
         tasks             = f"-n {self.ppn}"
         jobs              = f"-j {ARG('jobs')}"    if ARG("case_optimization")  else ""
@@ -110,8 +114,9 @@ class TestCase(case.Case):
         mfc_script = ".\mfc.bat" if os.name == 'nt' else "./mfc.sh"
         
         command: str = f'''\
-            {gpu_select} {mfc_script} run {filepath} {tasks} {binary_option} \
-            {case_optimization} {jobs} -t {' '.join(targets)} 2>&1\
+            {mfc_script} run {filepath} {tasks} {binary_option} \
+            {case_optimization} {jobs} -t {' '.join(targets)} \
+            {gpus_select} 2>&1\
             '''
 
         return subprocess.run(command, stdout=subprocess.PIPE,

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -105,8 +105,6 @@ def test():
     cons.print(f" tests/[bold magenta]UUID[/bold magenta]    Summary")
     cons.print()
     
-    _handle_case.GPU_LOAD = { id: 0 for id in ARG("gpus") }
-
     # Select the correct number of threads to use to launch test CASES
     # We can't use ARG("jobs") when the --case-optimization option is set
     # because running a test case may cause it to rebuild, and thus


### PR DESCRIPTION
Two minor bugfixes:

- The `system` variable was being aliased, resulting in a runtime error.
- The `--gpus` option is now opt-in, the default being the system / environment default if left unspecified.