### PR TITLE
bump required python minor version

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -4,7 +4,7 @@ unset u_c
 unset u_cg
 
 MFC_PYTHON_MIN_MAJOR=3
-MFC_PYTHON_MIN_MINOR=6
+MFC_PYTHON_MIN_MINOR=9
 
 # Check whether this script was called from MFC's root directory.
 if [ ! -f "$(pwd)/toolchain/mfc.py" ]; then


### PR DESCRIPTION
I made it require Python 3.9. I know 3.6 doesn't work. I know 3.9 does. I do not know about 3.7 or 3.8. For the `math.prod` this has a documented update somewhere, but 3.6 also doesn't work once this is replaced with a 3.6-compatible command (something wrong with the subprocesses call). 

Closes #265 
