### PR TITLE
IB-DB Treatment

### DIFF
--- a/src/common/m_derived_types.fpp
+++ b/src/common/m_derived_types.fpp
@@ -276,6 +276,7 @@ module m_derived_types
         real(kind(0d0)), dimension(2, 2, 2) :: interp_coeffs !< Interpolation Coefficients of image point
         integer :: ib_patch_id !< ID of the IB Patch the ghost point is part of
         logical :: slip
+        integer, dimension(3) :: DB
 
     end type ghost_point
 

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -159,6 +159,7 @@ module m_global_parameters
     !> @{
     type(int_bounds_info) :: bc_x, bc_y, bc_z
     !> @}
+    type(bounds_info) :: x_domain, y_domain, z_domain
 
     logical :: parallel_io !< Format of the data files
     logical :: file_per_process !< shared file or not when using parallel io
@@ -500,9 +501,9 @@ contains
             #:endfor
         #:endfor
 
-        ! x_domain%beg =  dflt_int; x_domain%end =  dflt_int;
-        ! y_domain%beg =  dflt_int; y_domain%end =  dflt_int;
-        ! z_domain%beg =  dflt_int; z_domain%end =  dflt_int;
+        x_domain%beg =  dflt_int; x_domain%end =  dflt_int
+        y_domain%beg =  dflt_int; y_domain%end =  dflt_int
+        z_domain%beg =  dflt_int; z_domain%end =  dflt_int
 
         ! Fluids physical parameters
         do i = 1, num_fluids_max

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -501,9 +501,9 @@ contains
             #:endfor
         #:endfor
 
-        x_domain%beg =  dflt_int; x_domain%end =  dflt_int
-        y_domain%beg =  dflt_int; y_domain%end =  dflt_int
-        z_domain%beg =  dflt_int; z_domain%end =  dflt_int
+        x_domain%beg = dflt_int; x_domain%end = dflt_int
+        y_domain%beg = dflt_int; y_domain%end = dflt_int
+        z_domain%beg = dflt_int; z_domain%end = dflt_int
 
         ! Fluids physical parameters
         do i = 1, num_fluids_max

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -392,14 +392,19 @@ contains
                     bound = p
                 end if
 
-                if (norm(dim) == 0) then
+                if (norm(dim) == 0 .or. ghost_points(q)%DB(dim) == 0) then
                     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)
+                    ! if (ghost_points(q)%DB(dim) == -1) then
+                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
+                    ! else if (ghost_points(q)%DB(dim) == 1) then
+                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
+                    ! end if
                 else
-                    if (ghost_points(q)%DB(dim) == -1) then
-                        ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
-                    else if (ghost_points(q)%DB(dim) == 1) then
-                        ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
-                    end if
+                    ! if (ghost_points(q)%DB(dim) == -1) then
+                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
+                    ! else if (ghost_points(q)%DB(dim) == 1) then
+                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
+                    ! end if
 
                     if (norm(dim) > 0) then
                         dir = 1
@@ -417,6 +422,9 @@ contains
                     ghost_points(q)%ip_grid(dim) = index
                 end if
             end do
+
+            print*, ghost_points(q)%loc(:)
+            print*, ghost_points(q)%ip_grid(:)
 
             ! print *, "GP Loc: ", ghost_points(q)%loc(:)
             ! print *, "Norm: ", norm(:)
@@ -539,23 +547,19 @@ contains
                             inner_points(count_i)%ib_patch_id = &
                                 patch_id
                             inner_points(count_i)%slip = patch_ib(patch_id)%slip
-
-                            if ((x_cc(i) - dx(i)) < x_domain%beg) then
-                                ghost_points(count)%DB(1) = -1
-                            else if ((x_cc(i) + dx(i)) > x_domain%end) then
+                            if ((x_cc(i) - dx(i)) < x_domain%beg .or. &
+                                (x_cc(i) + dx(i)) > x_domain%end) then
                                 ghost_points(count)%DB(1) = 1
                             else
                                 ghost_points(count)%DB(1) = 0
                             end if
 
-                            if ((y_cc(j) - dy(j)) < y_domain%beg) then
-                                ghost_points(count)%DB(2) = -1
-                            else if ((y_cc(j) + dy(j)) > y_domain%end) then
+                            if ((y_cc(j) - dy(j)) < y_domain%beg .or. &
+                                (y_cc(j) + dy(j)) > y_domain%end) then
                                 ghost_points(count)%DB(2) = 1
                             else
                                 ghost_points(count)%DB(2) = 0
                             end if
-
 
                             count_i = count_i + 1
 
@@ -669,7 +673,15 @@ contains
                         interp_coeffs(:, :, 1) = eta(:, :, 1)/buf
                     end if
                 end if
-                
+
+                ! if (gp%DB(1) == 1) then
+                !     interp_coeffs(2, 1, 1) = 1d0
+                ! else if (gp%DB(2) == 1) then
+                !     interp_coeffs(1, 2, 1) = 1d0
+                ! else if (gp%DB(1) == 1 .and. gp%DB(2) == 1) then
+                !     interp_coeffs(2, 2, 1) = 1d0
+                ! end if
+
                 ghost_points(i)%interp_coeffs = interp_coeffs
             end do
 

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -392,19 +392,14 @@ contains
                     bound = p
                 end if
 
-                if (norm(dim) == 0 .or. ghost_points(q)%DB(dim) == 0) then
+                if (norm(dim) == 0) then
                     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)
-                    ! if (ghost_points(q)%DB(dim) == -1) then
-                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
-                    ! else if (ghost_points(q)%DB(dim) == 1) then
-                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
-                    ! end if
                 else
-                    ! if (ghost_points(q)%DB(dim) == -1) then
-                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
-                    ! else if (ghost_points(q)%DB(dim) == 1) then
-                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
-                    ! end if
+                    if (ghost_points(q)%DB(dim) == -1) then
+                        ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
+                    else if (ghost_points(q)%DB(dim) == 1) then
+                        ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
+                    end if
 
                     if (norm(dim) > 0) then
                         dir = 1
@@ -422,9 +417,6 @@ contains
                     ghost_points(q)%ip_grid(dim) = index
                 end if
             end do
-
-            print*, ghost_points(q)%loc(:)
-            print*, ghost_points(q)%ip_grid(:)
 
             ! print *, "GP Loc: ", ghost_points(q)%loc(:)
             ! print *, "Norm: ", norm(:)
@@ -547,19 +539,23 @@ contains
                             inner_points(count_i)%ib_patch_id = &
                                 patch_id
                             inner_points(count_i)%slip = patch_ib(patch_id)%slip
-                            if ((x_cc(i) - dx(i)) < x_domain%beg .or. &
-                                (x_cc(i) + dx(i)) > x_domain%end) then
+
+                            if ((x_cc(i) - dx(i)) < x_domain%beg) then
+                                ghost_points(count)%DB(1) = -1
+                            else if ((x_cc(i) + dx(i)) > x_domain%end) then
                                 ghost_points(count)%DB(1) = 1
                             else
                                 ghost_points(count)%DB(1) = 0
                             end if
 
-                            if ((y_cc(j) - dy(j)) < y_domain%beg .or. &
-                                (y_cc(j) + dy(j)) > y_domain%end) then
+                            if ((y_cc(j) - dy(j)) < y_domain%beg) then
+                                ghost_points(count)%DB(2) = -1
+                            else if ((y_cc(j) + dy(j)) > y_domain%end) then
                                 ghost_points(count)%DB(2) = 1
                             else
                                 ghost_points(count)%DB(2) = 0
                             end if
+
 
                             count_i = count_i + 1
 
@@ -673,15 +669,7 @@ contains
                         interp_coeffs(:, :, 1) = eta(:, :, 1)/buf
                     end if
                 end if
