### PR TITLE
Upstream fixes and tools from Chemfc

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # We build doxygen from source because of
     # https://github.com/doxygen/doxygen/issues/9016

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Lint the toolchain
       run: ./mfc.sh lint

--- a/.github/workflows/pretty.yml
+++ b/.github/workflows/pretty.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Check formatting
       run: |
-        ./mfc.sh format
+        ./mfc.sh format -j $(nproc)
         git diff --exit-code

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Spell Check
       uses: crate-ci/typos@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup MacOS
         if:   matrix.os == 'macos'
@@ -46,10 +46,7 @@ jobs:
       - name: (MacOS) Build OpenMPI
         if:   matrix.os == 'macos' && matrix.mpi == 'mpi'
         run: |
-          echo "OMPI_FC=gfortran-13" >> $GITHUB_ENV
-          echo "OMPI_CXX=g++-13"     >> $GITHUB_ENV
-          echo "OMPI_MPICC=gcc-13"   >> $GITHUB_ENV
-          HOMEBREW_MAKE_JOBS=$(nproc) brew install --cc=gcc-13 --verbose --build-from-source open-mpi
+          brew install mpich
 
       - name: Setup Ubuntu
         if:   matrix.os == 'ubuntu' && matrix.intel == false
@@ -96,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Test
       run:  sudo ./mfc.sh docker ./mfc.sh test -j $(nproc) -a

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ examples/*/viz/
 examples/*.jpg
 examples/*.png
 *.mod
+
+# Video Files
+*.mp4
+*.mov
+*.mkv
+*.avi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,8 @@
 
     "cmake.configureOnOpen": false,
 
+    "python.defaultInterpreterPath": "${workspaceFolder}/build/venv/bin/python3",
+
     "fortran.preferredCase":       "lowercase",
     "fortran.linter.includePaths": [ "${workspacefolder}/src/**" ],
-    "fortran.linter.fypp.enabled": true
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,8 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
             -fcheck=all,no-array-temps 
             -fbacktrace
             -fimplicit-none
-        )
+            #-ffpe-trap=invalid,zero,denormal,overflow
+	)
     endif()
 
     if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 10)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It's rather straightforward.
 We'll give a brief intro. here for MacOS.
 Using [brew](https://brew.sh), install MFC's modest set of dependencies:
 ```console
-brew install wget make python make cmake coreutils gcc openmpi
+brew install wget make python make cmake coreutils gcc mpich
 ```
 You're now ready to build and test MFC!
 Clone it to a convenient directory via

--- a/docs/documentation/case.md
+++ b/docs/documentation/case.md
@@ -109,6 +109,7 @@ Definition of the parameters is described in the following subsections.
 | `t_step_start`           | Integer | Simulation starting time step |
 | `t_step_stop`            | Integer | Simulation stopping time step |
 | `t_step_save`            | Integer | Frequency to output data |
+| `t_step_print`           | Integer | Frequency to print the current step number to standard output (default 1) |
 
 The parameters define the boundaries of the spatial and temporal domains, and their discretization that are used in simulation.
 

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -111,26 +111,19 @@ Further reading on `open-mpi` incompatibility with `clang`-based `gcc` on macOS:
 We do *not* support `clang` due to conflicts with the Silo dependency.
 
 ```console
-# === MFC MPI Installation ===
 export MFC_GCC_VER=13
-export OMPI_MPICC=gcc-$MFC_GCC_VER
-export OMPI_CXX=g++-$MFC_GCC_VER
-export OMPI_FC=gfortran-$MFC_GCC_VER
 export CC=gcc-$MFC_GCC_VER
 export CXX=g++-$MFC_GCC_VER
 export FC=gfortran-$MFC_GCC_VER
-# === MFC MPI Installation ===
 ```
 
 **Close the open editor and terminal window**. Open a **new terminal** window before executing the commands below.
 
 ```console
-brew install wget make python make cmake coreutils gcc@$MFC_GCC_VER
-HOMEBREW_MAKE_JOBS=$(nproc) brew install --cc=gcc-$MFC_GCC_VER --verbose --build-from-source open-mpi
+brew install wget make python make cmake coreutils gcc@$MFC_GCC_VER mpich
 ```
 
-They will download the dependencies MFC requires to build itself. `open-mpi` will be compiled from source, using the version of GCC we specified above with the environment variables `HOMEBREW_CC` and `HOMEBREW_CXX`.
-Building this package might take a while.
+They will download the dependencies MFC requires to build itself.
 
 </details>
 

--- a/mfc.sh
+++ b/mfc.sh
@@ -34,6 +34,8 @@ elif [ "$1" == "format" ]; then
     shift; . "$(pwd)/toolchain/bootstrap/format.sh"  $@; exit 0
 elif [ "$1" == "docker" ]; then
     shift; . "$(pwd)/toolchain/bootstrap/docker.sh"  $@; exit 0
+elif [ "$1" == "venv" ]; then
+    shift; . "$(pwd)/toolchain/bootstrap/python.sh"  $@; return
 fi
 
 mkdir -p "$(pwd)/build"

--- a/src/post_process/m_start_up.f90
+++ b/src/post_process/m_start_up.f90
@@ -89,7 +89,7 @@ contains
                 backspace (1)
                 read (1, fmt='(A)') line
                 print *, 'Invalid line in namelist: '//trim(line)
-                call s_mpi_abort('Invalid line in pre_process.inp. It is '// &
+                call s_mpi_abort('Invalid line in post_process.inp. It is '// &
                                  'likely due to a datatype mismatch. Exiting ...')
             end if
 

--- a/src/pre_process/m_data_output.fpp
+++ b/src/pre_process/m_data_output.fpp
@@ -759,6 +759,18 @@ contains
 
         end if
 
+        open (1, FILE='equations.dat', STATUS='unknown')
+
+        write (1, '(A)') "Equations: "
+        if (momxb /= 0) write (1, '(A,I3,I3)') " * Momentum:          ", momxb, momxe
+        if (advxb /= 0) write (1, '(A,I3,I3)') " * Advection:         ", advxb, advxe
+        if (contxb /= 0) write (1, '(A,I3,I3)') " * Continuity:        ", contxb, contxe
+        if (bubxb /= 0) write (1, '(A,I3,I3)') " * Bubbles:           ", bubxb, bubxe
+        if (strxb /= 0) write (1, '(A,I3,I3)') " * Stress:            ", strxb, strxe
+        if (intxb /= 0) write (1, '(A,I3,I3)') " * Internal Energies: ", intxb, intxe
+
+        close (1)
+
     end subroutine s_initialize_data_output_module ! --------------------------
 
     !> Resets s_write_data_files pointer

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -83,6 +83,8 @@ module m_global_parameters
     integer :: t_step_start, t_step_stop, t_step_save
     !> @}
 
+    integer :: t_step_print !< Number of time-steps between printouts
+
     ! ==========================================================================
 
     ! Simulation Algorithm Parameters ==========================================
@@ -378,6 +380,7 @@ contains
         t_step_start = dflt_int
         t_step_stop = dflt_int
         t_step_save = dflt_int
+        t_step_print = 1
 
         ! Simulation algorithm parameters
         model_eqns = dflt_int

--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -130,8 +130,8 @@ contains
         call MPI_BCAST(case_dir, len(case_dir), MPI_CHARACTER, 0, MPI_COMM_WORLD, ierr)
 
         #:for VAR in ['t_step_old', 'm', 'n', 'p', 'm_glb', 'n_glb', 'p_glb',  &
-            & 't_step_start','t_step_stop','t_step_save','model_eqns',         &
-            & 'num_fluids','time_stepper', 'riemann_solver',      &
+            & 't_step_start','t_step_stop','t_step_save','t_step_print',       &
+            & 'model_eqns','num_fluids','time_stepper', 'riemann_solver',      &
             & 'wave_speeds', 'avg_state', 'precision', 'bc_x%beg', 'bc_x%end', &
             & 'bc_y%beg', 'bc_y%end', 'bc_z%beg', 'bc_z%end',  'fd_order',     &
             & 'num_probes', 'num_integrals', 'bubble_model', 'thermal',        &

--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -1827,7 +1827,7 @@ contains
             @:DEALLOCATE(qL_rsz_vf, qR_rsz_vf)
         end if
 
-        if (weno_Re_flux) then
+        if (any(Re_size > 0) .and. weno_Re_flux) then
             @:DEALLOCATE(dqL_rsx_vf, dqR_rsx_vf)
 
             if (n > 0) then

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -125,7 +125,7 @@ contains
 
         ! Namelist of the global parameters which may be specified by user
         namelist /user_inputs/ case_dir, run_time_info, m, n, p, dt, &
-            t_step_start, t_step_stop, t_step_save, &
+            t_step_start, t_step_stop, t_step_save, t_step_print, &
             model_eqns, num_fluids, adv_alphan, &
             mpp_lim, time_stepper, weno_eps, weno_flat, &
             riemann_flat, cu_mpi, cu_tensor, &
@@ -166,7 +166,7 @@ contains
                 backspace (1)
                 read (1, fmt='(A)') line
                 print *, 'Invalid line in namelist: '//trim(line)
-                call s_mpi_abort('Invalid line in pre_process.inp. It is '// &
+                call s_mpi_abort('Invalid line in simulation.inp. It is '// &
                                  'likely due to a datatype mismatch. Exiting ...')
             end if
 
@@ -317,39 +317,23 @@ contains
         end if
         ! ==================================================================
 
-        ! Cell-average Conservative Variables ==============================
-        if ((bubbles .neqv. .true.) .and. (hypoelasticity .neqv. .true.)) then
-            do i = 1, adv_idx%end
-                write (file_path, '(A,I0,A)') &
-                    trim(t_step_dir)//'/q_cons_vf', i, '.dat'
-                inquire (FILE=trim(file_path), EXIST=file_exist)
-                if (file_exist) then
-                    open (2, FILE=trim(file_path), &
-                          FORM='unformatted', &
-                          ACTION='read', &
-                          STATUS='old')
-                    read (2) q_cons_vf(i)%sf(0:m, 0:n, 0:p); close (2)
-                else
-                    call s_mpi_abort(trim(file_path)//' is missing. Exiting ...')
-                end if
-            end do
-        else
-            !make sure to read bubble variables
-            do i = 1, sys_size
-                write (file_path, '(A,I0,A)') &
-                    trim(t_step_dir)//'/q_cons_vf', i, '.dat'
-                inquire (FILE=trim(file_path), EXIST=file_exist)
-                if (file_exist) then
-                    open (2, FILE=trim(file_path), &
-                          FORM='unformatted', &
-                          ACTION='read', &
-                          STATUS='old')
-                    read (2) q_cons_vf(i)%sf(0:m, 0:n, 0:p); close (2)
-                else
-                    call s_mpi_abort(trim(file_path)//' is missing. Exiting ...')
-                end if
-            end do
-            !Read pb and mv for non-polytropic qbmm
+        do i = 1, sys_size
+            write (file_path, '(A,I0,A)') &
+                trim(t_step_dir)//'/q_cons_vf', i, '.dat'
+            inquire (FILE=trim(file_path), EXIST=file_exist)
+            if (file_exist) then
+                open (2, FILE=trim(file_path), &
+                      FORM='unformatted', &
+                      ACTION='read', &
+                      STATUS='old')
+                read (2) q_cons_vf(i)%sf(0:m, 0:n, 0:p); close (2)
+            else
+                call s_mpi_abort(trim(file_path)//' is missing. Exiting ...')
+            end if
+        end do
+
+        if ((bubbles .eqv. .true.) .or. (hypoelasticity .eqv. .true.)) then
+            ! Read pb and mv for non-polytropic qbmm
             if (qbmm .and. .not. polytropic) then
                 do i = 1, nb
                     do r = 1, nnode
@@ -1068,7 +1052,7 @@ contains
 
         integer :: i, j, k, l
 
-        if (proc_rank == 0) then
+        if (proc_rank == 0 .and. mod(t_step - t_step_start, t_step_print) == 0) then
             print '(" ["I3"%]  Time step "I8" of "I0" @ t_step = "I0"")', &
                 int(ceiling(100d0*(real(t_step - t_step_start)/(t_step_stop - t_step_start + 1)))), &
                 t_step - t_step_start + 1, &

--- a/toolchain/bootstrap/format.sh
+++ b/toolchain/bootstrap/format.sh
@@ -1,39 +1,33 @@
 #!/bin/bash
 
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -j|--jobs)
+            JOBS="$2"
+            shift
+            ;;
+        *)
+            echo "Format, unknown argument: $1."
+            exit 1
+            ;;
+    esac
+
+    shift
+done
+
 log "Formatting MFC:"
 
-fortran_files=$(find ${@:-src} -type f | grep -Ev 'src/.+/autogen/')
-
-longest=0
-for filepath in $fortran_files; do
-    if [ "${#filepath}" -gt "$longest" ]; then
-        longest="${#filepath}"
-    fi
-done
-
-for filepath in $fortran_files; do
-    echo -n " > $filepath $(printf '%*s' "$((longest - ${#filepath}))" '')"
-
-    before=$(sha256sum "$filepath" | cut -d' ' -f1)
-
-    python3 toolchain/indenter.py "$filepath"
-
-    if ! fprettify "$filepath" \
-        --silent --indent 4 --c-relations --enable-replacements --enable-decl \
-        --whitespace-comma 1 --whitespace-multdiv 0 --whitespace-plusminus 1 \
-        --case 1 1 1 1 --strict-indent --line-length 1000; then
-        error "failed to execute fprettify."
-        error "MFC has not been fprettify'ied."
-        exit 1
-    fi
-
-    after=$(sha256sum "$filepath" | cut -d' ' -f1)
-
-    if [ "$before" != "$after" ]; then
-        echo -e "$YELLOW[formatted]$COLOR_RESET"
-    else
-        echo -e "$GREEN[unchanged]$COLOR_RESET"
-    fi
-done
+if ! find ${@:-src} -type f | grep -Ev 'autogen' | grep -E '\.(f90|fpp)$' | \
+         parallel --jobs ${JOBS:-1} -- \
+             echo      "\> {}" \&\& \
+             python3   toolchain/indenter.py "{}" \&\& \
+             fprettify "{}" --silent --indent 4 --c-relations --enable-replacements \
+                       --enable-decl --whitespace-comma 1 --whitespace-multdiv 0    \
+                       --whitespace-plusminus 1 --case 1 1 1 1 --strict-indent      \
+                       --line-length 1000\;; then
+    error "Formatting MFC failed."
+    exit 1
+fi
 
 ok "Done. MFC has been formatted."
+

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -38,7 +38,7 @@ class MFCTarget:
         m = hashlib.sha256()
         m.update(self.name.encode())
         m.update(CFG().make_slug().encode())
-        m.update(input.load({}).get_fpp(self).encode())
+        m.update(input.load({}).get_fpp(self, False).encode())
 
         return m.hexdigest()[:10]
 

--- a/toolchain/mfc/common.py
+++ b/toolchain/mfc/common.py
@@ -39,8 +39,13 @@ def system(command: typing.List[str], print_cmd = None, **kwargs) -> subprocess.
     return subprocess.run(cmd, **kwargs, check=False)
 
 
-def file_write(filepath: str, content: str):
+def file_write(filepath: str, content: str, if_different: bool = False):
     try:
+        if if_different and os.path.isfile(filepath):
+            with open(filepath, "r") as f:
+                if f.read() == content:
+                    return
+
         with open(filepath, "w") as f:
             f.write(content)
     except IOError as exc:

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -83,7 +83,7 @@ for p_id in range(1, 10+1):
 
 SIMULATION = COMMON + [
     'run_time_info', 't_step_old', 't_tol', 'dt', 't_step_start',
-    't_step_stop', 't_step_save', 'time_stepper', 'weno_eps',
+    't_step_stop', 't_step_save', 't_step_print', 'time_stepper', 'weno_eps',
     'mapped_weno', 'mp_weno', 'weno_avg', 'weno_Re_flux',
     'riemann_solver', 'wave_speeds', 'avg_state', 'prim_vars_wrt',
     'alt_crv', 'alt_soundspeed', 'regularization', 'null_weights',


### PR DESCRIPTION
## Description

- Simplify macOS installation using pre-built `mpich` binaries instead of building `open-mpi` from source.
- Parallel `./mfc.sh format` (@wilfonba).
- Fixed `. ./mfc.sh venv` command.
- Added `t_step_print` casefile option. Defaults to 1 and is the frequency at which we print the current `t_step` to stdout. Useful for simulations with many short timesteps so that your terminal doesn't get filled up.
- Update deprecated `checkout@v3` to `@v4` in Github actions.
- Add the creation of the `<case dir>/equations.dat` file in `pre_process` listing the mappings from `cons.X` and `prim.X` variables to their names.
- More robust `case.fpp` generation.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

- [x] MacOS Sanoma (`./mfc.sh test`)
- [ ] CI (running)
