### PR TITLE
IBM Fix

### DIFF
--- a/src/pre_process/m_initial_condition.fpp
+++ b/src/pre_process/m_initial_condition.fpp
@@ -137,20 +137,6 @@ contains
                     print *, 'Processing patch', i
                 end if
 
-                !> IB Patches
-                !> @{
-                ! Spherical patch
-                if (patch_ib(i)%geometry == 8) then
-                    call s_sphere(i, ib_markers%sf, q_prim_vf, .true.)
-                    ! Cylindrical patch
-                elseif (patch_ib(i)%geometry == 10) then
-                    call s_cylinder(i, ib_markers%sf, q_prim_vf, .true.)
-
-                elseif (patch_ib(i)%geometry == 11) then
-                    call s_3D_airfoil(i, ib_markers%sf, q_prim_vf, .true.)
-                end if
-                !> @}
-
                 !> ICPP Patches
                 !> @{
                 ! Spherical patch
@@ -194,6 +180,26 @@ contains
             end do
             !> @}
 
+            !> IB Patches
+            !> @{
+            ! Spherical patch
+            do i = 1, num_ibs
+                if (proc_rank == 0) then
+                    print *, 'Processing 3D ib patch ', i
+                end if
+
+                if (patch_ib(i)%geometry == 8) then
+                    call s_sphere(i, ib_markers%sf, q_prim_vf, .true.)
+                    ! Cylindrical patch
+                elseif (patch_ib(i)%geometry == 10) then
+                    call s_cylinder(i, ib_markers%sf, q_prim_vf, .true.)
+
+                elseif (patch_ib(i)%geometry == 11) then
+                    call s_3D_airfoil(i, ib_markers%sf, q_prim_vf, .true.)
+                end if
+            end do
+            !> @}
+
             ! ==================================================================
 
             ! 2D Patch Geometries ==============================================
@@ -204,21 +210,6 @@ contains
                 if (proc_rank == 0) then
                     print *, 'Processing patch', i
                 end if
-
-                !> IB Patches
-                !> @{
-                ! Circular patch
-                if (patch_ib(i)%geometry == 2) then
-                    call s_circle(i, ib_markers%sf, q_prim_vf, .true.)
-
-                    ! Rectangular patch
-                elseif (patch_ib(i)%geometry == 3) then
-                    call s_rectangle(i, ib_markers%sf, q_prim_vf, .true.)
-
-                elseif (patch_ib(i)%geometry == 4) then
-                    call s_airfoil(i, ib_markers%sf, q_prim_vf, .true.)
-                end if
-                !> @}
 
                 !> ICPP Patches
                 !> @{
@@ -266,6 +257,25 @@ contains
                 end if
                 !> @}
             end do
+
+            !> IB Patches
+            !> @{
+            do i = 1, num_ibs
+                if (proc_rank == 0) then
+                    print *, 'Processing 2D ib patch ', i
+                end if
+                if (patch_ib(i)%geometry == 2) then
+                    call s_circle(i, ib_markers%sf, q_prim_vf, .true.)
+
+                    ! Rectangular patch
+                elseif (patch_ib(i)%geometry == 3) then
+                    call s_rectangle(i, ib_markers%sf, q_prim_vf, .true.)
+
+                elseif (patch_ib(i)%geometry == 4) then
+                    call s_airfoil(i, ib_markers%sf, q_prim_vf, .true.)
+                end if
+            end do
+            !> @}
 
             ! ==================================================================
 

--- a/src/pre_process/m_patches.fpp
+++ b/src/pre_process/m_patches.fpp
@@ -241,6 +241,7 @@ contains
         ! and verifying whether the current patch has permission to write to
         ! that cell. If both queries check out, the primitive variables of
         ! the current patch are assigned to this cell.
+
         do j = 0, n
             do i = 0, m
 
@@ -253,19 +254,29 @@ contains
 
                 end if
 
-                if (((x_cc(i) - x_centroid)**2 &
-                     + (y_cc(j) - y_centroid)**2 <= radius**2 &
-                     .and. &
-                     patch_icpp(patch_id)%alter_patch(patch_id_fp(i, j, 0))) &
-                    .or. &
-                    (.not. ib .and. patch_id_fp(i, j, 0) == smooth_patch_id)) &
+                if (ib .and. ((x_cc(i) - x_centroid)**2 &
+                              + (y_cc(j) - y_centroid)**2 <= radius**2)) &
                     then
-                    call s_assign_patch_primitive_variables(patch_id, i, j, 0, &
-                                                            eta, q_prim_vf, patch_id_fp)
 
-                    @:analytical()
+                    patch_id_fp(i, j, 0) = patch_id
+
                 end if
 
+                if (.not. ib) then
+                    if (((x_cc(i) - x_centroid)**2 &
+                         + (y_cc(j) - y_centroid)**2 <= radius**2 &
+                         .and. &
+                         patch_icpp(patch_id)%alter_patch(patch_id_fp(i, j, 0))) &
+                        .or. &
+                        (.not. ib .and. patch_id_fp(i, j, 0) == smooth_patch_id)) &
+                        then
+
+                        call s_assign_patch_primitive_variables(patch_id, i, j, 0, &
+                                                                eta, q_prim_vf, patch_id_fp)
+
+                        @:analytical()
+                    end if
+                end if
             end do
         end do
 
