### PR TITLE
#245: Fix duplicated examples.md items in website's docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ __pycache__
 
 docs/*/initial*
 docs/*/result*
+docs/documentation/*-example.png
 docs/documentation/examples.md
 
 examples/*batch/*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,6 +446,19 @@ if (MFC_SYSCHECK)
 endif()
 
 if (MFC_DOCUMENTATION)
+    # Files in docs/examples are used to generate docs/documentation/examples.md
+    file(GLOB_RECURSE examples_DOCs CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/docs/examples/*")
+
+    add_custom_command(
+        OUTPUT  "${CMAKE_CURRENT_SOURCE_DIR}/docs/documentation/examples.md"
+        DEPENDS "${examples_DOCs}"
+        COMMAND "bash" "${CMAKE_CURRENT_SOURCE_DIR}/docs/examples.sh" 
+                       "${CMAKE_CURRENT_SOURCE_DIR}"
+        COMMENT "Generating examples.md"
+    )
+
+    file(GLOB common_DOCs CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/docs/*")
+
     # GEN_DOCS: Given a target name (herein <target>), this macro sets up a
     # target, <target>_docs, that generates documentation for <target> using
     # Doxygen. It is then added as a dependency of the documentation target.
@@ -472,13 +485,20 @@ if (MFC_DOCUMENTATION)
             "${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in"
             "${CMAKE_CURRENT_BINARY_DIR}/${target}-Doxyfile" @ONLY)
 
+        set(opt_example_dependency "")
+        if (target STREQUAL "documentation")
+            set(opt_example_dependency "${CMAKE_CURRENT_SOURCE_DIR}/docs/documentation/examples.md")
+        endif()
+
+        file(GLOB_RECURSE ${target}_DOCs CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/docs/${target}/*")
+        list(APPEND ${target}_DOCs "${common_DOCs}")
+
         add_custom_command(
             OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/${target}/html/index.html"
             DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${target}-Doxyfile"
-                    "${${target}_SRCs}"
-            COMMAND  "bash" "${CMAKE_CURRENT_SOURCE_DIR}/docs/examples.sh" 
-                            "${CMAKE_CURRENT_SOURCE_DIR}" && 
-                    "${DOXYGEN_EXECUTABLE}" "${target}-Doxyfile"
+                    "${opt_example_dependency}"
+                    "${${target}_SRCs}" "${${target}_DOCs}"
+            COMMAND "${DOXYGEN_EXECUTABLE}" "${target}-Doxyfile"
             WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
             COMMENT "${target}: Generating documentation"
         )
@@ -503,7 +523,7 @@ if (MFC_DOCUMENTATION)
     ExternalProject_Add(doxygen-awesome-css
         PREFIX            doxygen-awesome-css
         GIT_REPOSITORY    "https://github.com/jothepro/doxygen-awesome-css"
-        GIT_TAG           "df83fbf22cfff76b875c13d324baf584c74e96d0"
+        GIT_TAG           "df88fe4fdd97714fadfd3ef17de0b4401f804052"
         CONFIGURE_COMMAND ""
         BUILD_COMMAND     ""
         INSTALL_COMMAND   ""

--- a/docs/examples.sh
+++ b/docs/examples.sh
@@ -7,19 +7,15 @@ rm "$examples_md" || true
 
 echo -e "# Example Cases\n" > "$examples_md"
 
-for casedir in $(find "$1/examples/" -maxdepth 1 -type d); do
-    casename="$(basename $casedir)"
-
-    if [ "$casename" == "examples" ]; then
-        continue
-    fi
+for casedir in $(find "$1/examples/" -mindepth 1 -maxdepth 1 -type d); do
+    casename="$(basename "$casedir")"
 
     if [ -f "$casedir/README.md" ]; then
-        sed -e "s/\.png/-$casename\.png/g" "$casedir/README.md" | sed 's/^#/##/g' >> "$examples_md"
-        echo "" >> "$examples_md"
+        sed -e "s/\.png/-$casename-example\.png/g" "$casedir/README.md" | sed 's/^#/##/g' >> "$examples_md"
+        echo '' >> "$examples_md"
 
-        for png in $(find "$casedir" -maxdepth 1 -name "*.png"); do
-            cp "$png" "$1/docs/documentation/$(basename $png | sed s/\.png//g)-$casename.png"
+        for png in $(find "$casedir" -maxdepth 1 -name '*.png'); do
+            cp "$png" "$1/docs/documentation/$(basename "$png" | sed s/\.png//g)-$casename-example.png"
         done
     fi
 done


### PR DESCRIPTION
Fixes #245: I am pretty sure this fixes the issue. There were multiple calls to `docs/examples.sh` because of how CMake was set-up to generate docs for each documentation target (pre_process, simulation, post_process, and documentation). Although the script makes sure `examples.md` is deleted before appending thereto, if there are multiple, un-serialized calls to the bash script, you can get duplicated items.