### PR TITLE
Remove grid stretch parameters from simulation inputs

### DIFF
--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -123,7 +123,7 @@ for cmp in ["x", "y", "z"]:
     SIMULATION.append(f'bc_{cmp}%ve1')
     SIMULATION.append(f'bc_{cmp}%ve2')
     SIMULATION.append(f'bc_{cmp}%ve3')
-    for prepend in ["domain%beg", "domain%end", "a", "b"]:
+    for prepend in ["domain%beg", "domain%end"]:
         SIMULATION.append(f"{cmp}_{prepend}")
 
 for wrt_id in range(1,10+1):


### PR DESCRIPTION
## Description

This PR removes the grid stretch parameters `xyz_{ab}` from the simulation input parameters in `case_dicts.py`.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### Scope

- [x] This PR comprises a set of related changes with a common goal


## How Has This Been Tested?

It builds successfully on my local MacOS. Simulations with stretched grid are not crashing.

* What computers and compilers did you use to test this: MacOS 12.2.1