### PR TITLE
Hotfix: Allow certain case parameters to be analytic expressions again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,7 +451,7 @@ function(MFC_SETUP_TARGET)
                 )
             endforeach()
 
-	    target_compile_options(${ARGS_TARGET}
+            target_compile_options(${ARGS_TARGET}
                 PRIVATE -gpu=keep,ptxinfo,lineinfo
             )
 
@@ -465,7 +465,7 @@ function(MFC_SETUP_TARGET)
                     PRIVATE -gpu=unified
                 )
             endif()
-            
+
             if (CMAKE_BUILD_TYPE STREQUAL "Debug")
                 target_compile_options(${ARGS_TARGET}
                     PRIVATE -gpu=autocompare,debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,7 +452,7 @@ function(MFC_SETUP_TARGET)
             endforeach()
 
             target_compile_options(${ARGS_TARGET}
-                PRIVATE -gpu=keep,ptxinfo,lineinfo
+                PRIVATE -gpu=keep,ptxinfo,lineinfo,unified
             )
 
             # GH-200 Unified Memory Support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,12 +451,8 @@ function(MFC_SETUP_TARGET)
                 )
             endforeach()
 
-            target_compile_options(${ARGS_TARGET}
-                PRIVATE -gpu=keep,ptxinfo,lineinfo,unified
-            )
-            # "This option must appear in both the compile and link lines" -- NVHPC Docs
-	    target_link_options(${ARGS_TARGET}
-                PRIVATE -gpu=unified
+	    target_compile_options(${ARGS_TARGET}
+                PRIVATE -gpu=keep,ptxinfo,lineinfo
             )
 
             # GH-200 Unified Memory Support
@@ -469,6 +465,7 @@ function(MFC_SETUP_TARGET)
                     PRIVATE -gpu=unified
                 )
             endif()
