### PR TITLE
coverage only runs when meanful files are changed (duplicates code fr…

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,18 @@
 name: Coverage Check
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+    paths:
+      - '**.f90'
+      - '**.fpp'
+      - '**.py'
+      - '**.yml'
+      - 'mfc.sh'
+      - 'golden.txt'
+      - 'golden-metadata.txt'
+      - 'CMakeLists.txt'
+      - 'requirements.txt'
+
 
 jobs:
   run:


### PR DESCRIPTION
…om `test.yml`). This removes the other `on:` commands because I couldn't figure out the right syntax.

## Description

Changed codecov to only run when meaningful files are changed.

This code probably needs improvement from @henryleberre and/or @okBrian. It duplicates paths from `test.yml` and gits rid of the `push` and `workflow_dispatch` events because I couldn't figure out the right syntax for them.

### Type of change

- [x] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] https://rhysd.github.io/actionlint/


