### PR TITLE
Add back MacOS debug runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,7 @@ jobs:
           - os:    macos
             intel: true
 
-          - os:    macos
-            debug: debug
-            intel: false
-
-        include: 
-
+        include:
           - os:    ubuntu
             mpi:   no-mpi
             debug: no-debug


### PR DESCRIPTION
Adding back the MacOS debug runner, which does seem useful.

Note that for some reason a failing MacOS runner stopping the Ubuntu runners from continuing, despite fail-fast being disabled and continue-on-error being enabled.

This seems new (starting with the last change to the runners, perhaps.