+            
             if (CMAKE_BUILD_TYPE STREQUAL "Debug")
                 target_compile_options(${ARGS_TARGET}
                     PRIVATE -gpu=autocompare,debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,10 @@ function(MFC_SETUP_TARGET)
             target_compile_options(${ARGS_TARGET}
                 PRIVATE -gpu=keep,ptxinfo,lineinfo,unified
             )
+            # "This option must appear in both the compile and link lines" -- NVHPC Docs
+	    target_link_options(${ARGS_TARGET}
+                PRIVATE -gpu=unified
+            )
 
             # GH-200 Unified Memory Support
             if (MFC_Unified)

--- a/examples/3D_performance_test/case.py
+++ b/examples/3D_performance_test/case.py
@@ -68,7 +68,7 @@ print(json.dumps({
     'format'                       : 1,
     'precision'                    : 2,
     'prim_vars_wrt'                :'T',
-    'parallel_io'                  :'T',
+    'parallel_io'                  :'F',
     # ==========================================================================
 
     # Patch 1: High pressured water ============================================

--- a/examples/3D_performance_test/case.py
+++ b/examples/3D_performance_test/case.py
@@ -68,7 +68,7 @@ print(json.dumps({
     'format'                       : 1,
     'precision'                    : 2,
     'prim_vars_wrt'                :'T',
-    'parallel_io'                  :'F',
+    'parallel_io'                  :'T',
     # ==========================================================================
 
     # Patch 1: High pressured water ============================================

--- a/toolchain/mfc/case.py
+++ b/toolchain/mfc/case.py
@@ -83,6 +83,8 @@ class Case:
         return 1 + min(int(self.params.get("n", 0)), 1) + min(int(self.params.get("p", 0)), 1)
 
     def __is_ic_analytical(self, key: str, val: str) -> bool:
+        '''Is this initial condition analytical?
+        More precisely, is this an arbitrary expression or a string representing a number?'''
         if common.is_number(val) or not isinstance(val, str):
             return False
 

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -1,5 +1,4 @@
 from enum import Enum
-
 from ..state import ARG
 
 class ParamType(Enum):
@@ -7,6 +6,17 @@ class ParamType(Enum):
     REAL = {"type": "number"}
     LOG = {"enum": ["T", "F"]}
     STR = {"type": "string"}
+    
+    _ANALYTIC_INT = {"type": ["integer", "string"]}
+    _ANALYTIC_REAL = {"type": ["number", "string"]}
+
+    def analytic(self):
+        if self == self.INT:
+            return self._ANALYTIC_INT
+        elif self == self.REAL:
+            return self._ANALYTIC_REAL
+        else:
+            return self.STR
 
 COMMON = {
     'hypoelasticity': ParamType.LOG,
@@ -105,9 +115,10 @@ for p_id in range(1, 10+1):
         PRE_PROCESS[f"patch_icpp({p_id})%{attribute}"] = ty
 
     for real_attr in ["radius",  "radii", "epsilon", "beta", "normal", "alpha_rho",
-                      "smooth_coeff", "rho", "vel", "pres", "alpha", "gamma",
+                      "smooth_coeff", "rho", "vel", "alpha", "gamma",
                       "pi_inf", "r0", "v0", "p0", "m0", "cv", "qv", "qvp", "cf_val"]: 
         PRE_PROCESS[f"patch_icpp({p_id})%{real_attr}"] = ParamType.REAL
+    PRE_PROCESS[f"patch_icpp({p_id})%pres"] = ParamType.REAL.analytic()
 
     # (cameron): This parameter has since been removed.
     # for i in range(100):
@@ -127,15 +138,16 @@ for p_id in range(1, 10+1):
         PRE_PROCESS[f'patch_icpp({p_id})%{cmp}_centroid'] = ParamType.REAL
         PRE_PROCESS[f'patch_icpp({p_id})%length_{cmp}'] = ParamType.REAL
 
-        for append in ["radii", "normal", "vel"]:
+        for append in ["radii", "normal"]:
             PRE_PROCESS[f'patch_icpp({p_id})%{append}({cmp_id})'] = ParamType.REAL
+        PRE_PROCESS[f'patch_icpp({p_id})%vel({cmp_id})'] = ParamType.REAL.analytic()
 
     for arho_id in range(1, 10+1):
-        PRE_PROCESS[f'patch_icpp({p_id})%alpha({arho_id})'] = ParamType.REAL
-        PRE_PROCESS[f'patch_icpp({p_id})%alpha_rho({arho_id})'] = ParamType.REAL
+        PRE_PROCESS[f'patch_icpp({p_id})%alpha({arho_id})'] = ParamType.REAL.analytic()
+        PRE_PROCESS[f'patch_icpp({p_id})%alpha_rho({arho_id})'] = ParamType.REAL.analytic()
 
     for taue_id in range(1, 6+1):
-        PRE_PROCESS[f'patch_icpp({p_id})%tau_e({taue_id})'] = ParamType.REAL
+        PRE_PROCESS[f'patch_icpp({p_id})%tau_e({taue_id})'] = ParamType.REAL.analytic()
 
     if p_id >= 2:
         PRE_PROCESS[f'patch_icpp({p_id})%alter_patch'] = ParamType.LOG

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -6,17 +6,16 @@ class ParamType(Enum):
     REAL = {"type": "number"}
     LOG = {"enum": ["T", "F"]}
     STR = {"type": "string"}
-    
+
     _ANALYTIC_INT = {"type": ["integer", "string"]}
     _ANALYTIC_REAL = {"type": ["number", "string"]}
 
     def analytic(self):
         if self == self.INT:
             return self._ANALYTIC_INT
-        elif self == self.REAL:
+        if self == self.REAL:
             return self._ANALYTIC_REAL
-        else:
-            return self.STR
+        return self.STR
 
 COMMON = {
     'hypoelasticity': ParamType.LOG,


### PR DESCRIPTION
## Description

After addressing GH-424, I broke parameters like those found in `1D_shuosher` and `1D_titarevtorro` which have analytic values -- they were falsely rejected as "strings" when they should have been accepted.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] `./mfc.sh test` passes
- [x] Ran `1D_shuosher` -- Simulation ran to completion
- [x] Ran `1D_titarevtorro` -- Case file passed validation but preprocessing failed:

```
 Pre-processing a 999x0x0 case on 1 rank(s)
 Processing patch           1
 Processing patch           2
 Invalid hcid specified for patch 2
STOP 1
```
This is behavior also appears on v4.8.2, before the new case validation was implemented. This may be specific to my machine.

**Test Configuration**:

* What computers and compilers did you use to test this:
Personal laptop. GNU:
* AMD Ryzen 7840U -- 8 Core, 16 Thread
* 32 GB DDR5

## Checklist

- [ ] I have added comments for the new code
- [ ] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [ ] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [ ] I cannot think of a way to condense this code and reduce any introduced additional line count

