### PR TITLE
new cpu phoenix modules

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -42,9 +42,9 @@ e-gpu gpu/0.15.4 cuda/11.0.2 nvhpc/22.2 openmpi/4.0.5 cmake/3.19.8
 e-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 p     GT Phoenix
-p-all python/3.9.12-rkxvr6 cmake/3.23.1-327dbl
-p-cpu gcc/10.3.0-o57x6h openmpi/4.1.4
-p-gpu cuda/11.7.0-7sdye3 nvhpc/22.11
+p-all python/3.9.12-rkxvr6 
+p-cpu gcc/12.1.0-qgxpzk mvapich2/2.3.7-733lcv
+p-gpu cmake/3.23.1-327dbl cuda/11.7.0-7sdye3 nvhpc/22.11
 p-gpu MFC_CUDA_CC=70,80 CC=nvc CXX=nvc++ FC=nvfortran
 
 f     OLCF Frontier


### PR DESCRIPTION
Updates CPU Phoenix modules to use gcc12 + mvapich2. Old CPU modules no longer working for some reason. We also now don't load cmake on CPU but allow MFC to build it itself.