### PR TITLE
Accomodate `mvapich` + `mpiexec`

### DIFF
--- a/toolchain/templates/default.mako
+++ b/toolchain/templates/default.mako
@@ -48,9 +48,14 @@ warn "Consider using a different template via the $MAGENTA--computer$COLOR_RESET
                 srun --ntasks-per-node ${tasks_per_node}         \
                      ${' '.join([f"'{x}'" for x in ARG('--') ])} \
                      "${target.get_install_binpath()}"
-        elif [ "$binary" == "mpirun" ] || [ "$binary" == "mpiexec" ]; then
+        elif [ "$binary" == "mpirun" ]; then
             ${' '.join([f"'{x}'" for x in profiler ])}              \
-                $binary -np ${nodes*tasks_per_node}                 \
+                mpirun -np ${nodes*tasks_per_node}                 \
+                        ${' '.join([f"'{x}'" for x in ARG('--') ])} \
+                        "${target.get_install_binpath()}"
+        elif [ "$binary" == "mpiexec" ]; then
+            ${' '.join([f"'{x}'" for x in profiler ])}              \
+                mpiexec --ntasks=${nodes*tasks_per_node}                 \
                         ${' '.join([f"'{x}'" for x in ARG('--') ])} \
                         "${target.get_install_binpath()}"
         fi


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue(s) if they exist.
Please also include relevant motivation and context.

Fixes #(issue) [optional]

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] Checked that this worked with
```console
atl1-1-03-004-1-2: p-sbryngelson3-0/MFC-Wilfong $ module list

Currently Loaded Modules:
  1) pace-slurm/2022.06                          11) libiconv/1.16-ncofu7       (H)  21) sqlite/3.38.5-6xd3fx          (H)
  2) cmake/3.23.1-327dbl                         12) xz/5.2.5-mxn6we            (H)  22) util-linux-uuid/2.37.4-ygzna4 (H)
  3) intel-oneapi-compilers/2022.1.0-toad7k      13) zlib/1.2.12-s6uu6m         (H)  23) python/3.9.12-2ct5jo
  4) bzip2/1.0.8-7nz6rg                     (H)  14) libxml2/2.9.13-luaxjf      (H)  24) libpciaccess/0.16-dpx2ak      (H)
  5) libmd/1.0.4-d7ocmo                     (H)  15) pigz/2.7-5i66gg            (H)  25) pmix/3.2.3-wqaac7             (H)
  6) libbsd/0.11.5-frvow4                   (H)  16) zstd/1.5.2-weflam          (H)  26) rdma-core/15-t43af2           (H)
  7) expat/2.4.8-7aege3                     (H)  17) tar/1.34-lcvrzy            (H)  27) slurm/current-mrxqvx          (H)
  8) ncurses/6.2-3heovb                     (H)  18) gettext/0.21-cge6os        (H)  28) mvapich2/2.3.7-6wqdfc
  9) readline/8.1-njnqfe                    (H)  19) libffi/3.4.2-lolk25        (H)
 10) gdbm/1.19-5ssywx                       (H)  20) openssl/1.0.2k-fips-czzxvp (H)
```
**Test Configuration**:

* What computers and compilers did you use to test this:
	* Phoenix + modules above
	* Checked that `./mfc.sh run [...] -b mpiexec` works
	* Checked that `./mfc.sh test [...] -- -b mpiexec` works
