### PR TITLE
fix hipfort versioning off of develop HEAD

### DIFF
--- a/toolchain/dependencies/CMakeLists.txt
+++ b/toolchain/dependencies/CMakeLists.txt
@@ -86,7 +86,7 @@ if (MFC_HIPFORT)
     if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
         ExternalProject_Add(hipfort
             GIT_REPOSITORY "https://github.com/ROCmSoftwarePlatform/hipfort"
-            GIT_TAG        develop
+            GIT_TAG        rocm-6.0.2
             GIT_SHALLOW    ON
             GIT_PROGRESS   ON
             CMAKE_ARGS     "-DHIPFORT_COMPILER=${CMAKE_Fortran_COMPILER}"


### PR DESCRIPTION
Frontier runner wasn't working because we fetched an incompatible latest HEAD off the hipfort git develop branch. This grabs a tag.