### PR TITLE
Fix apt in ubuntu workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,8 @@ jobs:
     # https://github.com/doxygen/doxygen/issues/9016
     - name: Build Doxygen
       run:  |
-        sudo apt install cmake ninja-build graphviz graphviz
+        sudo apt update -y
+        sudo apt install -y cmake ninja-build graphviz graphviz
         git clone https://github.com/doxygen/doxygen.git ../doxygen
         cmake -S ../doxygen -B ../doxygen/build -G Ninja
         sudo ninja -C ../doxygen/build install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Setup Ubuntu (Intel)
         if:   matrix.os == 'ubuntu' && matrix.intel == true
         run: |
-          sudo apt install tar wget make cmake python3 python3-dev
+          sudo apt update -y
+          sudo apt install -y tar wget make cmake python3 python3-dev
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB


### PR DESCRIPTION
Apt stopped working via the error 
```console
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
on all github workflows that didn't first call
```console
sudo apt update -y
```
Changing this seems to fix it.