### PR TITLE
IBM Fix on Non-uniform Initial Condition

### DIFF
--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -85,7 +85,7 @@ contains
         @:ALLOCATE_GLOBAL(levelset(0:m, 0:n, 0:p, num_ibs))
         @:ALLOCATE_GLOBAL(levelset_norm(0:m, 0:n, 0:p, num_ibs, 3))
 
-        !$acc enter data copyin(gp_layers, num_gps)
+        !$acc enter data copyin(gp_layers, num_gps, num_inner_gps)
 
     end subroutine s_initialize_ibm_module
 

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -43,8 +43,9 @@ module m_ibm
     @:CRAY_DECLARE_GLOBAL(real(kind(0d0)), dimension(:, :, :, :), levelset)
     @:CRAY_DECLARE_GLOBAL(real(kind(0d0)), dimension(:, :, :, :, :), levelset_norm)
     @:CRAY_DECLARE_GLOBAL(type(ghost_point), dimension(:), ghost_points)
+    @:CRAY_DECLARE_GLOBAL(type(ghost_point), dimension(:), inner_points)
 
-    !$acc declare link(levelset, levelset_norm, ghost_points)
+    !$acc declare link(levelset, levelset_norm, ghost_points, inner_points)
 #else
 
     !! Marker for solid cells. 0 if liquid, the patch id of its IB if solid
@@ -53,14 +54,16 @@ module m_ibm
     real(kind(0d0)), dimension(:, :, :, :, :), allocatable :: levelset_norm
     !! Matrix of normal vector to IB
     type(ghost_point), dimension(:), allocatable :: ghost_points
+    type(ghost_point), dimension(:), allocatable :: inner_points
     !! Matrix of normal vector to IB
 
-    !$acc declare create(levelset, levelset_norm, ghost_points)
+    !$acc declare create(levelset, levelset_norm, ghost_points, inner_points)
 #endif
 
     integer :: gp_layers !< Number of ghost point layers
     integer :: num_gps !< Number of ghost points
-    !$acc declare create(gp_layers, num_gps)
+    integer :: num_inner_gps !< Number of ghost points
+    !$acc declare create(gp_layers, num_gps, num_inner_gps)
 
 contains
 
@@ -97,12 +100,14 @@ contains
 
         call s_find_num_ghost_points()
 
-        !$acc update device(num_gps)
+        !$acc update device(num_gps, num_inner_gps)
         @:ALLOCATE_GLOBAL(ghost_points(num_gps))
-        !$acc enter data copyin(ghost_points)
+        @:ALLOCATE_GLOBAL(inner_points(num_inner_gps))
 
-        call s_find_ghost_points(ghost_points)
-        !$acc update device(ghost_points)
+        !$acc enter data copyin(ghost_points, inner_points)
+
+        call s_find_ghost_points(ghost_points, inner_points)
+        !$acc update device(ghost_points, inner_points)
 
         call s_compute_levelset(levelset, levelset_norm)
         !$acc update device(levelset, levelset_norm)
@@ -153,8 +158,9 @@ contains
         real(kind(0d0)) :: nbub
         real(kind(0d0)) :: buf
         type(ghost_point) :: gp
+        type(ghost_point) :: innerp
 
-        !$acc parallel loop gang vector private(physical_loc, dyn_pres, alpha_rho_IP, alpha_IP, pres_IP, vel_IP, vel_g, vel_norm_IP, r_IP, v_IP, pb_IP, mv_IP, nmom_IP, presb_IP, massv_IP, rho, gamma, pi_inf, Re_K, G_K, Gs, gp, norm, buf, j, k, l, q, coeff)
+        !$acc parallel loop gang vector private(physical_loc, dyn_pres, alpha_rho_IP, alpha_IP, pres_IP, vel_IP, vel_g, vel_norm_IP, r_IP, v_IP, pb_IP, mv_IP, nmom_IP, presb_IP, massv_IP, rho, gamma, pi_inf, Re_K, G_K, Gs, gp, innerp, norm, buf, j, k, l, q, coeff)
         do i = 1, num_gps
 
             gp = ghost_points(i)
@@ -288,6 +294,43 @@ contains
             end if
         end do
 
