### PR TITLE
Update Bridges2 modules 

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -142,7 +142,14 @@ if [ "$1" == 'load' ]; then
         fi
     done
 
-    ok "All modules have been loaded for $M$COMPUTER$CR on $M$CG$CR"'s.'
+    if [ "$cg" == 'gpu' ]; then
+        isnv=$($FC --version | grep NVIDIA | wc -l)
+        if [ $isnv -eq 0 ]; then
+            export CC=nvc CXX=nvc++ FC=nvfortran
+        fi
+    fi
+    ok 'All modules and environment variables have been loaded.'
+
 
     return
 elif [ "$1" == "format" ]; then

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -15,7 +15,7 @@ s-gpu nvhpc/22.11 cuda/nvhpc
 b     PSC Bridges2
 b-all python/3.8.6
 b-cpu allocations/1.0 gcc/10.2.0 openmpi/4.0.5-gcc10.2.0
-b-gpu openmpi/4.0.5-nvhpc22.9 nvhpc/22.9
+b-gpu openmpi/4.0.5-nvhpc22.9 nvhpc/22.9 cuda
 
 a     OLCF Ascent
 a-all python cmake/3.22.2


### PR DESCRIPTION
Bridges2 also seems to require `export FC=nvfortran`, or at least loading the nvhpc modules doesn't set this env variable (it is set to gfortran by default and doesn't change). 

I wonder if there's a slick way to build that in somehow @henryleberre ?