### PR TITLE
Shared node for benching

### DIFF
--- a/.github/workflows/phoenix/bench.sh
+++ b/.github/workflows/phoenix/bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-n_ranks=4
+n_ranks=2
 
 if [ "$job_device" == "gpu" ]; then
     n_ranks=$(nvidia-smi -L | wc -l)        # number of GPUs on node

--- a/.github/workflows/phoenix/submit.sh
+++ b/.github/workflows/phoenix/submit.sh
@@ -15,11 +15,13 @@ fi
 
 sbatch_cpu_opts="\
 #SBATCH -p cpu-small               # partition
+#SBATCH -N1                        # Number of nodes required
 #SBATCH --ntasks-per-node=24       # Number of cores per node required
 #SBATCH --mem-per-cpu=2G           # Memory per core\
 "
 
 sbatch_gpu_opts="\
+#SBATCH -n4                        # Number of ranks required
 #SBATCH -CV100-16GB
 #SBATCH -G2\
 "
@@ -39,7 +41,6 @@ sbatch <<EOT
 #!/bin/bash
 #SBATCH -Jshb-$job_slug            # Job name
 #SBATCH --account=gts-sbryngelson3 # charge account
-#SBATCH -N1                        # Number of nodes required
 $sbatch_device_opts
 #SBATCH -t 04:00:00                # Duration of the job (Ex: 15 mins)
 #SBATCH -q embers                  # QOS Name

--- a/.github/workflows/phoenix/submit.sh
+++ b/.github/workflows/phoenix/submit.sh
@@ -39,7 +39,7 @@ job_slug="`basename "$1" | sed 's/\.sh$//' | sed 's/[^a-zA-Z0-9]/-/g'`-$2"
 
 sbatch <<EOT
 #!/bin/bash
-#SBATCH -Jshb-$job_slug            # Job name
+#SBATCH -JMFC-$job_slug            # Job name
 #SBATCH --account=gts-sbryngelson3 # charge account
 $sbatch_device_opts
 #SBATCH -t 04:00:00                # Duration of the job (Ex: 15 mins)


### PR DESCRIPTION
Idea here is that many benchmark jobs fail because we need an entire node to benchmark on only 1 or 2 GPUs. Taking over the whole node is ideal for benchmarking, but my view is that our testing should be mostly robust to someone else performing periphery tasks on a node. This update lets us share nodes and gets us into the queue much quicker (at least that's my experience, we will see how the CI runs). We will also use other runners (like RG Violet/Quorra) for this purpose so we will have multiple points of contact for performance. 