### PR TITLE
Run Phoenix jobs using available CPU cores

### DIFF
--- a/misc/run-phoenix-release-cpu.sh
+++ b/misc/run-phoenix-release-cpu.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #SBATCH -Jshb-test-jobs            # Job name
+#SBATCH -p cpu-small               # partition
 #SBATCH --account=gts-sbryngelson3 # charge account
-#SBATCH -N1 --ntasks-per-node=12   # Number of nodes and cores per node required
-#SBATCH --mem-per-cpu=2G           # Memory per core
-#SBATCH -t 04:00:00                # Duration of the job (Ex: 15 mins)
+#SBATCH -N1 --ntasks-per-node=24   # Number of nodes and cores per node required
+#SBATCH -t 03:00:00                # Duration of the job (Ex: 15 mins)
 #SBATCH -q embers                  # QOS Name
 #SBATCH -otest.out                 # Combined output and error messages file
 #SBATCH -W                         # Do not exit until the submitted job terminates.


### PR DESCRIPTION
I'm attempting to improve runtime on Phoenix runners. Requesting a node without specifying the cpu-small partition can hang for a bit. 

I'm noticing that there's a problem with `./mfc.sh test -a` always rebuilding HDF5/Silo even if they are already built during `./mfc.sh build`. This is slowing things down (especially on Debug runs). I think this might be triggered via the following output:


```terminal
atl1-1-03-002-15-1: p-sbryngelson3-0/MFC-2 $ time ./mfc.sh test -j 12 -b mpirun -a
mfc: OK > (venv) Entered the Python virtual environment.

      .=++*:          -+*+=.          sbryngelson3@atl1-1-03-002-15-1.pace.gatech.edu [Linux]
     :+   -*-        ==   =* .        -------------------------------------------------------
   :*+      ==      ++    .+-         --jobs 12
  :*##-.....:*+   .#%+++=--+=:::.     --mpi
  -=-++-======#=--**+++==+*++=::-:.   --no-gpu
 .:++=----------====+*= ==..:%.....   --no-debug
  .:-=++++===--==+=-+=   +.  :=
  +#=::::::::=%=. -+:    =+   *:      -----------------------------------------------------------
 .*=-=*=..    :=+*+:      -...--      $ ./mfc.sh [build, run, test, clean, count, packer] --help

Generating syscheck/include/case.fpp.
  INFO: Custom case.fpp file is up to date.

$ cmake --build /storage/coda1/p-sbryngelson3/0/sbryngelson3/MFC-2/build/no-debug_no-gpu_mpi/syscheck --target syscheck
-j 12 --config Release

[100%] Built target syscheck

$ cmake --install /storage/coda1/p-sbryngelson3/0/sbryngelson3/MFC-2/build/no-debug_no-gpu_mpi/syscheck

-- Install configuration: "Release"
-- Installing: /storage/home/hcoda1/6/sbryngelson3/p-sbryngelson3-0/MFC-2/build/install/no-debug_no-gpu_mpi/bin/syscheck
-- Set runtime path of "/storage/home/hcoda1/6/sbryngelson3/p-sbryngelson3-0/MFC-2/build/install/no-debug_no-gpu_mpi/bin/syscheck" to ""
Generating pre_process/include/case.fpp.
  INFO: Custom case.fpp file is up to date.

$ cmake --build /storage/coda1/p-sbryngelson3/0/sbryngelson3/MFC-2/build/no-debug_no-gpu_mpi/pre_process --target
pre_process -j 12 --config Release

-- GLOB mismatch!
-- Enabled IPO / LTO
-- Configuring done
-- Generating done
-- Build files have been written to: /storage/home/hcoda1/6/sbryngelson3/p-sbryngelson3-0/MFC-2/build/no-debug_no-gpu_mpi/pre_process
[  8%] Preprocessing (Fypp) m_variables_conversion.fpp
[  8%] Preprocessing (Fypp) m_constants.fpp
[ 11%] Preprocessing (Fypp) m_check_patches.fpp
[ 11%] Preprocessing (Fypp) m_data_output.fpp
[ 14%] Preprocessing (Fypp) m_derived_types.fpp
[ 17%] Preprocessing (Fypp) m_global_parameters.fpp
[ 26%] Preprocessing (Fypp) m_helper.fpp
[ 26%] Preprocessing (Fypp) m_initial_condition.fpp
[ 26%] Preprocessing (Fypp) m_model.fpp
[ 29%] Preprocessing (Fypp) m_mpi_common.fpp
[ 32%] Preprocessing (Fypp) m_mpi_proxy.fpp
[ 35%] Preprocessing (Fypp) m_patches.fpp
[ 38%] Preprocessing (Fypp) m_start_up.fpp
Scanning dependencies of target pre_process
[ 41%] Building Fortran object CMakeFiles/pre_process.dir/src/pre_process/autogen/m_constants.fpp.f90.o
nvfortran-Warning-CUDA_HOME has been deprecated. Please, use NVHPC_CUDA_HOME instead.
/storage/home/hcoda1/6/sbryngelson3/p-sbryngelson3-0/MFC-2/src/pre_process/autogen/m_constants.fpp.f90:
[ 44%] Building Fortran object CMakeFiles/pre_process.dir/src/pre_process/autogen/m_derived_types.fpp.f90.o
nvfortran-Warning-CUDA_HOME has been deprecated. Please, use NVHPC_CUDA_HOME instead.
/storage/home/hcoda1/6/sbryngelson3/p-sbryngelson3-0/MFC-2/src/pre_process/autogen/m_derived_types.fpp.f90:
[ 47%] Building Fortran object CMakeFiles/pre_process.dir/src/pre_process/autogen/m_global_parameters.fpp.f90.o
nvfortran-Warning-CUDA_HOME has been deprecated. Please, use NVHPC_CUDA_HOME instead.
/storage/home/hcoda1/6/sbryngelson3/p-sbryngelson3-0/MFC-2/src/pre_process/autogen/m_global_parameters.fpp.f90:
[ 52%] Building Fortran object CMakeFiles/pre_process.dir/src/pre_process/autogen/m_mpi_common.fpp.f90.o
[ 52%] Building Fortran object CMakeFiles/pre_process.dir/src/pre_process/autogen/m_helper.fpp.f90.o
nvfortran-Warning-CUDA_HOME has been deprecated. Please, use NVHPC_CUDA_HOME instead.
```

Notice the `GLOB mismatch` that occurs for all targets and thus rebuilds their dependencies...

I also see that the build step on Phoenix takes 30 minutes (at least for the CPU build), but about 10 minutes if one grabs a CPU node and builds the code there. This might motivate building MFC in CI on a Phoenix compute node so we can do `-j 12`.

Update @henryleberre: This should actually be `-j 24` on the build and test, the compute nodes are dual-socket 12 core Intel Golds.

Update 2: Using `./mfc.sh test -j 24 -b mpirun -a` dispatches 24 jobs to 1 core on a 24 core node. Core 0 is saturated at 100% utilization (per `htop`) but others are idle. Is this an easy fix?