### PR TITLE
Silo: Reference official LLNL/Silo repository

### DIFF
--- a/toolchain/dependencies/CMakeLists.txt
+++ b/toolchain/dependencies/CMakeLists.txt
@@ -59,14 +59,16 @@ endif()
 
 # SILO
 if (MFC_SILO)
+    find_package(Git REQUIRED)
+
     # If we are using the CCE, HDF5 is not built, and we wish to find
     # the system's cray-hdf5. Otherwise, we point SILO to find HDF5 in
     # our common install directory using SILO_HDF5_DIR.
     ExternalProject_Add(silo
-        GIT_REPOSITORY "https://github.com/henryleberre/Silo"
-        GIT_TAG        af955eb5dd009caf00c41ca51611b37c052b042c
-        GIT_SHALLOW    ON
+        GIT_REPOSITORY "https://github.com/LLNL/Silo"
+        GIT_TAG        438477c80d32a3e1757d4584b993f382cace1535
         GIT_PROGRESS   ON
+        PATCH_COMMAND  "${GIT_EXECUTABLE}" stash && "${GIT_EXECUTABLE}" apply "${CMAKE_SOURCE_DIR}/Silo.patch"
         CMAKE_ARGS      -DSILO_ENABLE_SHARED=OFF
                         -DSILO_ENABLE_SILOCK=OFF
                         -DSILO_ENABLE_BROWSER=OFF

--- a/toolchain/dependencies/Silo.patch
+++ b/toolchain/dependencies/Silo.patch
@@ -1,0 +1,25 @@
+From 7405f0dc998ac104b4b5c0536bbf9b0644d85a11 Mon Sep 17 00:00:00 2001
+From: Henry LE BERRE <hberre3@gatech.edu>
+Date: Mon, 1 Apr 2024 17:06:21 -0400
+Subject: [PATCH] CMake MFC Fixes
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 111eb42..9e460f7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -68,7 +68,7 @@ project(Silo VERSION ${SILO_VERSION} LANGUAGES CXX C)
+ ###-----------------------------------------------------------------------------
+ # location for Silo CMake includes
+ ###-----------------------------------------------------------------------------
+-set(CMAKE_MODULE_PATH ${Silo_SOURCE_DIR}/CMake)
++list(APPEND CMAKE_MODULE_PATH "${Silo_SOURCE_DIR}/CMake")
+ 
+ ###-----------------------------------------------------------------------------
+ # If not already set, use a default build type of Release
+-- 
+2.45.1
+

--- a/toolchain/mfc/test/case.py
+++ b/toolchain/mfc/test/case.py
@@ -118,13 +118,14 @@ class TestCase(case.Case):
         tasks             = ["-n", str(self.ppn)]
         jobs              = ["-j", str(ARG("jobs"))] if ARG("case_optimization") else []
         case_optimization = ["--case-optimization"] if ARG("case_optimization") else []
+        rebuild           = [] if self.rebuild or ARG("case_optimization") else ["--no-build"]
 
         mfc_script = ".\\mfc.bat" if os.name == 'nt' else "./mfc.sh"
 
         target_names = [ get_target(t).name for t in targets ]
 
         command = [
-            mfc_script, "run", filepath, *tasks, *case_optimization,
+            mfc_script, "run", filepath, *rebuild, *tasks, *case_optimization,
             *jobs, "-t", *target_names, *gpus_select, *ARG("--")
         ]
 


### PR DESCRIPTION
## Description

Currently, Silo is fetched from my fork - which is not ideal. This had to be done to include some of my fixes for macOS and Frontier. Although the former set of changes was upstreamed, there is no *non-broken* release that includes it.. We therefore reference the commit hash from my PR. The Frontier hotfix cannot be upstreamed because CMake users are not supposed to manually specify `CMAKE_MODULE_PATH`s at configure-time. I cannot recall the specifics of the issue, but there may be a more permanent solution available. In the meantime, we manually patch the one-line hotfix in.

### Type of change

- [x] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal