### PR TITLE
Fix #346 - Accept & Provide ENV{MFC_CUDA_CC}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,10 +153,19 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
         add_compile_options(
             $<$<COMPILE_LANGUAGE:Fortran:-minline>
         )
+    elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(
+            $<$<COMPILE_LANGUAGE:Fortran:-O0>
+        )
     endif()
-    
+
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(-C -g -O0 -traceback -Mchkptr -Mchkstk -Minform=inform -Mbounds)
+    endif()
+
+    if (DEFINED ENV{MFC_CUDA_CC})
+        string(REGEX MATCHALL "[0-9]+" MFC_CUDA_CC $ENV{MFC_CUDA_CC})
+        message(STATUS "Found $MFC_CUDA_CC specified. GPU code will be generated for ${MFC_CUDA_CC}.")
     endif()
 endif()
 
@@ -395,13 +404,19 @@ function(MFC_SETUP_TARGET)
                 target_compile_definitions(${ARGS_TARGET} PRIVATE MFC_cuTENSOR)
             endif()
 
-            if     (CMAKE_BUILD_TYPE STREQUAL "Release")
+            foreach (cc ${MFC_CUDA_CC})
                 target_compile_options(${ARGS_TARGET}
-                    PRIVATE -gpu=keep,ptxinfo,lineinfo
+                    PRIVATE -gpu=cc${cc}
                 )
-            elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
+            endforeach()
+
+            target_compile_options(${ARGS_TARGET}
+                PRIVATE -gpu=keep,ptxinfo,lineinfo
+            )
+
+            if (CMAKE_BUILD_TYPE STREQUAL "Debug")
                 target_compile_options(${ARGS_TARGET}
-                    PRIVATE -gpu=keep,ptxinfo,lineinfo,autocompare,debug -O0
+                    PRIVATE -gpu=autocompare,debug
                 )
             endif()
         endif()

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -11,16 +11,19 @@ s-all python/3.8.10 darshan-runtime/3.3.1-lite hsi/5.0.2.p5 xalt/1.2.1
 s-cpu lsf-tools/2.0 cmake/3.23.2 ninja/1.10.2 spectrum-mpi/10.4.0.3-20210112
 s-cpu gcc/12.1.0
 s-gpu nvhpc/22.11 cuda/nvhpc
+s-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 b     PSC Bridges2
 b-all python/3.8.6
 b-cpu allocations/1.0 gcc/10.2.0 openmpi/4.0.5-gcc10.2.0
 b-gpu openmpi/4.0.5-nvhpc22.9 nvhpc/22.9 cuda
+b-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 a     OLCF Ascent
 a-all python cmake/3.22.2
 a-cpu gcc/11.1.0 spectrum-mpi cuda
 a-gpu nvhpc/21.11 spectrum-mpi cuda/nvhpc nsight-compute nsight-systems
+a-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 r     Richardson
 r-all python/3.7
@@ -30,16 +33,19 @@ w     OLCF Wombat
 w-all cmake/3.25.1 python/3.10.8
 w-cpu gcc/11.1.0 openmpi/4.0.5_gcc
 w-gpu nvhpc/22.11
+w-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 e     SDSC Expanse
 e-all python/3.8.5
 e-cpu cpu/0.15.4 gcc/9.2.0 openmpi/4.1.1 cmake/3.18.2
 e-gpu gpu/0.15.4 cuda/11.0.2 nvhpc/22.2 openmpi/4.0.5 cmake/3.19.8
+e-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 p     GT Phoenix
 p-all python/3.9.12-rkxvr6 cmake/3.23.1-327dbl
 p-cpu gcc/10.3.0-o57x6h openmpi/4.1.4
 p-gpu cuda/11.7.0-7sdye3 nvhpc/22.11
+p-gpu MFC_CUDA_CC=70,80 CC=nvc CXX=nvc++ FC=nvfortran
 
 c     OLCF Crusher
 c-all cmake/3.23.2 cray-fftw/3.3.10.2 hdf5/1.12.1 cray-python/3.9.13.1
@@ -51,3 +57,4 @@ d     NCSA Delta
 d-all python/3.11.6
 d-cpu gcc/11.4.0 openmpi
 d-gpu nvhpc/22.11 openmpi+cuda/4.1.5+cuda cmake
+d-gpu CC=nvc CXX=nvc++ FC=nvfortran


### PR DESCRIPTION
## Description

- Let CMake check for the `MFC_CUDA_CC` environment variable to specify `--gpu=ccXY` for the desired CUDA target architectures. If left unspecified, the behavior is unchanged.
- Add `MFC_CUDA_CC` for GT Phoenix in the `toolchain/modules` file.

Fixes #346. GPU build times are ~2.7x faster on GT Phoenix.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

**Test Configuration**:

What computers and compilers did you use to test this:

- GT Phoenix (CI) & Manual build.