### PR TITLE
changes to include maximum number of iterations for phase change

### DIFF
--- a/src/common/m_phase_change.fpp
+++ b/src/common/m_phase_change.fpp
@@ -119,6 +119,9 @@ contains
 
         !$acc declare create(p_infOV, p_infpT, p_infSL, sk, hk, gk, ek, rhok)
 
+        ! assigning value to the global parameter
+        max_iter_pc_ts = 0
+
         ! starting equilibrium solver
         !$acc parallel loop collapse(3) gang vector default(present) private(p_infOV, p_infpT, p_infSL, sk, hk, gk, ek, rhok,pS, pSOV, pSSL, TS, TSOV, TSatOV, TSatSL, TSSL, rhoe, dynE, rhos, rho, rM, m1, m2, MCT, TvF)
         do j = 0, m
@@ -396,6 +399,9 @@ contains
         ! common temperature
         TS = (rhoe + pS - mQ)/mCP
 
+        ! updating maximum number of iterations
+        max_iter_pc_ts = maxval((/ max_iter_pc_ts, ns/))
+
     end subroutine s_infinite_pt_relaxation_k ! -----------------------
 
     !>  This auxiliary subroutine is created to activate the pTg-equilibrium for N fluids under pT
@@ -517,6 +523,9 @@ contains
 
         ! common temperature
         TS = (rhoe + pS - mQ)/mCP
+
+        ! updating maximum number of iterations
+        max_iter_pc_ts = maxval((/ max_iter_pc_ts, ns/))
 
     end subroutine s_infinite_ptg_relaxation_k ! -----------------------
 

--- a/src/pre_process/m_global_parameters.fpp
+++ b/src/pre_process/m_global_parameters.fpp
@@ -216,6 +216,8 @@ module m_global_parameters
     type(pres_field) :: pb
     type(pres_field) :: mv
 
+    integer :: max_iter_pc_ts !< maximum number of iterations for phase change at each time-step    
+
 contains
 
     !>  Assigns default values to user inputs prior to reading

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -346,6 +346,9 @@ module m_global_parameters
     real(kind(0d0)), allocatable, dimension(:) :: gammas, gs_min, pi_infs, ps_inf, cvs, qvs, qvps
     !$acc declare create(gammas, gs_min, pi_infs, ps_inf, cvs, qvs, qvps)
 
+    integer :: max_iter_pc_ts !< maximum number of iterations for phase change at each time-step
+    !$acc declare create(max_iter_pc_ts)   
+    
     real(kind(0d0)) :: mytime       !< Current simulation time
     real(kind(0d0)) :: finaltime    !< Final simulation time
 

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -1058,6 +1058,10 @@ contains
                 t_step - t_step_start + 1, &
                 t_step_stop - t_step_start + 1, &
                 t_step
+                if (relax) then
+                    !$acc update host(max_iter_pc_ts)
+                    print *, 'maximum # iterations for phase-change', max_iter_pc_ts
+                end if
         end if
         mytime = mytime + dt
 


### PR DESCRIPTION
## Description

This pull request includes global variable "max_iter_pc_ts" to account for the maximum number of iterations within phase change, when this module is activated. It also include OpenACC statement for the GPU compilers

### Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

### Scope

- [X] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

The test to check this functionality was to add the global variable to the appropriate modules and checking whether the output was expected or not. After it was working for the CPU compilation, with was extended (and tested) to the GPU compilation. Note that this functionality only affects the .out file, whenever phase change is activated

**Test Configuration**:

* What computers and compilers did you use to test this: Bridges2 (CPU) and Delta (GPU)

## Checklist

- [X] I have added comments for the new code
- [X] I added Doxygen docstrings to the new code
- [N/A] I have made corresponding changes to the documentation (`docs/`)
- [N/A] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [N/A] I have added example cases in `examples/` that demonstrate my new feature performing as expected
- [X] I ran `./mfc.sh format` before committing my code
- [X] New and existing tests pass locally with my changes, including with GPU capability enabled and disabled
- [X] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [X] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/`)

To make sure the code is performing as expected on GPU devices, I have:
- [X] Checked that the code compiles using NVHPC compilers
- [N/A] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [N/A] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [N/A] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [N/A] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature