### PR TITLE
Fix Frontier performance regression

### DIFF
--- a/src/common/m_variables_conversion.fpp
+++ b/src/common/m_variables_conversion.fpp
@@ -4,7 +4,7 @@
 
 #:include 'macros.fpp'
 #:include 'inline_conversions.fpp'
-#:include '../simulation/include/case.fpp'
+#:include 'case.fpp'
 
 !> @brief This module consists of subroutines used in the conversion of the
 !!              conservative variables into the primitive ones and vice versa. In

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -110,7 +110,6 @@ module m_global_parameters
     #:else
         integer :: num_dims       !< Number of spatial dimensions
     #:endif
-    integer :: num_fluids
     logical :: adv_alphan     !< Advection of the last volume fraction
     logical :: mpp_lim        !< Mixture physical parameters (MPP) limits
     integer :: time_stepper   !< Time-stepper algorithm
@@ -119,9 +118,11 @@ module m_global_parameters
     #:if MFC_CASE_OPTIMIZATION
         integer, parameter :: weno_polyn = ${weno_polyn}$ !< Degree of the WENO polynomials (polyn)
         integer, parameter :: weno_order = ${weno_order}$ !< Order of the WENO reconstruction
+        integer, parameter :: num_fluids = ${num_fluids}$ !< number of fluids in the simulation
     #:else
         integer :: weno_polyn     !< Degree of the WENO polynomials (polyn)
         integer :: weno_order     !< Order of the WENO reconstruction
+        integer :: num_fluids     !< number of fluids in the simulation
     #:endif
 
     real(kind(0d0)) :: weno_eps       !< Binding for the WENO nonlinear weights
@@ -141,10 +142,10 @@ module m_global_parameters
     integer :: cpu_start, cpu_end, cpu_rate
 
     #:if not MFC_CASE_OPTIMIZATION
-        !$acc declare create(num_dims, weno_polyn, weno_order)
+        !$acc declare create(num_dims, weno_polyn, weno_order, num_fluids)
     #:endif
 
-    !$acc declare create(mpp_lim, num_fluids, model_eqns, mixture_err, alt_soundspeed, avg_state, mapped_weno, mp_weno, weno_eps, hypoelasticity)
+    !$acc declare create(mpp_lim, model_eqns, mixture_err, alt_soundspeed, avg_state, mapped_weno, mp_weno, weno_eps, hypoelasticity)
 
     logical :: relax          !< activate phase change
     integer :: relax_model    !< Relaxation model
@@ -462,7 +463,6 @@ contains
 
         ! Simulation algorithm parameters
         model_eqns = dflt_int
-        num_fluids = dflt_int
         adv_alphan = .false.
         mpp_lim = .false.
         time_stepper = dflt_int
@@ -541,6 +541,7 @@ contains
         #:if not MFC_CASE_OPTIMIZATION
             nb = 1
             weno_order = dflt_int
+            num_fluids = dflt_int
         #:endif
 
         R0_type = dflt_int
@@ -633,9 +634,6 @@ contains
 
         ! Gamma/Pi_inf Model ===============================================
         if (model_eqns == 1) then
-
-            ! Setting number of fluids
-            num_fluids = 1
 
             ! Annotating structure of the state and flux vectors belonging
             ! to the system of equations defined by the selected number of

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -126,7 +126,7 @@ contains
         ! Namelist of the global parameters which may be specified by user
         namelist /user_inputs/ case_dir, run_time_info, m, n, p, dt, &
             t_step_start, t_step_stop, t_step_save, t_step_print, &
-            model_eqns, num_fluids, adv_alphan, &
+            model_eqns, adv_alphan, &
             mpp_lim, time_stepper, weno_eps, weno_flat, &
             riemann_flat, cu_mpi, cu_tensor, &
             mapped_weno, mp_weno, weno_avg, &
@@ -141,7 +141,7 @@ contains
             rhoref, pref, bubbles, bubble_model, &
             R0ref, &
 #:if not MFC_CASE_OPTIMIZATION
-            nb, weno_order, &
+            nb, weno_order, num_fluids, &
 #:endif
             Ca, Web, Re_inv, &
             monopole, mono, num_mono, &

--- a/toolchain/mfc/case.py
+++ b/toolchain/mfc/case.py
@@ -176,7 +176,7 @@ class Case:
 #:set nb                    = {int(self.params.get("nb", 1))}
 #:set num_dims              = {1 + min(int(self.params.get("n", 0)), 1) + min(int(self.params.get("p", 0)), 1)}
 #:set nterms                = {nterms}
-#:set num_fluids            = {int(self.case_dict["num_fluids"])}
+#:set num_fluids            = {int(self.params["num_fluids"])}
 """
 
         return """\

--- a/toolchain/mfc/case.py
+++ b/toolchain/mfc/case.py
@@ -176,6 +176,7 @@ class Case:
 #:set nb                    = {int(self.params.get("nb", 1))}
 #:set num_dims              = {1 + min(int(self.params.get("n", 0)), 1) + min(int(self.params.get("p", 0)), 1)}
 #:set nterms                = {nterms}
+#:set num_fluids            = {int(self.case_dict["num_fluids"])}
 """
 
         return """\

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -186,7 +186,7 @@ for fl_id in range(1,10+1):
 
 ALL = list(set(PRE_PROCESS + SIMULATION + POST_PROCESS))
 
-CASE_OPTIMIZATION = [ "nb", "weno_order" ]
+CASE_OPTIMIZATION = [ "nb", "weno_order", "num_fluids"]
 
 
 def get_input_dict_keys(target_name: str) -> list:

--- a/toolchain/mfc/run/input.py
+++ b/toolchain/mfc/run/input.py
@@ -31,7 +31,6 @@ class MFCInputFile(Case):
         cons.print("Writing a (new) custom case.fpp file.")
         common.file_write(fpp_path, contents, True)
 
-    # pylint: disable=too-many-locals
     def generate_fpp(self, target) -> None:
         if target.isDependency:
             return


### PR DESCRIPTION
## Description

Fixes a performance regression on Frontier between the optimized code at the head of @abbotts fork of MFC and the current master branch.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

Ran the test suite on Frontier

## Checklist

- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x] Ran an Omniperf profile using `./mfc.sh run XXXX --gpu -t simulation --omniperf`, and have attached the output file and plain text results to this PR.
![image](https://github.com/MFlowCode/MFC/assets/48168887/0883891d-1483-4991-be82-ef5ae655188b)