+        !Correct the state of the inner points in IBs
+        !$acc parallel loop gang vector private(physical_loc, dyn_pres, alpha_rho_IP, alpha_IP, vel_g, rho, gamma, pi_inf, Re_K, innerp, j, k, l, q)
+        do i = 1, num_inner_gps
+
+            vel_g = 0d0
+            innerp = inner_points(i)
+            j = innerp%loc(1)
+            k = innerp%loc(2)
+            l = innerp%loc(3)
+            patch_id = inner_points(i)%ib_patch_id
+
+            ! Calculate physical location of GP
+            if (p > 0) then
+                physical_loc = [x_cc(j), y_cc(k), z_cc(l)]
+            else
+                physical_loc = [x_cc(j), y_cc(k), 0d0]
+            end if
+
+            !$acc loop seq
+            do q = 1, num_fluids
+                q_prim_vf(q)%sf(j, k, l) = alpha_rho_IP(q)
+                q_prim_vf(advxb + q - 1)%sf(j, k, l) = alpha_IP(q)
+            end do
+
+            call s_convert_species_to_mixture_variables_acc(rho, gamma, pi_inf, qv_K, alpha_IP, &
+                                                            alpha_rho_IP, Re_K, j, k, l)
+
+            dyn_pres = 0d0
+
+            !$acc loop seq
+            do q = momxb, momxe
+                q_cons_vf(q)%sf(j, k, l) = rho*vel_g(q - momxb + 1)
+                dyn_pres = dyn_pres + q_cons_vf(q)%sf(j, k, l)* &
+                           vel_g(q - momxb + 1)/2d0
+            end do
+        end do
+
     end subroutine s_ibm_correct_state
 
     !>  Function that computes that bubble wall pressure for Gilmore bubbles
@@ -413,6 +456,8 @@ contains
                                         j - gp_layers:j + gp_layers, 0)
                         if (any(subsection_2D == 0)) then
                             num_gps = num_gps + 1
+                        else
+                            num_inner_gps = num_inner_gps + 1
                         end if
                     end if
                 else
@@ -424,6 +469,8 @@ contains
                                             k - gp_layers:k + gp_layers)
                             if (any(subsection_3D == 0)) then
                                 num_gps = num_gps + 1
+                            else
+                                num_inner_gps = num_inner_gps + 1
                             end if
                         end if
                     end do
@@ -433,18 +480,20 @@ contains
 
     end subroutine s_find_num_ghost_points
 
-    subroutine s_find_ghost_points(ghost_points)
+    subroutine s_find_ghost_points(ghost_points, inner_points)
 
         type(ghost_point), dimension(num_gps), intent(INOUT) :: ghost_points
+        type(ghost_point), dimension(num_inner_gps), intent(INOUT) :: inner_points
         integer, dimension(2*gp_layers + 1, 2*gp_layers + 1) &
             :: subsection_2D
         integer, dimension(2*gp_layers + 1, 2*gp_layers + 1, 2*gp_layers + 1) &
             :: subsection_3D
         integer :: i, j, k !< Iterator variables
-        integer :: count
+        integer :: count, count_i
         integer :: patch_id
 
         count = 1
+        count_i = 1
 
         do i = 0, m
             do j = 0, n
@@ -460,6 +509,13 @@ contains
                                 patch_id
                             ghost_points(count)%slip = patch_ib(patch_id)%slip
                             count = count + 1
+                        else
+                            inner_points(count_i)%loc = [i, j, 0]
+                            patch_id = ib_markers%sf(i, j, 0)
+                            inner_points(count_i)%ib_patch_id = &
+                                patch_id
+                            inner_points(count_i)%slip = patch_ib(patch_id)%slip
+                            count_i = count_i + 1
                         end if
                     end if
                 else
@@ -476,6 +532,13 @@ contains
                                     ib_markers%sf(i, j, k)
                                 ghost_points(count)%slip = patch_ib(patch_id)%slip
                                 count = count + 1
+                            else
+                                inner_points(count_i)%loc = [i, j, k]
+                                patch_id = ib_markers%sf(i, j, k)
+                                inner_points(count_i)%ib_patch_id = &
+                                    ib_markers%sf(i, j, k)
+                                inner_points(count_i)%slip = patch_ib(patch_id)%slip
+                                count_i = count_i + 1
                             end if
                         end if
                     end do

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -297,6 +297,14 @@ contains
 
         call s_compute_rhs(q_cons_ts(1)%vf, q_prim_vf, rhs_vf, pb_ts(1)%sf, rhs_pb, mv_ts(1)%sf, rhs_mv, t_step)
 
+        if (ib .and. t_step == 1) then
+            if (qbmm .and. .not. polytropic) then
+                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf, pb_ts(1)%sf, mv_ts(1)%sf)
+            else
+                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf)
+            end if
+        end if
+
 #ifdef DEBUG
         print *, 'got rhs'
 #endif
@@ -409,6 +417,14 @@ contains
         call nvtxStartRange("Time_Step")
 
         call s_compute_rhs(q_cons_ts(1)%vf, q_prim_vf, rhs_vf, pb_ts(1)%sf, rhs_pb, mv_ts(1)%sf, rhs_mv, t_step)
+
+        if (ib .and. t_step == 1) then
+            if (qbmm .and. .not. polytropic) then
+                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf, pb_ts(1)%sf, mv_ts(1)%sf)
+            else
+                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf)
+            end if
+        end if
 
         if (run_time_info) then
             call s_write_run_time_information(q_prim_vf, t_step)
@@ -590,6 +606,14 @@ contains
         end if
 
         call s_compute_rhs(q_cons_ts(1)%vf, q_prim_vf, rhs_vf, pb_ts(1)%sf, rhs_pb, mv_ts(1)%sf, rhs_mv, t_step)
+
+        if (ib .and. t_step == 1) then
+            if (qbmm .and. .not. polytropic) then
+                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf, pb_ts(1)%sf, mv_ts(1)%sf)
+            else
+                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf)
+            end if
+        end if
 
         if (run_time_info) then
             call s_write_run_time_information(q_prim_vf, t_step)


### PR DESCRIPTION
## Description

This is to deal with the issues for IBM with non-uniform initial conditions as mentioned by @anandrdbz in [PR#398](https://github.com/MFlowCode/MFC/pull/398).

Fixes #401 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

I use two regular patches that are not overlapping over each other with initial different velocities and put three IBs at the interface of these two patches. Thus, the velocity inside the IBs is not uniform initially. Velocity inside IBs should be corrected to be zero at the simulation stage. The animations below are the test case showing the expected changes in IBs for 2D and 3D cases.

- [x] 2D case
https://github.com/MFlowCode/MFC/assets/98496194/1cadb40b-cfd4-4dc7-8fd6-5e433f18ef8e

- [x] 3D case
https://github.com/MFlowCode/MFC/assets/98496194/e031b4da-64fe-47af-800f-61c16be537a3

**Test Configuration**:
- [x] 2D case
   WENO5, 3rd Order Time Stepper.
    'patch_icpp(1)%geometry'       : 3,
    'patch_icpp(1)%x_centroid'     : x1/2, 
    'patch_icpp(1)%y_centroid'     : x2/4,
    'patch_icpp(1)%length_x'       : x1,
    'patch_icpp(1)%length_y'       : x2/2,
    'patch_icpp(1)%vel(1)'         : 0.0E+00,
    'patch_icpp(1)%vel(2)'         : 0.0E+00,
    'patch_icpp(1)%pres'           : 1.0E+05,
    'patch_icpp(1)%alpha_rho(1)'   : (1.0 - 1e-12)*rho1,
    'patch_icpp(1)%alpha(1)'       : 1.0 - 1e-12,
    'patch_icpp(1)%alpha_rho(2)'   : 1.0e-12*rho2,
    'patch_icpp(1)%alpha(2)'       : 1.0e-12,
    'patch_icpp(2)%geometry'       : 3,
    'patch_icpp(2)%alter_patch(1)' : 'T',
    'patch_icpp(2)%x_centroid'     : x1/2, 
    'patch_icpp(2)%y_centroid'     : 3*x2/4,
    'patch_icpp(2)%length_x'       : x1,
    'patch_icpp(2)%length_y'       : x2/2,
    'patch_icpp(2)%vel(1)'         : 1.0E+00,
    'patch_icpp(2)%vel(2)'         : 0.0E+00,
    'patch_icpp(2)%pres'           : 1.0E+05,
    'patch_icpp(2)%alpha_rho(1)'   : (1.0 - 1e-12)*rho1,
    'patch_icpp(2)%alpha(1)'       : 1.0 - 1e-12,
    'patch_icpp(2)%alpha_rho(2)'   : 1.0e-12*rho2,
    'patch_icpp(2)%alpha(2)'       : 1.0e-12,

     'patch_ib(1)%geometry'          : 2,
     'patch_ib(1)%x_centroid'        : x1/4,
     'patch_ib(1)%y_centroid'        : x2/2,
     'patch_ib(1)%radius'            : x2/6,
     'patch_ib(1)%slip'              : 'F',

     'patch_ib(2)%geometry'          : 2,
     'patch_ib(2)%x_centroid'        : 3*x1/4,
     'patch_ib(2)%y_centroid'        : x2/2,
     'patch_ib(2)%radius'            : x2/8,
     'patch_ib(2)%slip'              : 'F',

     'patch_ib(3)%geometry'          : 2,
     'patch_ib(3)%x_centroid'        : x1/2,
     'patch_ib(3)%y_centroid'        : x2/4,
     'patch_ib(3)%radius'            : x2/10,
     'patch_ib(3)%slip'              : 'F',

- [x] 3D case
   WENO5, 3rd Order Time Stepper.
   'patch_icpp(1)%geometry'       : 9,
    'patch_icpp(1)%x_centroid'     : 2.5,
    'patch_icpp(1)%y_centroid'     : 5.0,
    'patch_icpp(1)%z_centroid'     : 5.0,
    'patch_icpp(1)%length_x'       : 5,
    'patch_icpp(1)%length_y'       : 10,
    'patch_icpp(1)%length_z'       : 10,
    'patch_icpp(1)%vel(1)'         : -10,
    'patch_icpp(1)%vel(2)'         : 0.0E+00,
    'patch_icpp(1)%vel(3)'         : 0.0E+00,
    'patch_icpp(1)%pres'           : 10918.2549,
    'patch_icpp(1)%alpha_rho(1)'   : 1.22,
    'patch_icpp(1)%alpha(1)'       : 1.E+00,
    'patch_icpp(2)%geometry'       : 9,
    'patch_icpp(2)%x_centroid'     : 7.5,
    'patch_icpp(2)%y_centroid'     : 5.0,
    'patch_icpp(2)%z_centroid'     : 5.0,
    'patch_icpp(2)%length_x'       : 5,
    'patch_icpp(2)%length_y'       : 10,
    'patch_icpp(2)%length_z'       : 10,
    'patch_icpp(2)%vel(1)'         : 10,
    'patch_icpp(2)%vel(2)'         : 0.0E+00,
    'patch_icpp(2)%vel(3)'         : 0.0E+00,
    'patch_icpp(2)%pres'           : 10918.2549,
    'patch_icpp(2)%alpha_rho(1)'   : 1.22,
    'patch_icpp(2)%alpha(1)'       : 1.E+00,

    'patch_ib(1)%geometry'       : 8,
    'patch_ib(1)%x_centroid'     : 5,
    'patch_ib(1)%y_centroid'     : 5,
    'patch_ib(1)%z_centroid'     : 5,
    'patch_ib(1)%radius'         : 1,
    'patch_ib(1)%slip'           : 'F',

    'patch_ib(2)%geometry'       : 8,
    'patch_ib(2)%x_centroid'     : 5,
    'patch_ib(2)%y_centroid'     : 2.5,
    'patch_ib(2)%z_centroid'     : 5,
    'patch_ib(2)%radius'         : 1,
    'patch_ib(2)%slip'           : 'F',

    'patch_ib(3)%geometry'       : 8,
    'patch_ib(3)%x_centroid'     : 5,
    'patch_ib(3)%y_centroid'     : 7.5,
    'patch_ib(3)%z_centroid'     : 5.0,
    'patch_ib(3)%radius'         : 1,
    'patch_ib(3)%slip'           : 'F',

* What computers and compilers did you use to test this: MacOS with GCC 13.1.6 and PACE Phoenix V100-16GB with NVHPC 22.11

## Checklist

- [x] I have added comments for the new code
- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x] Checked that the code compiles using NVHPC compilers
- [x] Checked that the code compiles using CRAY compilers
- [x] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [x] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
