### PR TITLE
Temporary GNU 13 Silo Build Fix

### DIFF
--- a/toolchain/dependencies/CMakeLists.txt
+++ b/toolchain/dependencies/CMakeLists.txt
@@ -68,7 +68,9 @@ if (MFC_SILO)
         GIT_REPOSITORY "https://github.com/LLNL/Silo"
         GIT_TAG        438477c80d32a3e1757d4584b993f382cace1535
         GIT_PROGRESS   ON
-        PATCH_COMMAND  "${GIT_EXECUTABLE}" stash && "${GIT_EXECUTABLE}" apply "${CMAKE_SOURCE_DIR}/Silo.patch"
+        PATCH_COMMAND  "${GIT_EXECUTABLE}" stash
+                       && "${GIT_EXECUTABLE}" apply "${CMAKE_SOURCE_DIR}/Silo.patch"
+                       && "${GIT_EXECUTABLE}" apply "${CMAKE_SOURCE_DIR}/Silo-GNU-13.patch"
         CMAKE_ARGS      -DSILO_ENABLE_SHARED=OFF
                         -DSILO_ENABLE_SILOCK=OFF
                         -DSILO_ENABLE_BROWSER=OFF

--- a/toolchain/dependencies/Silo-GNU-13.patch
+++ b/toolchain/dependencies/Silo-GNU-13.patch
@@ -1,0 +1,31 @@
+From 51f0a23e72b366358146bb272d6d5c297929b0b0 Mon Sep 17 00:00:00 2001
+From: Henry LE BERRE <hberre3@gatech.edu>
+Date: Thu, 30 May 2024 19:15:23 +0200
+Subject: [PATCH] Temporary GNU 13 Silo Build Fix
+
+---
+ src/hdf5_drv/silo_hdf5.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/hdf5_drv/silo_hdf5.c b/src/hdf5_drv/silo_hdf5.c
+index 9a00194..cc23fbf 100644
+--- a/src/hdf5_drv/silo_hdf5.c
++++ b/src/hdf5_drv/silo_hdf5.c
+@@ -1810,8 +1810,12 @@ db_hdf5_cwg(DBfile *_dbfile)
+         else                                                     \
+              *dscount = m.MEMCNT;                                \
+         *dsnames = (char **) calloc(*dscount, sizeof(char**));   \
+-        for (i = 0; i < *dscount; i++)                           \
+-            (*dsnames)[i] = strdup(m.MEMNAME[i]);                \
++        if (sizeof(m.MEMNAME[0]) >= sizeof(char)) {              \
++            for (i = 0; i < *dscount; i++)                       \
++                (*dsnames)[i] = strdup((char*)m.MEMNAME[i]);     \
++        } else {                                                 \
++            (*dsnames)[0] = strdup((char*)m.MEMNAME);            \
++        }                                                        \
+         break;                                                   \
+     }
+ 
+-- 
+2.45.1
+


### PR DESCRIPTION
## Description

This hotfix gets Silo building on GNU 13. It should also pass the `-a` test suite. Let's perpetuate the tradition of hacky C code. This fix isn't pretty, but it should be correct, given the types we are working with.