@@ -916,33 +927,46 @@ contains
         ! variables of the current patch are assigned to this cell.
         do j = 0, n
             do i = 0, m
-                if (x_boundary%beg <= x_cc(i) .and. &
+                if (.not. ib) then
+                    if (x_boundary%beg <= x_cc(i) .and. &
+                        x_boundary%end >= x_cc(i) .and. &
+                        y_boundary%beg <= y_cc(j) .and. &
+                        y_boundary%end >= y_cc(j) &
+                        .and. &
+                        patch_icpp(patch_id)%alter_patch(patch_id_fp(i, j, 0))) &
+                        then
+
+                        call s_assign_patch_primitive_variables(patch_id, i, j, 0, &
+                                                                eta, q_prim_vf, patch_id_fp)
+
+                        @:analytical()
+
+                        call s_assign_patch_primitive_variables(patch_id, i, j, 0, &
+                                                                eta, q_prim_vf, patch_id_fp)
+
+                        if ((q_prim_vf(1)%sf(i, j, 0) < 1.e-10) .and. (model_eqns == 4)) then
+                            !zero density, reassign according to Tait EOS
+                            q_prim_vf(1)%sf(i, j, 0) = &
+                                (((q_prim_vf(E_idx)%sf(i, j, 0) + pi_inf)/(pref + pi_inf))**(1d0/lit_gamma))* &
+                                rhoref*(1d0 - q_prim_vf(alf_idx)%sf(i, j, 0))
+                        end if
+
+                        ! Updating the patch identities bookkeeping variable
+                        if (1d0 - eta < 1d-16) patch_id_fp(i, j, 0) = patch_id
+
+                    end if
+                end if
+
+                if (ib .and. x_boundary%beg <= x_cc(i) .and. &
                     x_boundary%end >= x_cc(i) .and. &
                     y_boundary%beg <= y_cc(j) .and. &
-                    y_boundary%end >= y_cc(j) &
-                    .and. &
-                    patch_icpp(patch_id)%alter_patch(patch_id_fp(i, j, 0))) &
+                    y_boundary%end >= y_cc(j)) &
                     then
 
-                    call s_assign_patch_primitive_variables(patch_id, i, j, 0, &
-                                                            eta, q_prim_vf, patch_id_fp)
-
-                    @:analytical()
-
-                    call s_assign_patch_primitive_variables(patch_id, i, j, 0, &
-                                                            eta, q_prim_vf, patch_id_fp)
-
-                    if ((q_prim_vf(1)%sf(i, j, 0) < 1.e-10) .and. (model_eqns == 4)) then
-                        !zero density, reassign according to Tait EOS
-                        q_prim_vf(1)%sf(i, j, 0) = &
-                            (((q_prim_vf(E_idx)%sf(i, j, 0) + pi_inf)/(pref + pi_inf))**(1d0/lit_gamma))* &
-                            rhoref*(1d0 - q_prim_vf(alf_idx)%sf(i, j, 0))
-                    end if
-
-                    ! Updating the patch identities bookkeeping variable
-                    if (1d0 - eta < 1d-16) patch_id_fp(i, j, 0) = patch_id
+                    patch_id_fp(i, j, 0) = patch_id
 
                 end if
+
             end do
         end do
 
@@ -1552,19 +1576,30 @@ contains
 
                     end if
 
-                    if (((x_cc(i) - x_centroid)**2 &
-                         + (cart_y - y_centroid)**2 &
-                         + (cart_z - z_centroid)**2 <= radius**2 &
-                         .and. &
-                         patch_icpp(patch_id)%alter_patch(patch_id_fp(i, j, k))) &
-                        .or. &
-                        (.not. ib .and. patch_id_fp(i, j, k) == smooth_patch_id)) &
+                    if (.not. ib) then
+                        if (((x_cc(i) - x_centroid)**2 &
+                             + (cart_y - y_centroid)**2 &
+                             + (cart_z - z_centroid)**2 <= radius**2 &
+                             .and. &
+                             patch_icpp(patch_id)%alter_patch(patch_id_fp(i, j, k))) &
+                            .or. &
+                            (.not. ib .and. patch_id_fp(i, j, k) == smooth_patch_id)) &
+                            then
+
+                            call s_assign_patch_primitive_variables(patch_id, i, j, k, &
+                                                                    eta, q_prim_vf, patch_id_fp)
+
+                            @:analytical()
+                        end if
+                    end if
+
+                    if (ib .and. ((x_cc(i) - x_centroid)**2 &
+                                  + (cart_y - y_centroid)**2 &
+                                  + (cart_z - z_centroid)**2 <= radius**2)) &
                         then
 
-                        call s_assign_patch_primitive_variables(patch_id, i, j, k, &
-                                                                eta, q_prim_vf, patch_id_fp)
+                        patch_id_fp(i, j, k) = patch_id
 