-
-                ! if (gp%DB(1) == 1) then
-                !     interp_coeffs(2, 1, 1) = 1d0
-                ! else if (gp%DB(2) == 1) then
-                !     interp_coeffs(1, 2, 1) = 1d0
-                ! else if (gp%DB(1) == 1 .and. gp%DB(2) == 1) then
-                !     interp_coeffs(2, 2, 1) = 1d0
-                ! end if
-
+                
                 ghost_points(i)%interp_coeffs = interp_coeffs
             end do
 

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -392,20 +392,9 @@ contains
                     bound = p
                 end if
 
-                if (norm(dim) == 0 .or. ghost_points(q)%DB(dim) == 0) then
+                if (norm(dim) == 0) then
                     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)
-                    ! if (ghost_points(q)%DB(dim) == -1) then
-                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
-                    ! else if (ghost_points(q)%DB(dim) == 1) then
-                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
-                    ! end if
                 else
-                    ! if (ghost_points(q)%DB(dim) == -1) then
-                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
-                    ! else if (ghost_points(q)%DB(dim) == 1) then
-                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
-                    ! end if
-
                     if (norm(dim) > 0) then
                         dir = 1
                     else
@@ -420,11 +409,13 @@ contains
                         index = index + dir
                     end do
                     ghost_points(q)%ip_grid(dim) = index
+                    if (ghost_points(q)%DB(dim) == -1) then
+                        ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim) + 1
+                    else if (ghost_points(q)%DB(dim) == 1) then
+                        ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim) - 1
+                    end if
                 end if
             end do
-
-            print*, ghost_points(q)%loc(:)
-            print*, ghost_points(q)%ip_grid(:)
 
             ! print *, "GP Loc: ", ghost_points(q)%loc(:)
             ! print *, "Norm: ", norm(:)
@@ -540,7 +531,7 @@ contains
                             end if
 
                             count = count + 1
-                            !  print*, i, j, (y_cc(j) + dy(j)), ghost_points(count)%DB(2)
+
                         else
                             inner_points(count_i)%loc = [i, j, 0]
                             patch_id = ib_markers%sf(i, j, 0)
@@ -578,6 +569,31 @@ contains
                                 ghost_points(count)%ib_patch_id = &
                                     ib_markers%sf(i, j, k)
                                 ghost_points(count)%slip = patch_ib(patch_id)%slip
+
+                                if ((x_cc(i) - dx(i)) < x_domain%beg) then
+                                    ghost_points(count)%DB(1) = -1
+                                else if ((x_cc(i) + dx(i)) > x_domain%end) then
+                                    ghost_points(count)%DB(1) = 1
+                                else
+                                    ghost_points(count)%DB(1) = 0
+                                end if
+
+                                if ((y_cc(j) - dy(j)) < y_domain%beg) then
+                                    ghost_points(count)%DB(2) = -1
+                                else if ((y_cc(j) + dy(j)) > y_domain%end) then
+                                    ghost_points(count)%DB(2) = 1
+                                else
+                                    ghost_points(count)%DB(2) = 0
+                                end if
+
+                                if ((z_cc(k) - dz(k)) < z_domain%beg) then
+                                    ghost_points(count)%DB(3) = -1
+                                else if ((z_cc(k) + dz(k)) > z_domain%end) then
+                                    ghost_points(count)%DB(3) = 1
+                                else
+                                    ghost_points(count)%DB(3) = 0
+                                end if
+
                                 count = count + 1
                             else
                                 inner_points(count_i)%loc = [i, j, k]
@@ -585,6 +601,31 @@ contains
                                 inner_points(count_i)%ib_patch_id = &
                                     ib_markers%sf(i, j, k)
                                 inner_points(count_i)%slip = patch_ib(patch_id)%slip
+
+                                if ((x_cc(i) - dx(i)) < x_domain%beg) then
+                                    ghost_points(count)%DB(1) = -1
+                                else if ((x_cc(i) + dx(i)) > x_domain%end) then
+                                    ghost_points(count)%DB(1) = 1
+                                else
+                                    ghost_points(count)%DB(1) = 0
+                                end if
+
+                                if ((y_cc(j) - dy(j)) < y_domain%beg) then
+                                    ghost_points(count)%DB(2) = -1
+                                else if ((y_cc(j) + dy(j)) > y_domain%end) then
+                                    ghost_points(count)%DB(2) = 1
+                                else
+                                    ghost_points(count)%DB(2) = 0
+                                end if
+
+                                if ((z_cc(k) - dz(k)) < z_domain%beg) then
+                                    ghost_points(count)%DB(3) = -1
+                                else if ((z_cc(k) + dz(k)) > z_domain%end) then
+                                    ghost_points(count)%DB(3) = 1
+                                else
+                                    ghost_points(count)%DB(3) = 0
+                                end if
+
                                 count_i = count_i + 1
                             end if
                         end if
@@ -621,16 +662,6 @@ contains
                 ! Get the interpolation points
                 i1 = gp%ip_grid(1); i2 = i1 + 1
                 j1 = gp%ip_grid(2); j2 = j1 + 1
-
-                ! if (gp%DB(1) == -1) then
-                !     i2 = i1 + 1
-                ! else if (gp%DB(1) == 1) then
-                !     i2 = i1 - 1
-                ! else if (gp%DB(2) == -1) then
-                !     j2 = j1 + 1
-                ! else if (gp%DB(2) == 1) then
-                !     j2 = j1 - 1
-                ! end if
 
                 dist = 0d0
                 buf = 1d0
@@ -673,14 +704,6 @@ contains
                         interp_coeffs(:, :, 1) = eta(:, :, 1)/buf
                     end if
                 end if
-
-                ! if (gp%DB(1) == 1) then
-                !     interp_coeffs(2, 1, 1) = 1d0
-                ! else if (gp%DB(2) == 1) then
-                !     interp_coeffs(1, 2, 1) = 1d0
-                ! else if (gp%DB(1) == 1 .and. gp%DB(2) == 1) then
-                !     interp_coeffs(2, 2, 1) = 1d0
-                ! end if
 
                 ghost_points(i)%interp_coeffs = interp_coeffs
             end do
@@ -792,16 +815,6 @@ contains
         i1 = gp%ip_grid(1); i2 = i1 + 1
         j1 = gp%ip_grid(2); j2 = j1 + 1
         k1 = gp%ip_grid(3); k2 = k1 + 1
-
-        if (gp%DB(1) == -1) then
-            i2 = i1 + 1
-        else if (gp%DB(1) == 1) then
-            i2 = i1 - 1
-        else if (gp%DB(2) == -1) then
-            j2 = j1 + 1
-            ! else if (gp%DB(2) == 1) then
-            !     j2 = j1 - 1
-        end if
 
         if (p == 0) then
             k1 = 0

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -394,7 +394,18 @@ contains
 
                 if (norm(dim) == 0 .or. ghost_points(q)%DB(dim) == 0) then
                     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)
+                    ! if (ghost_points(q)%DB(dim) == -1) then
+                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
+                    ! else if (ghost_points(q)%DB(dim) == 1) then
+                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
+                    ! end if
                 else
+                    ! if (ghost_points(q)%DB(dim) == -1) then
+                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)+1
+                    ! else if (ghost_points(q)%DB(dim) == 1) then
+                    !     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)-1
+                    ! end if
+
                     if (norm(dim) > 0) then
                         dir = 1
                     else
@@ -411,6 +422,9 @@ contains
                     ghost_points(q)%ip_grid(dim) = index
                 end if
             end do
+
+            print*, ghost_points(q)%loc(:)
+            print*, ghost_points(q)%ip_grid(:)
 
             ! print *, "GP Loc: ", ghost_points(q)%loc(:)
             ! print *, "Norm: ", norm(:)
@@ -509,15 +523,17 @@ contains
                                 patch_id
                             ghost_points(count)%slip = patch_ib(patch_id)%slip
 
-                            if ((x_cc(i) - dx(i)) < x_domain%beg .or. &
-                                (x_cc(i) + dx(i)) > x_domain%end) then
+                            if ((x_cc(i) - dx(i)) < x_domain%beg) then
+                                ghost_points(count)%DB(1) = -1
+                            else if ((x_cc(i) + dx(i)) > x_domain%end) then
                                 ghost_points(count)%DB(1) = 1
                             else
                                 ghost_points(count)%DB(1) = 0
                             end if
-                            
-                            if ((y_cc(j) - dy(j)) < y_domain%beg .or. &
-                                (y_cc(j) + dy(j)) > y_domain%end) then
+
+                            if ((y_cc(j) - dy(j)) < y_domain%beg) then
+                                ghost_points(count)%DB(2) = -1
+                            else if ((y_cc(j) + dy(j)) > y_domain%end) then
                                 ghost_points(count)%DB(2) = 1
                             else
                                 ghost_points(count)%DB(2) = 0
@@ -537,7 +553,7 @@ contains
                             else
                                 ghost_points(count)%DB(1) = 0
                             end if
-                            
+
                             if ((y_cc(j) - dy(j)) < y_domain%beg .or. &
                                 (y_cc(j) + dy(j)) > y_domain%end) then
                                 ghost_points(count)%DB(2) = 1
@@ -606,6 +622,16 @@ contains
                 i1 = gp%ip_grid(1); i2 = i1 + 1
                 j1 = gp%ip_grid(2); j2 = j1 + 1
 
+                ! if (gp%DB(1) == -1) then
+                !     i2 = i1 + 1
+                ! else if (gp%DB(1) == 1) then
+                !     i2 = i1 - 1
+                ! else if (gp%DB(2) == -1) then
+                !     j2 = j1 + 1
+                ! else if (gp%DB(2) == 1) then
+                !     j2 = j1 - 1
+                ! end if
+
                 dist = 0d0
                 buf = 1d0
                 dist(1, 1, 1) = sqrt( &
@@ -622,6 +648,7 @@ contains
                                 (y_cc(j2) - gp%ip_loc(2))**2)
 
                 interp_coeffs = 0d0
+
                 if (dist(1, 1, 1) <= 1d-16) then
                     interp_coeffs(1, 1, 1) = 1d0
                 else if (dist(2, 1, 1) <= 1d-16) then
@@ -646,6 +673,14 @@ contains
                         interp_coeffs(:, :, 1) = eta(:, :, 1)/buf
                     end if
                 end if
+
+                ! if (gp%DB(1) == 1) then
+                !     interp_coeffs(2, 1, 1) = 1d0
+                ! else if (gp%DB(2) == 1) then
+                !     interp_coeffs(1, 2, 1) = 1d0
+                ! else if (gp%DB(1) == 1 .and. gp%DB(2) == 1) then
+                !     interp_coeffs(2, 2, 1) = 1d0
+                ! end if
 
                 ghost_points(i)%interp_coeffs = interp_coeffs
             end do
@@ -757,6 +792,16 @@ contains
         i1 = gp%ip_grid(1); i2 = i1 + 1
         j1 = gp%ip_grid(2); j2 = j1 + 1
         k1 = gp%ip_grid(3); k2 = k1 + 1
+
+        if (gp%DB(1) == -1) then
+            i2 = i1 + 1
+        else if (gp%DB(1) == 1) then
+            i2 = i1 - 1
+        else if (gp%DB(2) == -1) then
+            j2 = j1 + 1
+            ! else if (gp%DB(2) == 1) then
+            !     j2 = j1 - 1
+        end if
 
         if (p == 0) then
             k1 = 0

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -392,10 +392,10 @@ contains
                     bound = p
                 end if
 
-                if (norm(dim) == 0) then
+                if (norm(dim) == 0 .or. ghost_points(q)%DB(dim) == 0) then
                     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)
                 else
-                    if (norm(dim) > 0 .and. ghost_points(q)%DB(dim) == 0) then
+                    if (norm(dim) > 0) then
                         dir = 1
                     else
                         dir = -1

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -395,7 +395,7 @@ contains
                 if (norm(dim) == 0) then
                     ghost_points(q)%ip_grid(dim) = ghost_points(q)%loc(dim)
                 else
-                    if (norm(dim) > 0) then
+                    if (norm(dim) > 0 .and. ghost_points(q)%DB(dim) == 0) then
                         dir = 1
                     else
                         dir = -1
@@ -508,14 +508,45 @@ contains
                             ghost_points(count)%ib_patch_id = &
                                 patch_id
                             ghost_points(count)%slip = patch_ib(patch_id)%slip
+
+                            if ((x_cc(i) - dx(i)) < x_domain%beg .or. &
+                                (x_cc(i) + dx(i)) > x_domain%end) then
+                                ghost_points(count)%DB(1) = 1
+                            else
+                                ghost_points(count)%DB(1) = 0
+                            end if
+                            
+                            if ((y_cc(j) - dy(j)) < y_domain%beg .or. &
+                                (y_cc(j) + dy(j)) > y_domain%end) then
+                                ghost_points(count)%DB(2) = 1
+                            else
+                                ghost_points(count)%DB(2) = 0
+                            end if
+
                             count = count + 1
+                            !  print*, i, j, (y_cc(j) + dy(j)), ghost_points(count)%DB(2)
                         else
                             inner_points(count_i)%loc = [i, j, 0]
                             patch_id = ib_markers%sf(i, j, 0)
                             inner_points(count_i)%ib_patch_id = &
                                 patch_id
                             inner_points(count_i)%slip = patch_ib(patch_id)%slip
+                            if ((x_cc(i) - dx(i)) < x_domain%beg .or. &
+                                (x_cc(i) + dx(i)) > x_domain%end) then
+                                ghost_points(count)%DB(1) = 1
+                            else
+                                ghost_points(count)%DB(1) = 0
+                            end if
+                            
+                            if ((y_cc(j) - dy(j)) < y_domain%beg .or. &
+                                (y_cc(j) + dy(j)) > y_domain%end) then
+                                ghost_points(count)%DB(2) = 1
+                            else
+                                ghost_points(count)%DB(2) = 0
+                            end if
+
                             count_i = count_i + 1
+
                         end if
                     end if
                 else

--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -163,7 +163,9 @@ contains
             & 'Re_inv', 'poly_sigma', 'palpha_eps', 'ptgalpha_eps', 'pi_fac',    &
             & 'bc_x%vb1','bc_x%vb2','bc_x%vb3','bc_x%ve1','bc_x%ve2','bc_x%ve2', &
             & 'bc_y%vb1','bc_y%vb2','bc_y%vb3','bc_y%ve1','bc_y%ve2','bc_y%ve3', &
-            & 'bc_z%vb1','bc_z%vb2','bc_z%vb3','bc_z%ve1','bc_z%ve2','bc_z%ve3' ]
+            & 'bc_z%vb1','bc_z%vb2','bc_z%vb3','bc_z%ve1','bc_z%ve2','bc_z%ve3', &
+            & 'x_domain%beg', 'x_domain%end', 'y_domain%beg', 'y_domain%end',    &
+            & 'z_domain%beg', 'z_domain%end']
             call MPI_BCAST(${VAR}$, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
         #:endfor
 

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -132,6 +132,7 @@ contains
             mapped_weno, mp_weno, weno_avg, &
             riemann_solver, wave_speeds, avg_state, &
             bc_x, bc_y, bc_z, &
+            x_domain, y_domain, z_domain, &
             hypoelasticity, &
             ib, num_ibs, patch_ib, &
             fluid_pp, probe_wrt, prim_vars_wrt, &

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -112,6 +112,8 @@ for cmp in ["x", "y", "z"]:
     SIMULATION.append(f'bc_{cmp}%ve1')
     SIMULATION.append(f'bc_{cmp}%ve2')
     SIMULATION.append(f'bc_{cmp}%ve3')
+    for prepend in ["domain%beg", "domain%end", "a", "b"]:
+        SIMULATION.append(f"{cmp}_{prepend}")
 
 for wrt_id in range(1,10+1):
     for cmp in ["x", "y", "z"]:


### PR DESCRIPTION
## Description

This PR adds the treatment for cases where immersed boundaries touch the domain boundaries. 


### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Use 2D rectangle and circle as well as 3D cylinder and sphere IBs touching the domain boundary w/ shock wave and high amplitude acoustic wave.

https://github.com/MFlowCode/MFC/assets/98496194/1feab706-34a2-4f03-91f4-f0c6e389aee1


https://github.com/MFlowCode/MFC/assets/98496194/4595cf58-730a-494b-bca4-550672b076c7


https://github.com/MFlowCode/MFC/assets/98496194/6d3589e2-d4ed-4b3e-a124-4773ba67f357


https://github.com/MFlowCode/MFC/assets/98496194/c62b4723-cf31-4acf-afc0-3fd23507506a


https://github.com/MFlowCode/MFC/assets/98496194/caec1540-e27b-46f6-9767-af65aa19b1b3


https://github.com/MFlowCode/MFC/assets/98496194/ae8feb88-a9d2-4fb6-be94-13c797623428


https://github.com/MFlowCode/MFC/assets/98496194/26a3efc3-002b-4430-aed0-f324901e5c7f


**Test Configuration**:

Sample 2D cases: 149*49

```
    'time_stepper'                 : 3,
    'weno_order'                   : 5,
    'weno_eps'                     : 1.E-16,
    'weno_Re_flux'                 : 'F',
    'weno_avg'                     : 'F',
    'avg_state'                    : 2,
    'mapped_weno'                  : 'F',
    'null_weights'                 : 'F',
    'mp_weno'                      : 'F',
    'riemann_solver'               : 2,
    'wave_speeds'                  : 1,
    'bc_x%beg'                     : -6,
    'bc_x%end'                     : -6,
    'bc_y%beg'                     : -15,
    'bc_y%end'                     : -15,
    'ib'		                   : 'T',
    'num_ibs'                      :  1, 
    'patch_icpp(1)%geometry'       : 3,
    'patch_icpp(1)%x_centroid'     : x1/2, 
    'patch_icpp(1)%y_centroid'     : x2/2,
    'patch_icpp(1)%length_x'       : x1,
    'patch_icpp(1)%length_y'       : x2,
    'patch_icpp(1)%vel(1)'         : 0.0E+00,
    'patch_icpp(1)%vel(2)'         : 0.0E+00,
    'patch_icpp(1)%pres'           : 1.0E+05,
    'patch_icpp(1)%alpha_rho(1)'   : (1.0 - 1e-12)*rho1,
    'patch_icpp(1)%alpha(1)'       : 1.0 - 1e-12,
    'patch_icpp(1)%alpha_rho(2)'   : 1.0e-12*rho2,
    'patch_icpp(1)%alpha(2)'       : 1.0e-12,

    'patch_icpp(2)%geometry'       : 3,
    'patch_icpp(2)%alter_patch(1)' : 'T',
    'patch_icpp(2)%x_centroid'     : x1/8, 
    'patch_icpp(2)%y_centroid'     : x2/2,
    'patch_icpp(2)%length_x'       : x1/4,
    'patch_icpp(2)%length_y'       : x2,
    'patch_icpp(2)%vel(1)'         : 80.0E+00,
    'patch_icpp(2)%vel(2)'         : 0.0E+00,
    'patch_icpp(2)%pres'           : 1.0E+05,
    'patch_icpp(2)%alpha_rho(1)'   : (1.0 - 1e-12)*rho1,
    'patch_icpp(2)%alpha(1)'       : 1.0 - 1e-12,
    'patch_icpp(2)%alpha_rho(2)'   : 1.0e-12*rho2,
    'patch_icpp(2)%alpha(2)'       : 1.0e-12,

     'patch_ib(1)%geometry'          : 3,
     'patch_ib(1)%x_centroid'        : x1/2,
     'patch_ib(1)%y_centroid'        : 5*x2/6,
     'patch_ib(1)%length_x'          : x1/4,
     'patch_ib(1)%length_y'          : x2/2,
     'patch_ib(1)%slip'                   : 'F',
```

Sample 3D cases: 89^3

    'time_stepper'                 : 3,
    'weno_order'                   : 5,
    'weno_eps'                     : 1.E-16,
    'weno_Re_flux'                 : 'F',
    'weno_avg'                     : 'F',
    'avg_state'                    : 2,
    'mapped_weno'                  : 'F',
    'null_weights'                 : 'F',
    'mp_weno'                      : 'F',
    'riemann_solver'               : 2,
    'wave_speeds'                  : 1,
    'bc_x%beg'                     : -6,
    'bc_x%end'                     : -6,
    'bc_y%beg'                     : -3,
    'bc_y%end'                     : -3,
    'bc_z%beg'                     : -1,
    'bc_z%end'                     : -1,
    'ib'                                    : 'T',
    'num_ibs'                         : 1,
    'patch_icpp(1)%geometry'       : 9,
    'patch_icpp(1)%x_centroid'     : 5.0,
    'patch_icpp(1)%y_centroid'     : 5.0,
    'patch_icpp(1)%z_centroid'     : 5.0,
    'patch_icpp(1)%length_x'       : 10,
    'patch_icpp(1)%length_y'       : 10,
    'patch_icpp(1)%length_z'       : 10,
    'patch_icpp(1)%vel(1)'         : 0,
    'patch_icpp(1)%vel(2)'         : 0.0E+00,
    'patch_icpp(1)%vel(3)'         : 0.0E+00,
    'patch_icpp(1)%pres'           : 10918.2549,
    'patch_icpp(1)%alpha_rho(1)'   : 1.22,
    'patch_icpp(1)%alpha(1)'       : 1.E+00,

    'patch_icpp(2)%geometry'       : 9,
    'patch_icpp(2)%x_centroid'     : 2.0,
    'patch_icpp(2)%y_centroid'     : 5.0,
    'patch_icpp(2)%z_centroid'     : 5.0,
    'patch_icpp(2)%length_x'       : 4,
    'patch_icpp(2)%length_y'       : 10,
    'patch_icpp(2)%length_z'       : 10,
    'patch_icpp(2)%vel(1)'         : 100,
    'patch_icpp(2)%vel(2)'         : 0.0E+00,
    'patch_icpp(2)%vel(3)'         : 0.0E+00,
    'patch_icpp(2)%pres'           : 10918.2549,
    'patch_icpp(2)%alpha_rho(1)'   : 1.22,
    'patch_icpp(2)%alpha(1)'       : 1.E+00,
    'patch_icpp(2)%alter_patch(1)' : 'T',

    'patch_ib(1)%geometry'       : 10,
    'patch_ib(1)%x_centroid'     : 6,
    'patch_ib(1)%y_centroid'     : 10,
    'patch_ib(1)%z_centroid'     : 5,
    'patch_ib(1)%length_z'       : 5,
    'patch_ib(1)%radius'         : 2,
    'patch_ib(1)%slip'           : 'F',

* What computers and compilers did you use to test this: MacOS with GCC 13.1.6 and PACE Phoenix V100-16GB with NVHPC 22.11


## Checklist

- [x] I have added comments for the new code
- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x] Checked that the code compiles using NVHPC compilers
- [x] Checked that the code compiles using CRAY compilers
- [x] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [x] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
