### PR TITLE
Fix I/O Bug

### DIFF
--- a/src/post_process/m_data_input.f90
+++ b/src/post_process/m_data_input.f90
@@ -392,7 +392,7 @@ contains
                                                MPI_DOUBLE_PRECISION, status, ierr)
                     end do
                 else
-                    do i = 1, adv_idx%end
+                    do i = 1, sys_size
                         var_MOK = int(i, MPI_OFFSET_KIND)
 
                         ! Initial displacement to skip at beginning of file

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -690,7 +690,7 @@ contains
                         end do
                     end if
                 else
-                    do i = 1, adv_idx%end
+                    do i = 1, sys_size
                         var_MOK = int(i, MPI_OFFSET_KIND)
 
                         ! Initial displacement to skip at beginning of file


### PR DESCRIPTION
## Description

Simulation and post_process only read the parallel I/O files up to `adv_idx%beg` when they should read up to `sys_size`. This fixes that.

### Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x ] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