-                        @:analytical()
                     end if
 
                 end do
@@ -1745,36 +1780,61 @@ contains
 
                     end if
 
-                    if ((((length_x /= dflt_real .and. &
-                           (cart_y - y_centroid)**2 &
-                           + (cart_z - z_centroid)**2 <= radius**2 .and. &
-                           x_boundary%beg <= x_cc(i) .and. &
-                           x_boundary%end >= x_cc(i)) &
-                          .or. &
-                          (length_y /= dflt_real .and. &
-                           (x_cc(i) - x_centroid)**2 &
-                           + (cart_z - z_centroid)**2 <= radius**2 .and. &
-                           y_boundary%beg <= cart_y .and. &
-                           y_boundary%end >= cart_y) &
-                          .or. &
-                          (length_z /= dflt_real .and. &
-                           (x_cc(i) - x_centroid)**2 &
-                           + (cart_y - y_centroid)**2 <= radius**2 .and. &
-                           z_boundary%beg <= cart_z .and. &
-                           z_boundary%end >= cart_z)) &
-                         .and. &
-                         patch_icpp(patch_id)%alter_patch(patch_id_fp(i, j, k))) &
-                        .or. &
-                        (.not. ib .and. patch_id_fp(i, j, k) == smooth_patch_id)) &
+                    if (.not. ib) then
+                        if ((((length_x /= dflt_real .and. &
+                               (cart_y - y_centroid)**2 &
+                               + (cart_z - z_centroid)**2 <= radius**2 .and. &
+                               x_boundary%beg <= x_cc(i) .and. &
+                               x_boundary%end >= x_cc(i)) &
+                              .or. &
+                              (length_y /= dflt_real .and. &
+                               (x_cc(i) - x_centroid)**2 &
+                               + (cart_z - z_centroid)**2 <= radius**2 .and. &
+                               y_boundary%beg <= cart_y .and. &
+                               y_boundary%end >= cart_y) &
+                              .or. &
+                              (length_z /= dflt_real .and. &
+                               (x_cc(i) - x_centroid)**2 &
+                               + (cart_y - y_centroid)**2 <= radius**2 .and. &
+                               z_boundary%beg <= cart_z .and. &
+                               z_boundary%end >= cart_z)) &
+                             .and. &
+                             patch_icpp(patch_id)%alter_patch(patch_id_fp(i, j, k))) &
+                            .or. &
+                            (.not. ib .and. patch_id_fp(i, j, k) == smooth_patch_id)) &
+                            then
+
+                            call s_assign_patch_primitive_variables(patch_id, i, j, k, &
+                                                                    eta, q_prim_vf, patch_id_fp)
+
+                            @:analytical()
+
+                            ! Updating the patch identities bookkeeping variable
+                            if (1d0 - eta < 1d-16) patch_id_fp(i, j, k) = patch_id
+                        end if
+                    end if
+
+                    if (ib .and. ((length_x /= dflt_real .and. &
+                                   (cart_y - y_centroid)**2 &
+                                   + (cart_z - z_centroid)**2 <= radius**2 .and. &
+                                   x_boundary%beg <= x_cc(i) .and. &
+                                   x_boundary%end >= x_cc(i)) &
+                                  .or. &
+                                  (length_y /= dflt_real .and. &
+                                   (x_cc(i) - x_centroid)**2 &
+                                   + (cart_z - z_centroid)**2 <= radius**2 .and. &
+                                   y_boundary%beg <= cart_y .and. &
+                                   y_boundary%end >= cart_y) &
+                                  .or. &
+                                  (length_z /= dflt_real .and. &
+                                   (x_cc(i) - x_centroid)**2 &
+                                   + (cart_y - y_centroid)**2 <= radius**2 .and. &
+                                   z_boundary%beg <= cart_z .and. &
+                                   z_boundary%end >= cart_z))) &
                         then
 
-                        call s_assign_patch_primitive_variables(patch_id, i, j, k, &
-                                                                eta, q_prim_vf, patch_id_fp)
+                        patch_id_fp(i, j, k) = patch_id
 
-                        @:analytical()
-
-                        ! Updating the patch identities bookkeeping variable
-                        if (1d0 - eta < 1d-16) patch_id_fp(i, j, k) = patch_id
                     end if
 
                 end do


### PR DESCRIPTION
## Description

This is a simple fix on the pre_process checker and documentation to ensure that more than one immersed boundaries can be used properly. Please note that this is not a general fix. Boundaries immersed in the interface of two patches with different initial primitive variables are not allowed. 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Adding one regular patch for the 2nd immersed circle boundary with an inflow.

- [x] Two immersed 2D circle with inflow

https://github.com/MFlowCode/MFC/assets/98496194/d1e94475-736d-45f8-96b9-0c3d27047e0b

**Test Configuration**:

* What computers and compilers did you use to test this: macOS and GCC

## Checklist

- [x] I have added comments for the new code
- [x] I have made corresponding changes to the documentation (`docs/`)
- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count