### PR TITLE
mvapich mpiexec flags & Print invocation

### DIFF
--- a/toolchain/templates/bridges2.mako
+++ b/toolchain/templates/bridges2.mako
@@ -39,12 +39,12 @@ echo
     ${helpers.run_prologue(target)}
 
     % if not mpi:
-        ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}"
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}")
     % else:
-        ${' '.join([f"'{x}'" for x in profiler ])}             \
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])}             \
             mpirun -np ${nodes*tasks_per_node}                 \
                    ${' '.join([f"'{x}'" for x in ARG('--') ])} \
-                   "${target.get_install_binpath()}"
+                   "${target.get_install_binpath()}")
     % endif
 
     ${helpers.run_epilogue(target)}

--- a/toolchain/templates/default.mako
+++ b/toolchain/templates/default.mako
@@ -33,26 +33,31 @@ warn "Consider using a different template via the $MAGENTA--computer$COLOR_RESET
     ${helpers.run_prologue(target)}
 
     % if not mpi:
-        ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}"
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}")
     % else:
         if [ "$binary" == "jsrun" ]; then
-            ${' '.join([f"'{x}'" for x in profiler ])}            \
+            (set -x; ${' '.join([f"'{x}'" for x in profiler ])}   \
                 jsrun --nrs          ${tasks_per_node*nodes}      \
                       --cpu_per_rs   1                            \
                       --gpu_per_rs   ${1 if gpu else 0}           \
                       --tasks_per_rs 1                            \
                       ${' '.join([f"'{x}'" for x in ARG('--') ])} \
-                      "${target.get_install_binpath()}"
+                      "${target.get_install_binpath()}")
         elif [ "$binary" == "srun" ]; then
-            ${' '.join([f"'{x}'" for x in profiler ])}           \
+            (set -x; ${' '.join([f"'{x}'" for x in profiler ])}  \
                 srun --ntasks-per-node ${tasks_per_node}         \
                      ${' '.join([f"'{x}'" for x in ARG('--') ])} \
-                     "${target.get_install_binpath()}"
-        elif [ "$binary" == "mpirun" ] || [ "$binary" == "mpiexec" ]; then
-            ${' '.join([f"'{x}'" for x in profiler ])}              \
+                     "${target.get_install_binpath()}")
+        elif [ "$binary" == "mpirun" ]; then
+            (set -x; ${' '.join([f"'{x}'" for x in profiler ])}     \
                 $binary -np ${nodes*tasks_per_node}                 \
                         ${' '.join([f"'{x}'" for x in ARG('--') ])} \
-                        "${target.get_install_binpath()}"
+                        "${target.get_install_binpath()}")
+        elif [ "$binary" == "mpiexec" ]; then
+            (set -x; ${' '.join([f"'{x}'" for x in profiler ])}     \
+                $binary --ntasks ${nodes*tasks_per_node}            \
+                        ${' '.join([f"'{x}'" for x in ARG('--') ])} \
+                        "${target.get_install_binpath()}")
         fi
     % endif
 

--- a/toolchain/templates/delta.mako
+++ b/toolchain/templates/delta.mako
@@ -41,12 +41,12 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/sw/spack/deltas11-2023-03/apps/linux-rh
     ${helpers.run_prologue(target)}
 
     % if not mpi:
-        ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}"
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}")
     % else:
-        ${' '.join([f"'{x}'" for x in profiler ])}             \
-            mpirun -np ${nodes*tasks_per_node} \
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])}    \
+            mpirun -np ${nodes*tasks_per_node}                 \
                    ${' '.join([f"'{x}'" for x in ARG('--') ])} \
-                   "${target.get_install_binpath()}"
+                   "${target.get_install_binpath()}")
     % endif
 
     ${helpers.run_epilogue(target)}

--- a/toolchain/templates/phoenix.mako
+++ b/toolchain/templates/phoenix.mako
@@ -39,13 +39,13 @@ echo
     ${helpers.run_prologue(target)}
 
     % if not mpi:
-        ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}"
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}")
     % else:
-        ${' '.join([f"'{x}'" for x in profiler ])}             \
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])}    \
             mpirun -np ${nodes*tasks_per_node}                 \
                    --bind-to none                              \
                    ${' '.join([f"'{x}'" for x in ARG('--') ])} \
-                   "${target.get_install_binpath()}"
+                   "${target.get_install_binpath()}")
     % endif
 
     ${helpers.run_epilogue(target)}

--- a/toolchain/templates/summit.mako
+++ b/toolchain/templates/summit.mako
@@ -24,9 +24,9 @@ echo
     ${helpers.run_prologue(target)}
 
     % if not mpi:
-        ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}"
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])} "${target.get_install_binpath()}")
     % else:
-        ${' '.join([f"'{x}'" for x in profiler ])}          \
+        (set -x; ${' '.join([f"'{x}'" for x in profiler ])} \
             jsrun                                           \
                 ${'--smpiargs="-gpu"' if gpu else ''}       \
                 --nrs          ${tasks_per_node*nodes}      \
@@ -34,7 +34,7 @@ echo
                 --gpu_per_rs   ${1 if gpu else 0}           \
                 --tasks_per_rs 1                            \
                 ${' '.join([f"'{x}'" for x in ARG('--') ])} \
-                "${target.get_install_binpath()}"
+                "${target.get_install_binpath()}")
     % endif
 
     ${helpers.run_epilogue(target)}


### PR DESCRIPTION
## Description

- Changed flags passed to `mpiexec` in the `default.mako` template for Intel compilers (with Intel-MPI) to run on GT Phoenix.
- Made the invocation of the MPI binary be printed by the template files for easier debugging.

Motivation: @sbryngelson wanted it.

Fixes #(issue) [optional]

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] "It worked on my Phoenix session with an Intel environment".
- [x] It "lgtm".

**Test Configuration**:

* What computers and compilers did you use to test this:

- Intel (2021).

## Checklist

- [ ] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected
- [ ] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
