### PR TITLE
IBM+STL

### DIFF
--- a/src/common/m_derived_types.fpp
+++ b/src/common/m_derived_types.fpp
@@ -208,6 +208,25 @@ module m_derived_types
         real(kind(0d0)) :: theta
 
         logical :: slip
+        ! character(LEN=pathlen_max) :: model_filepath !<
+        ! !! Path the STL file relative to case_dir.
+
+        ! t_vec3 :: model_translate !<
+        ! !! Translation of the STL object.
+
+        ! t_vec3 :: model_scale !<
+        ! !! Scale factor for the STL object.
+
+        ! t_vec3 :: model_rotate !<
+        ! !! Angle to rotate the STL object along each cartesian coordinate axis,
+        ! !! in radians.
+
+        ! integer :: model_spc !<
+        ! !! Number of samples per cell to use when discretizing the STL object.
+
+        ! real(kind(0d0)) :: model_threshold !<
+
+        type(ic_model_parameters) :: model !< Model parameters
 
     end type ib_patch_parameters
 
@@ -277,6 +296,7 @@ module m_derived_types
         integer :: ib_patch_id !< ID of the IB Patch the ghost point is part of
         logical :: slip
         integer, dimension(3) :: DB
+        integer :: IBB
 
     end type ghost_point
 

--- a/src/pre_process/m_check_ib_patches.fpp
+++ b/src/pre_process/m_check_ib_patches.fpp
@@ -52,6 +52,8 @@ contains
                     call s_check_3D_airfoil_ib_patch_geometry(i)
                 else if (patch_ib(i)%geometry == 10) then
                     call s_check_cylinder_ib_patch_geometry(i)
+                else if (patch_ib(i)%geometry == 5) then
+                    call s_check_2D_STL_ib_patch_geometry(i)
                 else
                     call s_mpi_abort('Unsupported choice of the '// &
                                      'geometry of active patch '//trim(iStr)// &
@@ -74,6 +76,21 @@ contains
         !!      the circle patch have consistently been inputted by the
         !!      user.
         !!  @param patch_id Patch identifier
+    subroutine s_check_2D_STL_ib_patch_geometry(patch_id)
+        integer, intent(IN) :: patch_id
+        call s_int_to_str(patch_id, iStr)
+
+        ! Constraints on the geometric parameters of the circle patch
+        if (n == 0 .or. p > 0) then
+
+            call s_mpi_abort('Inconsistency(ies) detected in '// &
+                             'geometric parameters of circle '// &
+                             'patch '//trim(iStr)//'. Exiting ...')
+
+        end if
+
+    end subroutine s_check_2D_STL_ib_patch_geometry
+
     subroutine s_check_circle_ib_patch_geometry(patch_id) ! -------------------
 
         integer, intent(IN) :: patch_id

--- a/src/pre_process/m_global_parameters.fpp
+++ b/src/pre_process/m_global_parameters.fpp
@@ -402,6 +402,11 @@ contains
             patch_ib(i)%m = dflt_real
             patch_ib(i)%p = dflt_real
             patch_ib(i)%slip = .false.
+            patch_ib(i)%model%scale(:) = 1d0
+            patch_ib(i)%model%translate(:) = 0d0
+            patch_ib(i)%model%filepath(:) = ' '
+            patch_ib(i)%model%spc = 10
+            patch_ib(i)%model%threshold = 0.9d0
         end do
 
         ! Fluids physical parameters

--- a/src/pre_process/m_global_parameters.fpp
+++ b/src/pre_process/m_global_parameters.fpp
@@ -404,6 +404,7 @@ contains
             patch_ib(i)%slip = .false.
             patch_ib(i)%model%scale(:) = 1d0
             patch_ib(i)%model%translate(:) = 0d0
+            patch_ib(i)%model%rotate(:) = 0d0
             patch_ib(i)%model%filepath(:) = ' '
             patch_ib(i)%model%spc = 10
             patch_ib(i)%model%threshold = 0.9d0

--- a/src/pre_process/m_initial_condition.fpp
+++ b/src/pre_process/m_initial_condition.fpp
@@ -173,7 +173,7 @@ contains
 
                     ! 3D STL patch
                 elseif (patch_icpp(i)%geometry == 21) then
-                    call s_model(i, patch_id_fp, q_prim_vf)
+                    call s_model(i, patch_id_fp, q_prim_vf, .false.)
 
                 end if
 
@@ -252,7 +252,7 @@ contains
 
                     ! STL patch
                 elseif (patch_icpp(i)%geometry == 21) then
-                    call s_model(i, patch_id_fp, q_prim_vf)
+                    call s_model(i, patch_id_fp, q_prim_vf, .false.)
 
                 end if
                 !> @}
@@ -273,6 +273,9 @@ contains
 
                 elseif (patch_ib(i)%geometry == 4) then
                     call s_airfoil(i, ib_markers%sf, q_prim_vf, .true.)
+
+                elseif (patch_ib(i)%geometry == 5) then
+                    call s_model(i, ib_markers%sf, q_prim_vf, .true.)
                 end if
             end do
             !> @}

--- a/src/pre_process/m_mpi_proxy.fpp
+++ b/src/pre_process/m_mpi_proxy.fpp
@@ -96,11 +96,20 @@ contains
             call MPI_BCAST(patch_icpp(i)%model%spc, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
 
             ! Broadcast IB variables
+            call MPI_BCAST(patch_ib(i)%model%filepath, len(patch_ib(i)%model%filepath), MPI_CHARACTER, 0, MPI_COMM_WORLD, ierr)
             call MPI_BCAST(patch_ib(i)%geometry, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
             #:for VAR in [ 'x_centroid', 'y_centroid', 'z_centroid',           &
                 & 'length_x', 'length_y', 'length_z', 'radius', 'c', 'p', 't', 'm', 'theta', 'slip']
                 call MPI_BCAST(patch_ib(i)%${VAR}$, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
             #:endfor
+
+            #:for VAR in [ 'model%translate', 'model%scale', 'model%rotate']
+                call MPI_BCAST(patch_ib(i)%${VAR}$, size(patch_ib(i)%${VAR}$), MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+            #:endfor
+
+            call MPI_BCAST(patch_ib(i)%model%threshold, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+            call MPI_BCAST(patch_ib(i)%model%spc, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+
         end do
 
         ! Fluids physical parameters

--- a/src/pre_process/m_patches.fpp
+++ b/src/pre_process/m_patches.fpp
@@ -1999,7 +1999,6 @@ contains
                             char(13)//"  * Generating grid: ", &
                             nint(100*real(cell_num)/ncells), "%"
                     end if
-
                     point = (/x_cc(i), y_cc(j), 0d0/)
                     if (p > 0) then
                         point(3) = z_cc(k)
@@ -2015,20 +2014,22 @@ contains
                         eta = f_model_is_inside(model, point, (/dx, dy, dz/), patch_icpp(patch_id)%model%spc)
                     end if
 
-                    if (patch_icpp(patch_id)%smoothen) then
-                        if (eta > patch_icpp(patch_id)%model%threshold) then
-                            eta = 1d0
-                        end if
-                    else
-                        if (eta > patch_icpp(patch_id)%model%threshold) then
-                            eta = 1d0
+                    if (.not. ib) then
+                        if (patch_icpp(patch_id)%smoothen) then
+                            if (eta > patch_icpp(patch_id)%model%threshold) then
+                                eta = 1d0
+                            end if
                         else
-                            eta = 0d0
+                            if (eta > patch_icpp(patch_id)%model%threshold) then
+                                eta = 1d0
+                            else
+                                eta = 0d0
+                            end if
                         end if
-                    end if
-
-                    call s_assign_patch_primitive_variables(patch_id, i, j, k, &
+                    
+                        call s_assign_patch_primitive_variables(patch_id, i, j, k, &
                                                             eta, q_prim_vf, patch_id_fp)
+                    end if
 
                     ! Note: Should probably use *eta* to compute primitive variables
                     ! if defining them analytically.

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -100,8 +100,12 @@ contains
         call s_mpi_sendrecv_ib_buffers(ib_markers, gp_layers)
 
         call s_find_num_ghost_points()
-
         !$acc update device(num_gps, num_inner_gps)
+
+        ! if (proc_rank == 0) then
+        !     call s_mpi_sendrecv_num_gps(num_gps)
+        ! end if
+
         @:ALLOCATE_GLOBAL(ghost_points(num_gps))
         @:ALLOCATE_GLOBAL(inner_points(num_inner_gps))
 
@@ -527,7 +531,6 @@ contains
                 end if
             end do
         end do
-
     end subroutine s_find_num_ghost_points
 
     subroutine s_find_ghost_points(ghost_points, inner_points)

--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -1990,6 +1990,16 @@ contains
 
     end subroutine s_mpi_sendrecv_ib_buffers ! ---------
 
+    subroutine s_mpi_sendrecv_num_gps(num_gps)
+        integer, intent(INOUT) :: num_gps
+
+#ifdef MFC_MPI
+
+        call MPI_BCAST(num_gps, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+
+#endif
+    end subroutine s_mpi_sendrecv_num_gps
+
     !> Module deallocation and/or disassociation procedures
     subroutine s_finalize_mpi_proxy_module() ! -----------------------------
 

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -28,6 +28,27 @@ for ib_id in range(1, 10+1):
         PRE_PROCESS.append(f'patch_ib({ib_id})%{cmp}_centroid')
         PRE_PROCESS.append(f'patch_ib({ib_id})%length_{cmp}')
 
+    for attribute in ["translate", "scale", "rotate"]:
+        for j in range(1, 4):
+            PRE_PROCESS.append(f"patch_ib({ib_id})%model%{attribute}({j})")
+    
+    PRE_PROCESS.append(f"patch_ib({ib_id})%model%filepath")
+    PRE_PROCESS.append(f"patch_ib({ib_id})%model%spc")
+    PRE_PROCESS.append(f"patch_ib({ib_id})%model%threshold")
+
+
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_scale({1})")
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_scale({2})")
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_scale({3})")
+
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_translate({1})")
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_translate({2})")
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_translate({3})")
+
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_rotate({1})")
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_rotate({2})")
+    # PRE_PROCESS.append(f"patch_ib({ib_id})%model_rotate({3})")
+
 for cmp in ["x", "y", "z"]:
     for prepend in ["domain%beg", "domain%end", "a", "b"]:
         PRE_PROCESS.append(f"{cmp}_{prepend}")


### PR DESCRIPTION
## Description

This PR enables STL patches in IBM. Adding 3D, MPI communication, and GPU part of the code now. If you have any case in mind that I can run for validating the approach, please let me know and I can test it for you. Any idea is appreciated.

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


### Scope

- [x] This PR comprises a set of related changes with a common goal


## How Has This Been Tested?

- [x] 2D Test using simple geometry such as rectangles and compare results between levelset function for STL and the levelset function for rectangle.


https://github.com/MFlowCode/MFC/assets/98496194/64a0b066-8252-4e3e-a87d-1957fd9167e0



- [x] 2D Test using STL arbitrary shapes.

https://github.com/MFlowCode/MFC/assets/98496194/6265e0d4-4744-46a2-a786-30c72dd18f51


https://github.com/MFlowCode/MFC/assets/98496194/9972202b-86fb-4b25-97f2-eddeae9e57f2


**Test Configuration**:

* What computers and compilers did you use to test this: MacOS 12.2.1

## Checklist

- [ ] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [ ] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [ ] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [ ] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran an Omniperf profile using `./mfc.sh run XXXX --gpu -t simulation --omniperf`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
