### PR TITLE
Pre_Proccess, Added Intent, Comments, and Formatting

### DIFF
--- a/src/pre_process/m_assign_variables.f90
+++ b/src/pre_process/m_assign_variables.f90
@@ -35,6 +35,9 @@ module m_assign_variables
         !! @param j (x) cell index in which the mixture or species primitive variables from the indicated patch areassigned
         !! @param k (y,th) cell index in which the mixture or species primitive variables from the indicated patch areassigned
         !! @param l (z) cell index in which the mixture or species primitive variables from the indicated patch areassigned
+        !! @param eta pseudo volume fraction
+        !! @param q_prim_vf Primitive variables
+        !! @param patch_id_fp Array to track patch ids
         subroutine s_assign_patch_xxxxx_primitive_variables(patch_id, j, k, l, &
                                                             eta, q_prim_vf, patch_id_fp)
 
@@ -42,19 +45,20 @@ module m_assign_variables
 
             integer, intent(in) :: patch_id
             integer, intent(in) :: j, k, l
-            real(kind(0d0)), intent(in) :: eta 
+            real(kind(0d0)), intent(in) :: eta
             type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
-            integer, dimension(0:m, 0:n, 0:p), intent(inout):: patch_id_fp
+            integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
 
         end subroutine s_assign_patch_xxxxx_primitive_variables
 
     end interface
 
-    private; public :: s_initialize_assign_variables_module, &
- s_assign_patch_primitive_variables, &
- s_assign_patch_mixture_primitive_variables, &
- s_assign_patch_species_primitive_variables, &
- s_finalize_assign_variables_module
+    private; 
+    public :: s_initialize_assign_variables_module, &
+              s_assign_patch_primitive_variables, &
+              s_assign_patch_mixture_primitive_variables, &
+              s_assign_patch_species_primitive_variables, &
+              s_finalize_assign_variables_module
 
 contains
 
@@ -87,16 +91,19 @@ contains
         !!              with those of the smoothing patch. The specific details
         !!              of the combination may be found in Shyue's work (1998).
         !! @param patch_id the patch identifier
-        !! @param j  the x-dir node index
-        !! @param k  the y-dir node index
-        !! @param l  the z-dir node index
+        !! @param j the x-dir node index
+        !! @param k the y-dir node index
+        !! @param l the z-dir node index
+        !! @param eta pseudo volume fraction
+        !! @param q_prim_vf Primitive variables
+        !! @param patch_id_fp Array to track patch ids
     subroutine s_assign_patch_mixture_primitive_variables(patch_id, j, k, l, &
                                                           eta, q_prim_vf, patch_id_fp)
         !$acc routine seq
 
         integer, intent(in) :: patch_id
         integer, intent(in) :: j, k, l
-        real(kind(0d0)), intent(in) :: eta 
+        real(kind(0d0)), intent(in) :: eta
         type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
         integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
 
@@ -154,11 +161,14 @@ contains
     end subroutine s_assign_patch_mixture_primitive_variables ! ------------
 
     !Stable perturbation in pressure (Ando)
+    !! @param j the x-dir node index
+    !! @param k the y-dir node index
+    !! @param l the z-dir node index
+    !! @param q_prim_vf Primitive variables
     subroutine s_perturb_primitive(j, k, l, q_prim_vf)
 
         integer, intent(in) :: j, k, l
         type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
-        
 
         integer :: i
         real(kind(0d0)) :: pres_mag, loc, n_tait, B_tait, p0
@@ -233,16 +243,19 @@ contains
         !!  s_assign_patch_species_primitive_variables with adaptation for
         !!  ensemble-averaged bubble modeling
         !! @param patch_id the patch identifier
-        !! @param j  the x-dir node index
-        !! @param k  the y-dir node index
-        !! @param l  the z-dir node index
+        !! @param j the x-dir node index
+        !! @param k the y-dir node index
+        !! @param l the z-dir node index
+        !! @param eta pseudo volume fraction
+        !! @param q_prim_vf Primitive variables
+        !! @param patch_id_fp Array to track patch ids
     subroutine s_assign_patch_species_primitive_variables(patch_id, j, k, l, &
                                                           eta, q_prim_vf, patch_id_fp)
         !$acc routine seq
 
         integer, intent(in) :: patch_id
         integer, intent(in) :: j, k, l
-        real(kind(0d0)), intent(in) :: eta 
+        real(kind(0d0)), intent(in) :: eta
         integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
         type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
@@ -250,7 +263,7 @@ contains
         ! function, respectively, obtained from the combination of primitive
         ! variables of the current and smoothing patches
         real(kind(0d0)) :: rho         !< density
-        real(kind(0d0)) :: gamma 
+        real(kind(0d0)) :: gamma
         real(kind(0d0)) :: lit_gamma   !< specific heat ratio
         real(kind(0d0)) :: pi_inf      !< stiffness from SEOS
         real(kind(0d0)) :: qv          !< reference energy from SEOS

--- a/src/pre_process/m_assign_variables.f90
+++ b/src/pre_process/m_assign_variables.f90
@@ -40,11 +40,11 @@ module m_assign_variables
 
             import :: scalar_field, sys_size, n, m, p
 
-            integer, intent(IN) :: patch_id
-            integer, intent(IN) :: j, k, l
-            integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-            type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-            real(kind(0d0)) :: eta !<
+            integer, intent(in) :: patch_id
+            integer, intent(in) :: j, k, l
+            real(kind(0d0)), intent(in) :: eta 
+            type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+            integer, dimension(0:m, 0:n, 0:p), intent(inout):: patch_id_fp
 
         end subroutine s_assign_patch_xxxxx_primitive_variables
 
@@ -92,14 +92,13 @@ contains
         !! @param l  the z-dir node index
     subroutine s_assign_patch_mixture_primitive_variables(patch_id, j, k, l, &
                                                           eta, q_prim_vf, patch_id_fp)
-
         !$acc routine seq
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: eta !<
 
-        integer, intent(IN) :: j, k, l
+        integer, intent(in) :: patch_id
+        integer, intent(in) :: j, k, l
+        real(kind(0d0)), intent(in) :: eta 
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
 
         real(kind(0d0)) :: rho    !< density
         real(kind(0d0)), dimension(int(E_idx - mom_idx%beg)) :: vel    !< velocity
@@ -157,8 +156,9 @@ contains
     !Stable perturbation in pressure (Ando)
     subroutine s_perturb_primitive(j, k, l, q_prim_vf)
 
-        type(scalar_field), dimension(1:sys_size), intent(INOUT) :: q_prim_vf
-        integer, intent(IN) :: j, k, l
+        integer, intent(in) :: j, k, l
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+        
 
         integer :: i
         real(kind(0d0)) :: pres_mag, loc, n_tait, B_tait, p0
@@ -238,22 +238,22 @@ contains
         !! @param l  the z-dir node index
     subroutine s_assign_patch_species_primitive_variables(patch_id, j, k, l, &
                                                           eta, q_prim_vf, patch_id_fp)
-
         !$acc routine seq
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: eta !<
-        integer, intent(IN) :: j, k, l
+
+        integer, intent(in) :: patch_id
+        integer, intent(in) :: j, k, l
+        real(kind(0d0)), intent(in) :: eta 
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         ! Density, the specific heat ratio function and the liquid stiffness
         ! function, respectively, obtained from the combination of primitive
         ! variables of the current and smoothing patches
-        real(kind(0d0)) :: rho          !< density
-        real(kind(0d0)) :: gamma
-        real(kind(0d0)) :: lit_gamma    !< specific heat ratio
-        real(kind(0d0)) :: pi_inf       !< stiffness from SEOS
-        real(kind(0d0)) :: qv       !< reference energy from SEOS
+        real(kind(0d0)) :: rho         !< density
+        real(kind(0d0)) :: gamma 
+        real(kind(0d0)) :: lit_gamma   !< specific heat ratio
+        real(kind(0d0)) :: pi_inf      !< stiffness from SEOS
+        real(kind(0d0)) :: qv          !< reference energy from SEOS
         real(kind(0d0)) :: orig_rho
         real(kind(0d0)) :: orig_gamma
         real(kind(0d0)) :: orig_pi_inf

--- a/src/pre_process/m_check_ib_patches.fpp
+++ b/src/pre_process/m_check_ib_patches.fpp
@@ -31,8 +31,6 @@ contains
 
     subroutine s_check_ib_patches()
 
-        ! integer, intent(in) :: i
-
         integer :: i
 
         do i = 1, num_patches_max
@@ -76,7 +74,8 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_circle_ib_patch_geometry(patch_id) ! -------------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
+
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the circle patch
@@ -96,7 +95,8 @@ contains
 
     subroutine s_check_airfoil_ib_patch_geometry(patch_id) ! -------------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
+
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the circle patch
@@ -115,7 +115,8 @@ contains
 
     subroutine s_check_3d_airfoil_ib_patch_geometry(patch_id) ! -------------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
+
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the circle patch
@@ -139,7 +140,8 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_rectangle_ib_patch_geometry(patch_id) ! ----------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
+
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the rectangle patch
@@ -167,7 +169,8 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_sphere_ib_patch_geometry(patch_id) ! ----------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
+
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the rectangle patch
@@ -195,8 +198,8 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_cylinder_ib_patch_geometry(patch_id) ! -----------------
 
-        ! Patch identifier
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
+
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the cylinder patch
@@ -239,7 +242,8 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_inactive_ib_patch_geometry(patch_id) ! -----------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
+        
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the inactive patch

--- a/src/pre_process/m_check_ib_patches.fpp
+++ b/src/pre_process/m_check_ib_patches.fpp
@@ -23,13 +23,14 @@ module m_check_ib_patches
 
     implicit none
 
-    private; public :: s_check_ib_patches
+    private; 
+    public :: s_check_ib_patches
 
     character(len=10) :: iStr
 
 contains
 
-    subroutine s_check_ib_patches()
+    subroutine s_check_ib_patches
 
         integer :: i
 
@@ -93,13 +94,17 @@ contains
 
     end subroutine s_check_circle_ib_patch_geometry ! -------------------------
 
+    !>  This subroutine verifies that the geometric parameters of
+        !!      the airfoil patch have consistently been inputted by the
+        !!      user.
+        !!  @param patch_id Patch identifier
     subroutine s_check_airfoil_ib_patch_geometry(patch_id) ! -------------------
 
         integer, intent(in) :: patch_id
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the circle patch
+        ! Constraints on the geometric parameters of the airfoil patch
         if (n == 0 .or. p > 0 .or. patch_ib(patch_id)%c <= 0d0 &
             .or. patch_ib(patch_id)%p <= 0d0 .or. patch_ib(patch_id)%t <= 0d0 &
             .or. patch_ib(patch_id)%m <= 0d0 .or. patch_ib(patch_id)%x_centroid == dflt_real &
@@ -113,13 +118,17 @@ contains
 
     end subroutine s_check_airfoil_ib_patch_geometry ! -------------------------
 
+    !>  This subroutine verifies that the geometric parameters of
+        !!      the 3d airfoil patch have consistently been inputted by the
+        !!      user.
+        !!  @param patch_id Patch identifier
     subroutine s_check_3d_airfoil_ib_patch_geometry(patch_id) ! -------------------
 
         integer, intent(in) :: patch_id
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the circle patch
+        ! Constraints on the geometric parameters of the 3d airfoil patch
         if (n == 0 .or. p == 0 .or. patch_ib(patch_id)%c <= 0d0 &
             .or. patch_ib(patch_id)%p <= 0d0 .or. patch_ib(patch_id)%t <= 0d0 &
             .or. patch_ib(patch_id)%m <= 0d0 .or. patch_ib(patch_id)%x_centroid == dflt_real &
@@ -173,7 +182,7 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the rectangle patch
+        ! Constraints on the geometric parameters of the sphere patch
         if (n == 0 .or. p == 0 &
             .or. &
             patch_ib(patch_id)%x_centroid == dflt_real &
@@ -243,7 +252,7 @@ contains
     subroutine s_check_inactive_ib_patch_geometry(patch_id) ! -----------------
 
         integer, intent(in) :: patch_id
-        
+
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the inactive patch

--- a/src/pre_process/m_check_patches.fpp
+++ b/src/pre_process/m_check_patches.fpp
@@ -31,8 +31,6 @@ contains
 
     subroutine s_check_patches()
 
-        ! integer, intent(in) :: i
-
         integer :: i
 
         do i = 1, num_patches_max
@@ -145,7 +143,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_line_segment_patch_geometry(patch_id) ! -------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the line segment patch
@@ -169,7 +167,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_circle_patch_geometry(patch_id) ! -------------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the circle patch
@@ -193,7 +191,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_rectangle_patch_geometry(patch_id) ! ----------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the rectangle patch
@@ -221,7 +219,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_line_sweep_patch_geometry(patch_id) ! ---------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the line sweep patch
@@ -251,7 +249,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_ellipse_patch_geometry(patch_id) ! ------------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the ellipse patch
@@ -281,7 +279,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_2D_TaylorGreen_vortex_patch_geometry(patch_id) ! --------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the TaylorGreen vortex patch geometric parameters
@@ -311,7 +309,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_1D_analytical_patch_geometry(patch_id) ! ---------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the analytical patch
@@ -335,7 +333,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_2D_analytical_patch_geometry(patch_id) ! ---------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the analytical patch
@@ -361,7 +359,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_3D_analytical_patch_geometry(patch_id) ! ---------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the analytical patch
@@ -391,7 +389,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_sphere_patch_geometry(patch_id) ! -------------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the sphere patch
@@ -419,7 +417,8 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_spherical_harmonic_patch_geometry(patch_id) ! -------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
+
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the spherical harmonic patch
@@ -454,7 +453,7 @@ contains
     subroutine s_check_cuboid_patch_geometry(patch_id) ! -------------------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the cuboid patch
@@ -487,7 +486,7 @@ contains
     subroutine s_check_cylinder_patch_geometry(patch_id) ! -----------------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the cylinder patch
@@ -532,7 +531,7 @@ contains
     subroutine s_check_plane_sweep_patch_geometry(patch_id) ! --------------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the plane sweep patch
@@ -564,7 +563,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_ellipsoid_patch_geometry(patch_id) ! ----------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the ellipsoid patch
@@ -595,7 +594,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_inactive_patch_geometry(patch_id) ! -----------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the geometric parameters of the inactive patch
@@ -643,7 +642,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_active_patch_alteration_rights(patch_id) ! ----------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the alteration rights of an active patch
@@ -666,7 +665,7 @@ contains
     subroutine s_check_inactive_patch_alteration_rights(patch_id) ! --------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the alteration rights of an inactive patch
@@ -688,7 +687,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_supported_patch_smoothing(patch_id) ! ---------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the smoothing parameters of a supported patch
@@ -721,7 +720,7 @@ contains
     subroutine s_check_unsupported_patch_smoothing(patch_id) ! -------------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         ! call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the smoothing parameters of an unsupported patch
@@ -745,7 +744,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_active_patch_primitive_variables(patch_id) ! --------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the primitive variables of an active patch
@@ -806,7 +805,7 @@ contains
         !!  @param patch_id Patch identifier
     subroutine s_check_inactive_patch_primitive_variables(patch_id) ! ------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
         ! Constraints on the primitive variables of an inactive patch
@@ -834,7 +833,7 @@ contains
 
     subroutine s_check_model_geometry(patch_id) ! ------------------------------
 
-        integer, intent(IN) :: patch_id
+        integer, intent(in) :: patch_id
 
         logical :: file_exists
 

--- a/src/pre_process/m_check_patches.fpp
+++ b/src/pre_process/m_check_patches.fpp
@@ -29,7 +29,7 @@ module m_check_patches
 
 contains
 
-    subroutine s_check_patches()
+    subroutine s_check_patches
 
         integer :: i
 
@@ -412,7 +412,7 @@ contains
     end subroutine s_check_sphere_patch_geometry ! -------------------------
 
     !>  This subroutine verifies that the geometric parameters of
-        !!      the spherical harmonic  patch have consistently been
+        !!      the spherical harmonic patch have consistently been
         !!      inputted by the user.
         !!  @param patch_id Patch identifier
     subroutine s_check_spherical_harmonic_patch_geometry(patch_id) ! -------

--- a/src/pre_process/m_checker.f90
+++ b/src/pre_process/m_checker.f90
@@ -2,8 +2,6 @@
 !!@file m_checker.f90
 !!@brief Contains module m_checker
 
-#define UNSUPPORTED_MESSAGE(f, s) "Unsupported combination of values of " + f + " and " + s + "Exiting ..."
-
 !> @brief The purpose of the module is to check for compatible input files
 module m_checker
 

--- a/src/pre_process/m_checker.f90
+++ b/src/pre_process/m_checker.f90
@@ -19,7 +19,7 @@ module m_checker
 
 contains
 
-    subroutine s_check_inputs()
+    subroutine s_check_inputs
 
         integer :: bub_fac !< For allowing an extra fluid_pp if there are subgrid bubbles
         character(len=5) :: iStr !< for int to string conversion

--- a/src/pre_process/m_checker.f90
+++ b/src/pre_process/m_checker.f90
@@ -2,6 +2,8 @@
 !!@file m_checker.f90
 !!@brief Contains module m_checker
 
+#define UNSUPPORTED_MESSAGE(f, s) "Unsupported combination of values of " + f + " and " + s + "Exiting ..."
+
 !> @brief The purpose of the module is to check for compatible input files
 module m_checker
 
@@ -19,12 +21,10 @@ contains
 
     subroutine s_check_inputs()
 
-        integer :: bub_fac !<
-            !! For allowing an extra fluid_pp if there are subgrid bubbles
+        integer :: bub_fac !< For allowing an extra fluid_pp if there are subgrid bubbles
         character(len=5) :: iStr !< for int to string conversion
         integer :: i
-        logical :: dir_check !<
-            !! Logical variable used to test the existence of folders
+        logical :: dir_check !< Logical variable used to test the existence of folders
 
 #ifndef MFC_MPI
         if (parallel_io .eqv. .true.) then

--- a/src/pre_process/m_data_output.fpp
+++ b/src/pre_process/m_data_output.fpp
@@ -36,10 +36,10 @@ module m_data_output
     implicit none
 
     private; public :: s_write_serial_data_files, &
- s_write_parallel_data_files, &
- s_write_data_files, &
- s_initialize_data_output_module, &
- s_finalize_data_output_module
+                    s_write_parallel_data_files, &
+                    s_write_data_files, &
+                    s_initialize_data_output_module, &
+                    s_finalize_data_output_module
 
     abstract interface ! ===================================================
 
@@ -52,11 +52,11 @@ module m_data_output
             ! Conservative variables
             type(scalar_field), &
                 dimension(sys_size), &
-                intent(IN) :: q_cons_vf
+                intent(in) :: q_cons_vf
 
             ! IB markers
             type(integer_field), &
-                intent(IN) :: ib_markers
+                intent(in) :: ib_markers
 
         end subroutine s_write_abstract_data_files ! -------------------
     end interface ! ========================================================
@@ -77,11 +77,11 @@ contains
     subroutine s_write_serial_data_files(q_cons_vf, ib_markers) ! -----------
         type(scalar_field), &
             dimension(sys_size), &
-            intent(IN) :: q_cons_vf
+            intent(in) :: q_cons_vf
 
         ! IB markers
         type(integer_field), &
-            intent(IN) :: ib_markers
+            intent(in) :: ib_markers
 
         logical :: file_exist !< checks if file exists
 
@@ -471,11 +471,11 @@ contains
         ! Conservative variables
         type(scalar_field), &
             dimension(sys_size), &
-            intent(IN) :: q_cons_vf
+            intent(in) :: q_cons_vf
 
         ! IB markers
         type(integer_field), &
-            intent(IN) :: ib_markers
+            intent(in) :: ib_markers
 
 #ifdef MFC_MPI
 

--- a/src/pre_process/m_data_output.fpp
+++ b/src/pre_process/m_data_output.fpp
@@ -35,16 +35,18 @@ module m_data_output
 
     implicit none
 
-    private; public :: s_write_serial_data_files, &
-                    s_write_parallel_data_files, &
-                    s_write_data_files, &
-                    s_initialize_data_output_module, &
-                    s_finalize_data_output_module
+    private; 
+    public :: s_write_serial_data_files, &
+              s_write_parallel_data_files, &
+              s_write_data_files, &
+              s_initialize_data_output_module, &
+              s_finalize_data_output_module
 
     abstract interface ! ===================================================
 
         !>  Interface for the conservative data
-        !! @param q_cons_vf The conservative variables
+        !! @param q_cons_vf Conservative variables
+        !! @param ib_markers track if a cell is within the immersed boundary
         subroutine s_write_abstract_data_files(q_cons_vf, ib_markers)
 
             import :: scalar_field, integer_field, sys_size, m, n, p, pres_field
@@ -73,7 +75,8 @@ contains
 
     !>  Writes grid and initial condition data files to the "0"
         !!  time-step directory in the local processor rank folder
-        !! @param q_cons_vf The conservative variables
+        !! @param q_cons_vf Conservative variables
+        !! @param ib_markers track if a cell is within the immersed boundary
     subroutine s_write_serial_data_files(q_cons_vf, ib_markers) ! -----------
         type(scalar_field), &
             dimension(sys_size), &
@@ -465,7 +468,8 @@ contains
 
     !> Writes grid and initial condition data files in parallel to the "0"
         !!  time-step directory in the local processor rank folder
-        !! @param q_cons_vf The conservative variables
+        !! @param q_cons_vf Conservative variables
+        !! @param ib_markers track if a cell is within the immersed boundary
     subroutine s_write_parallel_data_files(q_cons_vf, ib_markers) ! --
 
         ! Conservative variables
@@ -714,7 +718,7 @@ contains
 
     !> Computation of parameters, allocation procedures, and/or
         !!              any other tasks needed to properly setup the module
-    subroutine s_initialize_data_output_module() ! ----------------------------
+    subroutine s_initialize_data_output_module ! ----------------------------
         ! Generic string used to store the address of a particular file
         character(LEN=len_trim(case_dir) + 2*name_len) :: file_loc
 
@@ -778,7 +782,7 @@ contains
     end subroutine s_initialize_data_output_module ! --------------------------
 
     !> Resets s_write_data_files pointer
-    subroutine s_finalize_data_output_module() ! ---------------------------
+    subroutine s_finalize_data_output_module ! ---------------------------
 
         s_write_data_files => null()
 

--- a/src/pre_process/m_global_parameters.fpp
+++ b/src/pre_process/m_global_parameters.fpp
@@ -19,32 +19,30 @@ module m_global_parameters
     implicit none
 
     ! Logistics ================================================================
-    integer :: num_procs            !< Number of processors
-    character(LEN=path_len) :: case_dir             !< Case folder location
-    logical :: old_grid             !< Use existing grid data
-    logical :: old_ic               !< Use existing IC data
-    integer :: t_step_old, t_step_start           !< Existing IC/grid folder
+    integer :: num_procs                 !< Number of processors
+    character(LEN=path_len) :: case_dir  !< Case folder location
+    logical :: old_grid                  !< Use existing grid data
+    logical :: old_ic                    !< Use existing IC data
+    integer :: t_step_old, t_step_start  !< Existing IC/grid folder
     ! ==========================================================================
 
     ! Computational Domain Parameters ==========================================
 
     integer :: proc_rank !< Rank of the local processor
 
+    !! Number of cells in the x-, y- and z-coordinate directions
     integer :: m
     integer :: n
-    integer :: p !<
-    !! Number of cells in the x-, y- and z-coordinate directions
+    integer :: p 
 
-    integer(8) :: nGlobal ! Global number of cells in the domain
+    integer(8) :: nGlobal !< Global number of cells in the domain
 
-    integer :: m_glb, n_glb, p_glb !<
-    !! Global number of cells in each direction
+    integer :: m_glb, n_glb, p_glb !< Global number of cells in each direction
 
     integer :: num_dims !< Number of spatial dimensions
 
     logical :: cyl_coord
-    integer :: grid_geometry !<
-    !! Cylindrical coordinates (either axisymmetric or full 3D)
+    integer :: grid_geometry !< Cylindrical coordinates (either axisymmetric or full 3D)
 
     real(kind(0d0)), allocatable, dimension(:) :: x_cc, y_cc, z_cc !<
     !! Locations of cell-centers (cc) in x-, y- and z-directions, respectively
@@ -73,31 +71,31 @@ module m_global_parameters
     ! ==========================================================================
 
     ! Simulation Algorithm Parameters ==========================================
-    integer :: model_eqns      !< Multicomponent flow model
-    logical :: relax           !< activate phase change
-    integer :: relax_model     !< Relax Model
-    real(kind(0d0)) :: palpha_eps     !< trigger parameter for the p relaxation procedure, phase change model
-    real(kind(0d0)) :: ptgalpha_eps   !< trigger parameter for the pTg relaxation procedure, phase change model
-    integer :: num_fluids      !< Number of different fluids present in the flow
-    logical :: adv_alphan      !< Advection of the last volume fraction
-    logical :: mpp_lim         !< Alpha limiter
-    integer :: sys_size        !< Number of unknowns in the system of equations
-    integer :: weno_order      !< Order of accuracy for the WENO reconstruction
-    logical :: hypoelasticity  !< activate hypoelasticity
+    integer :: model_eqns            !< Multicomponent flow model
+    logical :: relax                 !< activate phase change
+    integer :: relax_model           !< Relax Model
+    real(kind(0d0)) :: palpha_eps    !< trigger parameter for the p relaxation procedure, phase change model
+    real(kind(0d0)) :: ptgalpha_eps  !< trigger parameter for the pTg relaxation procedure, phase change model
+    integer :: num_fluids            !< Number of different fluids present in the flow
+    logical :: adv_alphan            !< Advection of the last volume fraction
+    logical :: mpp_lim               !< Alpha limiter
+    integer :: sys_size              !< Number of unknowns in the system of equations
+    integer :: weno_order            !< Order of accuracy for the WENO reconstruction
+    logical :: hypoelasticity        !< activate hypoelasticity
 
     ! Annotations of the structure, i.e. the organization, of the state vectors
-    type(int_bounds_info) :: cont_idx                   !< Indexes of first & last continuity eqns.
-    type(int_bounds_info) :: mom_idx                    !< Indexes of first & last momentum eqns.
-    integer :: E_idx                      !< Index of total energy equation
-    integer :: alf_idx                    !< Index of void fraction
-    integer :: n_idx                      !< Index of number density
-    type(int_bounds_info) :: adv_idx                    !< Indexes of first & last advection eqns.
-    type(int_bounds_info) :: internalEnergies_idx       !< Indexes of first & last internal energy eqns.
-    type(bub_bounds_info) :: bub_idx                    !< Indexes of first & last bubble variable eqns.
-    integer :: gamma_idx                  !< Index of specific heat ratio func. eqn.
-    integer :: pi_inf_idx                 !< Index of liquid stiffness func. eqn.
-    type(int_bounds_info) :: stress_idx                 !< Indexes of elastic shear stress eqns.
-    integer :: c_idx            !< Index of the color function
+    type(int_bounds_info) :: cont_idx              !< Indexes of first & last continuity eqns.
+    type(int_bounds_info) :: mom_idx               !< Indexes of first & last momentum eqns.
+    integer :: E_idx                               !< Index of total energy equation
+    integer :: alf_idx                             !< Index of void fraction
+    integer :: n_idx                               !< Index of number density
+    type(int_bounds_info) :: adv_idx               !< Indexes of first & last advection eqns.
+    type(int_bounds_info) :: internalEnergies_idx  !< Indexes of first & last internal energy eqns.
+    type(bub_bounds_info) :: bub_idx               !< Indexes of first & last bubble variable eqns.
+    integer :: gamma_idx                           !< Index of specific heat ratio func. eqn.
+    integer :: pi_inf_idx                          !< Index of liquid stiffness func. eqn.
+    type(int_bounds_info) :: stress_idx            !< Indexes of elastic shear stress eqns.
+    integer :: c_idx                               !< Index of the color function
 
     type(int_bounds_info) :: bc_x, bc_y, bc_z !<
     !! Boundary conditions in the x-, y- and z-coordinate directions
@@ -230,7 +228,7 @@ contains
     !>  Assigns default values to user inputs prior to reading
         !!              them in. This allows for an easier consistency check of
         !!              these parameters once they are read from the input file.
-    subroutine s_assign_default_values_to_user_inputs() ! ------------------
+    subroutine s_assign_default_values_to_user_inputs ! ------------------
 
         integer :: i !< Generic loop operator
 
@@ -433,7 +431,7 @@ contains
 
     !> Computation of parameters, allocation procedures, and/or
         !! any other tasks needed to properly setup the module
-    subroutine s_initialize_global_parameters_module() ! ----------------------
+    subroutine s_initialize_global_parameters_module ! ----------------------
 
         integer :: i, j, fac
 
@@ -734,7 +732,7 @@ contains
 
     end subroutine s_initialize_global_parameters_module ! --------------------
 
-    subroutine s_initialize_parallel_io() ! --------------------------------
+    subroutine s_initialize_parallel_io ! --------------------------------
 
         num_dims = 1 + min(1, n) + min(1, p)
 

--- a/src/pre_process/m_global_parameters.fpp
+++ b/src/pre_process/m_global_parameters.fpp
@@ -33,7 +33,7 @@ module m_global_parameters
     !! Number of cells in the x-, y- and z-coordinate directions
     integer :: m
     integer :: n
-    integer :: p 
+    integer :: p
 
     integer(8) :: nGlobal !< Global number of cells in the domain
 

--- a/src/pre_process/m_grid.f90
+++ b/src/pre_process/m_grid.f90
@@ -28,11 +28,12 @@ module m_grid
 
     implicit none
 
-    private; public :: s_initialize_grid_module, &
-                    s_generate_grid, &
-                    s_generate_serial_grid, &
-                    s_generate_parallel_grid, &
-                    s_finalize_grid_module
+    private; 
+    public :: s_initialize_grid_module, &
+              s_generate_grid, &
+              s_generate_serial_grid, &
+              s_generate_parallel_grid, &
+              s_finalize_grid_module
 
     abstract interface ! ===================================================
 

--- a/src/pre_process/m_grid.f90
+++ b/src/pre_process/m_grid.f90
@@ -29,14 +29,14 @@ module m_grid
     implicit none
 
     private; public :: s_initialize_grid_module, &
- s_generate_grid, &
- s_generate_serial_grid, &
- s_generate_parallel_grid, &
- s_finalize_grid_module
+                    s_generate_grid, &
+                    s_generate_serial_grid, &
+                    s_generate_parallel_grid, &
+                    s_finalize_grid_module
 
     abstract interface ! ===================================================
 
-        subroutine s_generate_abstract_grid() ! ------------------------
+        subroutine s_generate_abstract_grid ! ------------------------
 
             ! integer, intent(IN), optional :: dummy
 
@@ -53,10 +53,10 @@ contains
         !!              inputted by the user. The grid information is stored in
         !!              the grid variables containing coordinates of the cell-
         !!              centers and cell-boundaries.
-    subroutine s_generate_serial_grid() ! -----------------------------------------
+    subroutine s_generate_serial_grid ! -----------------------------------------
 
         ! Generic loop iterator
-        integer :: i, j              !< generic loop operatorss
+        integer :: i, j             !< generic loop operatorss
         real(kind(0d0)) :: length   !< domain lengths
 
         ! Grid Generation in the x-direction ===============================
@@ -195,7 +195,7 @@ contains
         !!              inputted by the user. The grid information is stored in
         !!              the grid variables containing coordinates of the cell-
         !!              centers and cell-boundaries.
-    subroutine s_generate_parallel_grid() !-------------------------
+    subroutine s_generate_parallel_grid !-------------------------
 
 #ifdef MFC_MPI
 
@@ -344,7 +344,7 @@ contains
 
     !> Computation of parameters, allocation procedures, and/or
         !!              any other tasks needed to properly setup the module
-    subroutine s_initialize_grid_module() ! -----------------------------------
+    subroutine s_initialize_grid_module ! -----------------------------------
 
         if (parallel_io .neqv. .true.) then
             s_generate_grid => s_generate_serial_grid
@@ -355,7 +355,7 @@ contains
     end subroutine s_initialize_grid_module ! ---------------------------------
 
     !> Deallocation procedures for the module
-    subroutine s_finalize_grid_module() ! --------------------------------
+    subroutine s_finalize_grid_module ! --------------------------------
 
         s_generate_grid => null()
 

--- a/src/pre_process/m_initial_condition.fpp
+++ b/src/pre_process/m_initial_condition.fpp
@@ -462,7 +462,7 @@ contains
         ! THESE VARIABLES ARE UNUSED WITHIN THE FUNCTION
         real(kind(0d0)) :: tr, ti !< most unstable eigenvalue
         real(kind(0d0)), dimension(5, 0:m, 0:n, 0:p), intent(out) :: wave !< instability wave
-        real(kind(0d0)), intent(in):: shift !< phase shift
+        real(kind(0d0)), intent(in) :: shift !< phase shift
 
         real(kind(0d0)), dimension(0:n) :: rho_mean, u_mean !<  mean density and velocity profiles
         real(kind(0d0)) :: p_mean !< mean pressure profile

--- a/src/pre_process/m_initial_condition.fpp
+++ b/src/pre_process/m_initial_condition.fpp
@@ -62,7 +62,7 @@ contains
 
     !> Computation of parameters, allocation procedures, and/or
         !!              any other tasks needed to properly setup the module
-    subroutine s_initialize_initial_condition_module() ! -------------------
+    subroutine s_initialize_initial_condition_module ! -------------------
 
         integer :: i !< generic loop iterator
 
@@ -115,7 +115,7 @@ contains
         !!              on the grid using the primitive variables included with
         !!              the patch parameters. The subroutine is complete once the
         !!              primitive variables are converted to conservative ones.
-    subroutine s_generate_initial_condition() ! ----------------------------
+    subroutine s_generate_initial_condition ! ----------------------------
 
         integer :: i  !< Generic loop operator
 
@@ -322,7 +322,7 @@ contains
 
     end subroutine s_generate_initial_condition ! --------------------------
 
-    subroutine s_perturb_sphere() ! ----------------------------------------
+    subroutine s_perturb_sphere ! ----------------------------------------
 
         integer :: i, j, k, l !< generic loop operators
 
@@ -354,7 +354,7 @@ contains
 
     end subroutine s_perturb_sphere ! --------------------------------------
 
-    subroutine s_perturb_surrounding_flow() ! ------------------------------
+    subroutine s_perturb_surrounding_flow ! ------------------------------
 
         integer :: i, j, k, l !<  generic loop iterators
 
@@ -394,7 +394,7 @@ contains
         !!              instability waves with spatial wavenumbers, (4,0), (2,0),
         !!              and (1,0) are superposed. For a 3D waves, (4,4), (4,-4),
         !!              (2,2), (2,-2), (1,1), (1,-1) areadded on top of 2D waves.
-    subroutine s_superposition_instability_wave() ! ------------------------
+    subroutine s_superposition_instability_wave ! ------------------------
         real(kind(0d0)), dimension(5, 0:m, 0:n, 0:p) :: wave, wave1, wave2, wave_tmp
         real(kind(0d0)) :: tr, ti
         real(kind(0d0)) :: Lx, Lz
@@ -459,6 +459,11 @@ contains
         !!              (See Sandham 1989 PhD thesis for details).
     subroutine s_instability_wave(alpha, beta, tr, ti, wave, shift)
         real(kind(0d0)), intent(in) :: alpha, beta !<  spatial wavenumbers
+        ! THESE VARIABLES ARE UNUSED WITHIN THE FUNCTION
+        real(kind(0d0)) :: tr, ti !< most unstable eigenvalue
+        real(kind(0d0)), dimension(5, 0:m, 0:n, 0:p), intent(out) :: wave !< instability wave
+        real(kind(0d0)), intent(in):: shift !< phase shift
+
         real(kind(0d0)), dimension(0:n) :: rho_mean, u_mean !<  mean density and velocity profiles
         real(kind(0d0)) :: p_mean !< mean pressure profile
         real(kind(0d0)), dimension(0:n) :: drho_mean, du_mean, dt_mean !< y-derivatives of mean profiles
@@ -468,10 +473,7 @@ contains
         real(kind(0d0)), dimension(0:5*(n + 1) - 1, 0:5*(n + 1) - 1) :: zr, zi !< eigenvectors
         real(kind(0d0)), dimension(0:5*(n + 1) - 1) :: wr, wi !< eigenvalues
         real(kind(0d0)), dimension(0:5*(n + 1) - 1) :: fv1, fv2, fv3 !< temporary memory
-        real(kind(0d0)) :: tr, ti !< most unstable eigenvalue
         real(kind(0d0)), dimension(0:5*(n + 1) - 1) :: vr, vi, vnr, vni !< most unstable eigenvector and normalized one
-        real(kind(0d0)), dimension(5, 0:m, 0:n, 0:p) :: wave !< instability wave
-        real(kind(0d0)) :: shift !< phase shift
         real(kind(0d0)) :: gam, pi_inf, rho1, mach, c1
         integer :: ierr
         integer :: j, k, l !<  generic loop iterators
@@ -572,13 +574,14 @@ contains
         !!              eigenvalue and corresponding eigenvector among the
         !!              given set of eigenvalues and eigenvectors.
     subroutine s_generate_wave(nl, wr, wi, zr, zi, alpha, beta, wave, shift)
-        integer nl
-        real(kind(0d0)), dimension(0:nl - 1) :: wr, wi !< eigenvalues
-        real(kind(0d0)), dimension(0:nl - 1, 0:nl - 1) :: zr, zi !< eigenvectors
+        integer, intent(in) :: nl
+        real(kind(0d0)), dimension(0:nl - 1), intent(in) :: wr, wi !< eigenvalues
+        real(kind(0d0)), dimension(0:nl - 1, 0:nl - 1), intent(in) :: zr, zi !< eigenvectors
+        real(kind(0d0)), intent(in) :: alpha, beta, shift
+
         real(kind(0d0)), dimension(0:nl - 1) :: vr, vi, vnr, vni !< most unstable eigenvector
         real(kind(0d0)), dimension(5, 0:m, 0:n, 0:p) :: wave
-        real(kind(0d0)) :: alpha, beta, ang, shift
-        real(kind(0d0)) :: norm
+        real(kind(0d0)) :: norm, ang
         real(kind(0d0)) :: tr, ti, cr, ci !< temporary memory
         integer idx
         integer i, j, k
@@ -635,7 +638,7 @@ contains
     end subroutine s_generate_wave
 
     !>  Deallocation procedures for the module
-    subroutine s_finalize_initial_condition_module() ! ---------------------
+    subroutine s_finalize_initial_condition_module ! ---------------------
 
         integer :: i !< Generic loop iterator
 

--- a/src/pre_process/m_model.fpp
+++ b/src/pre_process/m_model.fpp
@@ -22,6 +22,8 @@ module m_model
 contains
 
     !> This procedure reads a binary STL file.
+    !! @param filepath Path to the STL file.
+    !! @param model The binary of the STL file.
     subroutine s_read_stl_binary(filepath, model)
 
         character(LEN=*), intent(in) :: filepath
@@ -69,6 +71,8 @@ contains
     end subroutine s_read_stl_binary
 
     !> This procedure reads an ASCII STL file.
+    !! @param filepath Path to the STL file.
+    !! @param model the STL file.
     subroutine s_read_stl_ascii(filepath, model)
 
         character(LEN=*), intent(in) :: filepath
@@ -148,6 +152,8 @@ contains
     end subroutine s_read_stl_ascii
 
     !> This procedure reads an STL file.
+    !! @param filepath Path to the STL file.
+    !! @param model the STL file.
     subroutine s_read_stl(filepath, model)
 
         character(LEN=*), intent(in) :: filepath
@@ -180,6 +186,8 @@ contains
     end subroutine
 
     !> This procedure reads an OBJ file.
+    !! @param filepath Path to the odj file.
+    !! @param model The obj file.
     subroutine s_read_obj(filepath, model)
 
         character(LEN=*), intent(in) :: filepath
@@ -276,6 +284,8 @@ contains
     end function f_model_read
 
     !> This procedure writes a binary STL file.
+    !! @param filepath Path to the STL file.
+    !! @param model STL to write
     subroutine s_write_stl(filepath, model)
 
         character(LEN=*), intent(in) :: filepath
@@ -324,6 +334,8 @@ contains
     end subroutine s_write_stl
 
     !> This procedure writes an OBJ file.
+    !! @param filepath Path to the obj file.
+    !! @param model obj to write.
     subroutine s_write_obj(filepath, model)
 
         character(LEN=*), intent(in) :: filepath

--- a/src/pre_process/m_model.fpp
+++ b/src/pre_process/m_model.fpp
@@ -24,8 +24,8 @@ contains
     !> This procedure reads a binary STL file.
     subroutine s_read_stl_binary(filepath, model)
 
-        character(LEN=*), intent(IN) :: filepath
-        type(t_model), intent(OUT) :: model
+        character(LEN=*), intent(in) :: filepath
+        type(t_model), intent(out) :: model
 
         integer :: i, j, iunit, iostat
 
@@ -71,8 +71,8 @@ contains
     !> This procedure reads an ASCII STL file.
     subroutine s_read_stl_ascii(filepath, model)
 
-        character(LEN=*), intent(IN) :: filepath
-        type(t_model), intent(OUT) :: model
+        character(LEN=*), intent(in) :: filepath
+        type(t_model), intent(out) :: model
 
         integer :: i, j, iunit, iostat
 
@@ -150,8 +150,8 @@ contains
     !> This procedure reads an STL file.
     subroutine s_read_stl(filepath, model)
 
-        character(LEN=*), intent(IN) :: filepath
-        type(t_model), intent(OUT) :: model
+        character(LEN=*), intent(in) :: filepath
+        type(t_model), intent(out) :: model
 
         integer :: iunit, iostat
 
@@ -182,8 +182,8 @@ contains
     !> This procedure reads an OBJ file.
     subroutine s_read_obj(filepath, model)
 
-        character(LEN=*), intent(IN) :: filepath
-        type(t_model), intent(OUT) :: model
+        character(LEN=*), intent(in) :: filepath
+        type(t_model), intent(out) :: model
 
         integer :: i, j, k, l, iunit, iostat, nVertices
 
@@ -258,7 +258,7 @@ contains
     !! @return The model read from the file.
     function f_model_read(filepath) result(model)
 
-        character(LEN=*), intent(IN) :: filepath
+        character(LEN=*), intent(in) :: filepath
 
         type(t_model) :: model
 
@@ -278,8 +278,8 @@ contains
     !> This procedure writes a binary STL file.
     subroutine s_write_stl(filepath, model)
 
-        character(LEN=*), intent(IN) :: filepath
-        type(t_model), intent(IN) :: model
+        character(LEN=*), intent(in) :: filepath
+        type(t_model), intent(in) :: model
 
         integer :: i, j, iunit, iostat
 
@@ -326,8 +326,8 @@ contains
     !> This procedure writes an OBJ file.
     subroutine s_write_obj(filepath, model)
 
-        character(LEN=*), intent(IN) :: filepath
-        type(t_model), intent(IN) :: model
+        character(LEN=*), intent(in) :: filepath
+        type(t_model), intent(in) :: model
 
         integer :: iunit, iostat
 
@@ -360,11 +360,11 @@ contains
 
     !> This procedure writes a binary STL file.
     !! @param filepath  Path to the file to write.
-    !! @param triangles Triangles to write.
+    !! @param model Model to write.
     subroutine s_model_write(filepath, model)
 
-        character(LEN=*), intent(IN) :: filepath
-        type(t_model), intent(IN) :: model
+        character(LEN=*), intent(in) :: filepath
+        type(t_model), intent(in) :: model
 
         select case (filepath(len(trim(filepath)) - 3:len(trim(filepath))))
         case (".stl")
@@ -382,7 +382,7 @@ contains
     !> This procedure frees the memory allocated for an STL mesh.
     subroutine s_model_free(model)
 
-        type(t_model), intent(INOUT) :: model
+        type(t_model), intent(inout) :: model
 
         deallocate (model%trs)
 
@@ -390,10 +390,10 @@ contains
 
     function f_read_line(iunit, line) result(bIsLine)
 
-        integer, intent(IN) :: iunit
-        character(80), intent(OUT) :: line
-        logical :: bIsLine
+        integer, intent(in) :: iunit
+        character(80), intent(out) :: line
 
+        logical :: bIsLine
         integer :: iostat
 
         bIsLine = .true.
@@ -419,7 +419,7 @@ contains
 
     subroutine s_skip_ignored_lines(iunit)
 
-        integer, intent(IN) :: iunit
+        integer, intent(in) :: iunit
 
         character(80) :: line
 

--- a/src/pre_process/m_mpi_proxy.fpp
+++ b/src/pre_process/m_mpi_proxy.fpp
@@ -33,7 +33,7 @@ contains
         !!       these are not available to the remaining processors. This
         !!       subroutine is then in charge of broadcasting the required
         !!       information.
-    subroutine s_mpi_bcast_user_inputs() ! ---------------------------------
+    subroutine s_mpi_bcast_user_inputs ! ---------------------------------
 
 #ifdef MFC_MPI
 
@@ -119,7 +119,7 @@ contains
         !!             as well as recomputing some of the global parameters so
         !!              that they reflect the configuration of sub-domain that is
         !!              overseen by the local processor.
-    subroutine s_mpi_decompose_computational_domain() ! --------------------
+    subroutine s_mpi_decompose_computational_domain ! --------------------
 
 #ifdef MFC_MPI
 

--- a/src/pre_process/m_patches.fpp
+++ b/src/pre_process/m_patches.fpp
@@ -28,28 +28,29 @@ module m_patches
 
     implicit none
 
-    private; public :: s_line_segment, &
-                        s_spiral, &
-                        s_circle, &
-                        s_airfoil, &
-                        s_3D_airfoil, &
-                        s_varcircle, &
-                        s_3dvarcircle, &
-                        s_ellipse, &
-                        s_ellipsoid, &
-                        s_rectangle, &
-                        s_sweep_line, &
-                        s_2D_TaylorGreen_vortex, &
-                        s_1D_analytical, &
-                        s_1d_bubble_pulse, &
-                        s_2D_analytical, &
-                        s_3D_analytical, &
-                        s_spherical_harmonic, &
-                        s_sphere, &
-                        s_cuboid, &
-                        s_cylinder, &
-                        s_sweep_plane, &
-                        s_model
+    private; 
+    public :: s_line_segment, &
+              s_spiral, &
+              s_circle, &
+              s_airfoil, &
+              s_3D_airfoil, &
+              s_varcircle, &
+              s_3dvarcircle, &
+              s_ellipse, &
+              s_ellipsoid, &
+              s_rectangle, &
+              s_sweep_line, &
+              s_2D_TaylorGreen_vortex, &
+              s_1D_analytical, &
+              s_1d_bubble_pulse, &
+              s_2D_analytical, &
+              s_3D_analytical, &
+              s_spherical_harmonic, &
+              s_sphere, &
+              s_cuboid, &
+              s_cylinder, &
+              s_sweep_plane, &
+              s_model
 
     real(kind(0d0)) :: x_centroid, y_centroid, z_centroid
     real(kind(0d0)) :: length_x, length_y, length_z
@@ -88,6 +89,8 @@ contains
     !!              line segment patch DOES NOT allow for the smearing of its
     !!              boundaries.
     !! @param patch_id patch identifier
+    !! @param patch_id_fp Array to track patch ids
+    !! @param q_prim_vf Array of primitive variables
     subroutine s_line_segment(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------
 
         integer, intent(in) :: patch_id
@@ -143,7 +146,9 @@ contains
         !!              of the patch is well-defined when its centroid and radius
         !!              are provided. Note that the circular patch DOES allow for
         !!              the smoothing of its boundary.
-        !!  @param patch_id patch identifier
+        !! @param patch_id patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_spiral(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------------
 
         integer, intent(in) :: patch_id
@@ -207,12 +212,15 @@ contains
         !!              are provided. Note that the circular patch DOES allow for
         !!              the smoothing of its boundary.
         !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
+        !! @param ib True if this patch is an immersed boundary
     subroutine s_circle(patch_id, patch_id_fp, q_prim_vf, ib) ! ----------------------------------------
 
         integer, intent(in) :: patch_id
         integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
         type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
-        logical, intent(in) :: ib   !< True if this patch is an immersed boundary
+        logical, intent(in) :: ib
 
         real(kind(0d0)) :: radius
 
@@ -283,12 +291,16 @@ contains
 
     end subroutine s_circle ! ----------------------------------------------
 
+    !! @param patch_id is the patch identifier
+    !! @param patch_id_fp Array to track patch ids
+    !! @param q_prim_vf Array of primitive variables
+    !! @param ib True if this patch is an immersed boundary
     subroutine s_airfoil(patch_id, patch_id_fp, q_prim_vf, ib)
 
         integer, intent(in) :: patch_id
         integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
         type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
-        logical, intent(in) :: ib   !< True if this patch is an immersed boundary
+        logical, intent(in) :: ib
 
         real(kind(0d0)) :: x0, y0, f, x_act, y_act, ca, pa, ma, ta, theta, xa, ya, yt, xu, yu, xl, yl, xc, yc, dycdxc, sin_c, cos_c
         integer :: i, j, k, l
@@ -441,12 +453,16 @@ contains
 
     end subroutine s_airfoil
 
+    !! @param patch_id is the patch identifier
+    !! @param patch_id_fp Array to track patch ids
+    !! @param q_prim_vf Array of primitive variables
+    !! @param ib True if this patch is an immersed boundary
     subroutine s_3D_airfoil(patch_id, patch_id_fp, q_prim_vf, ib)
 
         integer, intent(in) :: patch_id
         integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
         type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
-        logical, intent(in) :: ib   !< True if this patch is an immersed boundary
+        logical, intent(in) :: ib
 
         real(kind(0d0)) :: x0, y0, z0, lz, z_max, z_min, f, x_act, y_act, ca, pa, ma, ta, theta, xa, ya, yt, xu, yu, xl, yl, xc, yc, dycdxc, sin_c, cos_c
         integer :: i, j, k, l
@@ -608,9 +624,11 @@ contains
 
     end subroutine s_3D_airfoil
 
-    !>             The varcircle patch is a 2D geometry that may be used
+    !>  The varcircle patch is a 2D geometry that may be used
         !!             . It  generatres an annulus
         !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_varcircle(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------------
 
         ! Patch identifier
@@ -666,6 +684,9 @@ contains
 
     end subroutine s_varcircle ! ----------------------------------------------
 
+    !! @param patch_id is the patch identifier
+    !! @param patch_id_fp Array to track patch ids
+    !! @param q_prim_vf Array of primitive variables
     subroutine s_3dvarcircle(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------------
 
         ! Patch identifier
@@ -727,11 +748,13 @@ contains
 
     end subroutine s_3dvarcircle ! ----------------------------------------------
 
-    !>      The elliptical patch is a 2D geometry. The geometry of
+    !> The elliptical patch is a 2D geometry. The geometry of
         !!      the patch is well-defined when its centroid and radii
         !!      are provided. Note that the elliptical patch DOES allow
         !!      for the smoothing of its boundary
         !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_ellipse(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------------
 
         integer, intent(in) :: patch_id
@@ -791,11 +814,13 @@ contains
 
     end subroutine s_ellipse ! ---------------------------------------------
 
-    !>      The ellipsoidal patch is a 3D geometry. The geometry of
+    !> The ellipsoidal patch is a 3D geometry. The geometry of
         !!       the patch is well-defined when its centroid and radii
         !!       are provided. Note that the ellipsoidal patch DOES allow
         !!       for the smoothing of its boundary
         !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_ellipsoid(patch_id, patch_id_fp, q_prim_vf) ! -------------------------------------
 
         ! Patch identifier
@@ -870,7 +895,7 @@ contains
 
     end subroutine s_ellipsoid ! -------------------------------------------
 
-    !>      The rectangular patch is a 2D geometry that may be used,
+    !> The rectangular patch is a 2D geometry that may be used,
         !!              for example, in creating a solid boundary, or pre-/post-
         !!              shock region, in alignment with the axes of the Cartesian
         !!              coordinate system. The geometry of such a patch is well-
@@ -879,6 +904,9 @@ contains
         !!              rectangular patch DOES NOT allow for the smoothing of its
         !!              boundaries.
         !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
+        !! @param ib True if this patch is an immersed boundary
     subroutine s_rectangle(patch_id, patch_id_fp, q_prim_vf, ib) ! -------------------------------------
 
         integer, intent(in) :: patch_id
@@ -970,7 +998,7 @@ contains
 
     end subroutine s_rectangle ! -------------------------------------------
 
-    !>  The swept line patch is a 2D geometry that may be used,
+    !> The swept line patch is a 2D geometry that may be used,
         !!      for example, in creating a solid boundary, or pre-/post-
         !!      shock region, at an angle with respect to the axes of the
         !!      Cartesian coordinate system. The geometry of the patch is
@@ -978,6 +1006,8 @@ contains
         !!      in the sweep direction, are provided. Note that the sweep
         !!      line patch DOES allow the smoothing of its boundary.
         !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_sweep_line(patch_id, patch_id_fp, q_prim_vf) ! ------------------------------------
 
         integer, intent(in) :: patch_id
@@ -1041,6 +1071,8 @@ contains
         !!              Geometry of the patch is well-defined when its centroid
         !!              are provided.
         !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_2D_TaylorGreen_Vortex(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------
 
         integer, intent(in) :: patch_id
@@ -1114,7 +1146,9 @@ contains
 
     !>  This patch assigns the primitive variables as analytical
         !!  functions such that the code can be verified.
-        !!  @param patch_id is the patch identifier
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_1D_analytical(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------
 
         ! Patch identifier
@@ -1170,6 +1204,9 @@ contains
 
     end subroutine s_1D_analytical ! ---------------------------------------
 
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_1d_bubble_pulse(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------
         ! Description: This patch assigns the primitive variables as analytical
         !       functions such that the code can be verified.
@@ -1183,7 +1220,6 @@ contains
         integer :: i, j, k
         ! Placeholders for the cell boundary values
         real(kind(0d0)) :: fac, a, b, c, d, pi_inf, gamma, lit_gamma
-
 
         pi_inf = fluid_pp(1)%pi_inf
         gamma = fluid_pp(1)%gamma
@@ -1225,7 +1261,9 @@ contains
 
     !>  This patch assigns the primitive variables as analytical
         !!  functions such that the code can be verified.
-        !!  @param patch_id is the patch identifier
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_2D_analytical(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------
 
         integer, intent(in) :: patch_id
@@ -1290,9 +1328,11 @@ contains
 
     end subroutine s_2D_analytical ! ---------------------------------------
 
-    !>      This patch assigns the primitive variables as analytical
+    !> This patch assigns the primitive variables as analytical
         !!      functions such that the code can be verified.
-        !!      @param patch_id is the patch identifier
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_3D_analytical(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------
 
         integer, intent(in) :: patch_id
@@ -1372,9 +1412,11 @@ contains
 
     end subroutine s_3D_analytical ! ---------------------------------------
 
-    !>      This patch generates the shape of the spherical harmonics
+    !> This patch generates the shape of the spherical harmonics
         !!      as a perturbation to a perfect sphere
-        !!      @param patch_id is the patch identifier
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_spherical_harmonic(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------
 
         integer, intent(in) :: patch_id
@@ -1504,7 +1546,10 @@ contains
         !!              geometry is well-defined when its centroid and radius are
         !!              provided. Please note that the spherical patch DOES allow
         !!              for the smoothing of its boundary.
-        !!      @param patch_id is the patch identifier
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
+        !! @param ib True if this patch is an immersed boundary
     subroutine s_sphere(patch_id, patch_id_fp, q_prim_vf, ib) ! ----------------------------------------
 
         integer, intent(in) :: patch_id
@@ -1598,7 +1643,7 @@ contains
 
     end subroutine s_sphere ! ----------------------------------------------
 
-    !>      The cuboidal patch is a 3D geometry that may be used, for
+    !> The cuboidal patch is a 3D geometry that may be used, for
         !!              example, in creating a solid boundary, or pre-/post-shock
         !!              region, which is aligned with the axes of the Cartesian
         !!              coordinate system. The geometry of such a patch is well-
@@ -1606,7 +1651,9 @@ contains
         !!              z-coordinate directions are provided. Please notice that
         !!              the cuboidal patch DOES NOT allow for the smearing of its
         !!              boundaries.
-        !!      @param patch_id is the patch identifier
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
     subroutine s_cuboid(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------------
 
         integer, intent(in) :: patch_id
@@ -1678,7 +1725,7 @@ contains
 
     end subroutine s_cuboid ! ----------------------------------------------
 
-    !>              The cylindrical patch is a 3D geometry that may be used,
+    !> The cylindrical patch is a 3D geometry that may be used,
         !!              for example, in setting up a cylindrical solid boundary
         !!              confinement, like a blood vessel. The geometry of this
         !!              patch is well-defined when the centroid, the radius and
@@ -1686,7 +1733,10 @@ contains
         !!              y- or z-coordinate direction, are provided. Please note
         !!              that the cylindrical patch DOES allow for the smoothing
         !!              of its lateral boundary.
-        !!      @param patch_id is the patch identifier
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Array of primitive variables
+        !! @param ib True if this patch is an immersed boundary
     subroutine s_cylinder(patch_id, patch_id_fp, q_prim_vf, ib) ! --------------------------------------
 
         integer, intent(in) :: patch_id
@@ -1840,7 +1890,9 @@ contains
         !!              well-defined when its centroid and normal vector, aimed
         !!              in the sweep direction, are provided. Note that the sweep
         !!              plane patch DOES allow the smoothing of its boundary.
-        !!      @param patch_id is the patch identifier
+        !! @param patch_id is the patch identifier
+        !! @param patch_id_fp Array to track patch ids
+        !! @param q_prim_vf Primitive variables
     subroutine s_sweep_plane(patch_id, patch_id_fp, q_prim_vf) ! -----------------------------------
 
         integer, intent(in) :: patch_id
@@ -1849,7 +1901,7 @@ contains
 
         integer :: i, j, k !< Generic loop iterators
         real(kind(0d0)) :: a, b, c, d
-        
+
         ! Transferring the centroid information of the plane to be swept
         x_centroid = patch_icpp(patch_id)%x_centroid
         y_centroid = patch_icpp(patch_id)%y_centroid
@@ -1915,6 +1967,8 @@ contains
 
     !> The STL patch is a 2/3D geometry that is imported from an STL file.
     !! @param patch_id is the patch identifier
+    !! @param patch_id_fp Array to track patch ids
+    !! @param q_prim_vf Primitive variables
     subroutine s_model(patch_id, patch_id_fp, q_prim_vf) ! ---------------------
 
         integer, intent(in) :: patch_id

--- a/src/pre_process/m_patches.fpp
+++ b/src/pre_process/m_patches.fpp
@@ -29,27 +29,27 @@ module m_patches
     implicit none
 
     private; public :: s_line_segment, &
- s_spiral, &
- s_circle, &
- s_airfoil, &
- s_3D_airfoil, &
- s_varcircle, &
- s_3dvarcircle, &
- s_ellipse, &
- s_ellipsoid, &
- s_rectangle, &
- s_sweep_line, &
- s_2D_TaylorGreen_vortex, &
- s_1D_analytical, &
- s_1d_bubble_pulse, &
- s_2D_analytical, &
- s_3D_analytical, &
- s_spherical_harmonic, &
- s_sphere, &
- s_cuboid, &
- s_cylinder, &
- s_sweep_plane, &
- s_model
+                        s_spiral, &
+                        s_circle, &
+                        s_airfoil, &
+                        s_3D_airfoil, &
+                        s_varcircle, &
+                        s_3dvarcircle, &
+                        s_ellipse, &
+                        s_ellipsoid, &
+                        s_rectangle, &
+                        s_sweep_line, &
+                        s_2D_TaylorGreen_vortex, &
+                        s_1D_analytical, &
+                        s_1d_bubble_pulse, &
+                        s_2D_analytical, &
+                        s_3D_analytical, &
+                        s_spherical_harmonic, &
+                        s_sphere, &
+                        s_cuboid, &
+                        s_cylinder, &
+                        s_sweep_plane, &
+                        s_model
 
     real(kind(0d0)) :: x_centroid, y_centroid, z_centroid
     real(kind(0d0)) :: length_x, length_y, length_z
@@ -90,9 +90,9 @@ contains
     !! @param patch_id patch identifier
     subroutine s_line_segment(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         real(kind(0d0)) :: pi_inf, gamma, lit_gamma
 
@@ -146,9 +146,9 @@ contains
         !!  @param patch_id patch identifier
     subroutine s_spiral(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< Generic loop iterators
         real(kind(0d0)) :: th, thickness, nturns, mya
@@ -209,10 +209,11 @@ contains
         !! @param patch_id is the patch identifier
     subroutine s_circle(patch_id, patch_id_fp, q_prim_vf, ib) ! ----------------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        logical, intent(IN) :: ib   !< True if this patch is an immersed boundary
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+        logical, intent(in) :: ib   !< True if this patch is an immersed boundary
+
         real(kind(0d0)) :: radius
 
         integer :: i, j, k !< Generic loop iterators
@@ -284,10 +285,11 @@ contains
 
     subroutine s_airfoil(patch_id, patch_id_fp, q_prim_vf, ib)
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        logical, intent(IN) :: ib   !< True if this patch is an immersed boundary
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+        logical, intent(in) :: ib   !< True if this patch is an immersed boundary
+
         real(kind(0d0)) :: x0, y0, f, x_act, y_act, ca, pa, ma, ta, theta, xa, ya, yt, xu, yu, xl, yl, xc, yc, dycdxc, sin_c, cos_c
         integer :: i, j, k, l
         integer :: Np1, Np2
@@ -441,10 +443,11 @@ contains
 
     subroutine s_3D_airfoil(patch_id, patch_id_fp, q_prim_vf, ib)
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        logical, intent(IN) :: ib   !< True if this patch is an immersed boundary
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+        logical, intent(in) :: ib   !< True if this patch is an immersed boundary
+
         real(kind(0d0)) :: x0, y0, z0, lz, z_max, z_min, f, x_act, y_act, ca, pa, ma, ta, theta, xa, ya, yt, xu, yu, xl, yl, xc, yc, dycdxc, sin_c, cos_c
         integer :: i, j, k, l
         integer :: Np1, Np2
@@ -611,15 +614,13 @@ contains
     subroutine s_varcircle(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: radius
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         ! Generic loop iterators
         integer :: i, j, k
-
-        real(kind(0d0)) :: myr, thickness
+        real(kind(0d0)) :: radius, myr, thickness
 
         ! Transferring the circular patch's radius, centroid, smearing patch
         ! identity and smearing coefficient information
@@ -668,15 +669,13 @@ contains
     subroutine s_3dvarcircle(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: radius
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         ! Generic loop iterators
         integer :: i, j, k
-
-        real(kind(0d0)) :: myr, thickness
+        real(kind(0d0)) :: radius, myr, thickness
 
         ! Transferring the circular patch's radius, centroid, smearing patch
         ! identity and smearing coefficient information
@@ -735,12 +734,12 @@ contains
         !! @param patch_id is the patch identifier
     subroutine s_ellipse(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: a, b
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< Generic loop operators
+        real(kind(0d0)) :: a, b
 
         ! Transferring the elliptical patch's radii, centroid, smearing
         ! patch identity, and smearing coefficient information
@@ -800,13 +799,13 @@ contains
     subroutine s_ellipsoid(patch_id, patch_id_fp, q_prim_vf) ! -------------------------------------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: a, b, c
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         ! Generic loop iterators
         integer :: i, j, k
+        real(kind(0d0)) :: a, b, c
 
         ! Transferring the ellipsoidal patch's radii, centroid, smearing
         ! patch identity, and smearing coefficient information
@@ -882,14 +881,13 @@ contains
         !! @param patch_id is the patch identifier
     subroutine s_rectangle(patch_id, patch_id_fp, q_prim_vf, ib) ! -------------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-
-        real(kind(0d0)) :: pi_inf, gamma, lit_gamma !< Equation of state parameters
-        logical :: ib !< True if this patch is an immersed boundary
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+        logical, intent(in) :: ib !< True if this patch is an immersed boundary
 
         integer :: i, j, k !< generic loop iterators
+        real(kind(0d0)) :: pi_inf, gamma, lit_gamma !< Equation of state parameters
 
         pi_inf = fluid_pp(1)%pi_inf
         gamma = fluid_pp(1)%gamma
@@ -982,12 +980,12 @@ contains
         !! @param patch_id is the patch identifier
     subroutine s_sweep_line(patch_id, patch_id_fp, q_prim_vf) ! ------------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: a, b, c
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< Generic loop operators
+        real(kind(0d0)) :: a, b, c
 
         ! Transferring the centroid information of the line to be swept
         x_centroid = patch_icpp(patch_id)%x_centroid
@@ -1045,14 +1043,13 @@ contains
         !! @param patch_id is the patch identifier
     subroutine s_2D_TaylorGreen_Vortex(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-
-        real(kind(0d0)) :: pi_inf, gamma, lit_gamma !< equation of state parameters
-        real(kind(0d0)) :: L0, U0 !< Taylor Green Vortex parameters
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< generic loop iterators
+        real(kind(0d0)) :: pi_inf, gamma, lit_gamma !< equation of state parameters
+        real(kind(0d0)) :: L0, U0 !< Taylor Green Vortex parameters
 
         pi_inf = fluid_pp(1)%pi_inf
         gamma = fluid_pp(1)%gamma
@@ -1121,15 +1118,14 @@ contains
     subroutine s_1D_analytical(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-
-        ! Placeholders for the cell boundary values
-        real(kind(0d0)) :: a, b, c, d, pi_inf, gamma, lit_gamma
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         ! Generic loop iterators
         integer :: i, j, k
+        ! Placeholders for the cell boundary values
+        real(kind(0d0)) :: a, b, c, d, pi_inf, gamma, lit_gamma
 
         @:Hardcoded1DVariables()
 
@@ -1179,15 +1175,15 @@ contains
         !       functions such that the code can be verified.
 
         ! Patch identifier
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-
-        ! Placeholders for the cell boundary values
-        real(kind(0d0)) :: fac, a, b, c, d, pi_inf, gamma, lit_gamma
+        integer, intent(in) :: patch_id
+        integer, intent(inout), dimension(0:m, 0:n, 0:p) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         ! Generic loop iterators
         integer :: i, j, k
+        ! Placeholders for the cell boundary values
+        real(kind(0d0)) :: fac, a, b, c, d, pi_inf, gamma, lit_gamma
+
 
         pi_inf = fluid_pp(1)%pi_inf
         gamma = fluid_pp(1)%gamma
@@ -1232,15 +1228,14 @@ contains
         !!  @param patch_id is the patch identifier
     subroutine s_2D_analytical(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
+        integer :: i, j, k !< generic loop iterators
         real(kind(0d0)) :: a, b, c, d !< placeholderrs for the cell boundary values
         real(kind(0d0)) :: pi_inf, gamma, lit_gamma !< equation of state parameters
         real(kind(0d0)) :: l, U0 !< Taylor Green Vortex parameters
-
-        integer :: i, j, k !< generic loop iterators
 
         @:Hardcoded2DVariables()
 
@@ -1300,12 +1295,12 @@ contains
         !!      @param patch_id is the patch identifier
     subroutine s_3D_analytical(patch_id, patch_id_fp, q_prim_vf) ! ---------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: pi_inf, gamma, lit_gamma !< equation of state parameters
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< generic loop iterators
+        real(kind(0d0)) :: pi_inf, gamma, lit_gamma !< equation of state parameters
 
         @:Hardcoded3DVariables()
 
@@ -1382,15 +1377,12 @@ contains
         !!      @param patch_id is the patch identifier
     subroutine s_spherical_harmonic(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-
-        real(kind(0d0)) :: epsilon, beta
-        real(kind(0d0)) :: radius
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< generic loop iterators
-
+        real(kind(0d0)) :: radius, epsilon, beta
         complex(kind(0d0)) :: cmplx_i = (0d0, 1d0)
         complex(kind(0d0)) :: H
 
@@ -1515,14 +1507,14 @@ contains
         !!      @param patch_id is the patch identifier
     subroutine s_sphere(patch_id, patch_id_fp, q_prim_vf, ib) ! ----------------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        logical, intent(IN) :: ib   !< True if this patch is an immersed boundary
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: radius
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+        logical, intent(in) :: ib   !< True if this patch is an immersed boundary
 
         ! Generic loop iterators
         integer :: i, j, k !< generic loop iterators
+        real(kind(0d0)) :: radius
 
         real(kind(0d0)) :: radius_pressure, pressure_bubble, pressure_inf !<
             !! Variables to initialize the pressure field that corresponds to the
@@ -1617,9 +1609,9 @@ contains
         !!      @param patch_id is the patch identifier
     subroutine s_cuboid(patch_id, patch_id_fp, q_prim_vf) ! ----------------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< Generic loop iterators
 
@@ -1697,13 +1689,13 @@ contains
         !!      @param patch_id is the patch identifier
     subroutine s_cylinder(patch_id, patch_id_fp, q_prim_vf, ib) ! --------------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        logical, intent(IN) :: ib   !< True if this patch is an immersed boundary
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: radius
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
+        logical, intent(in) :: ib   !< True if this patch is an immersed boundary
 
         integer :: i, j, k !< Generic loop iterators
+        real(kind(0d0)) :: radius
 
         ! Transferring the cylindrical patch's centroid, length, radius,
         ! smoothing patch identity and smoothing coefficient information
@@ -1851,13 +1843,13 @@ contains
         !!      @param patch_id is the patch identifier
     subroutine s_sweep_plane(patch_id, patch_id_fp, q_prim_vf) ! -----------------------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
-        real(kind(0d0)) :: a, b, c, d
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< Generic loop iterators
-
+        real(kind(0d0)) :: a, b, c, d
+        
         ! Transferring the centroid information of the plane to be swept
         x_centroid = patch_icpp(patch_id)%x_centroid
         y_centroid = patch_icpp(patch_id)%y_centroid
@@ -1925,9 +1917,9 @@ contains
     !! @param patch_id is the patch identifier
     subroutine s_model(patch_id, patch_id_fp, q_prim_vf) ! ---------------------
 
-        integer, intent(IN) :: patch_id
-        integer, intent(INOUT), dimension(0:m, 0:n, 0:p) :: patch_id_fp
-        type(scalar_field), dimension(1:sys_size) :: q_prim_vf
+        integer, intent(in) :: patch_id
+        integer, dimension(0:m, 0:n, 0:p), intent(inout) :: patch_id_fp
+        type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         integer :: i, j, k !< Generic loop iterators
 
@@ -2033,7 +2025,7 @@ contains
     subroutine s_convert_cylindrical_to_cartesian_coord(cyl_y, cyl_z)
         !$acc routine seq
 
-        real(kind(0d0)), intent(IN) :: cyl_y, cyl_z
+        real(kind(0d0)), intent(in) :: cyl_y, cyl_z
 
         cart_y = cyl_y*sin(cyl_z)
         cart_z = cyl_y*cos(cyl_z)
@@ -2068,7 +2060,7 @@ contains
     !! @param a Starting position
     function f_r(myth, offset, a)
         !$acc routine seq
-        real(kind(0d0)), intent(IN) :: myth, offset, a
+        real(kind(0d0)), intent(in) :: myth, offset, a
         real(kind(0d0)) :: b
         real(kind(0d0)) :: f_r
 

--- a/src/pre_process/m_start_up.fpp
+++ b/src/pre_process/m_start_up.fpp
@@ -51,23 +51,23 @@ module m_start_up
     implicit none
 
     private; public :: s_read_input_file, &
- s_check_input_file, &
- s_read_grid_data_files, &
- s_read_ic_data_files, &
- s_read_serial_grid_data_files, &
- s_read_serial_ic_data_files, &
- s_read_parallel_grid_data_files, &
- s_read_parallel_ic_data_files, &
- s_check_grid_data_files, &
- s_initialize_modules, &
- s_initialize_mpi_domain, &
- s_finalize_modules, &
- s_apply_initial_condition, &
- s_save_data, s_read_grid
+        s_check_input_file, &
+        s_read_grid_data_files, &
+        s_read_ic_data_files, &
+        s_read_serial_grid_data_files, &
+        s_read_serial_ic_data_files, &
+        s_read_parallel_grid_data_files, &
+        s_read_parallel_ic_data_files, &
+        s_check_grid_data_files, &
+        s_initialize_modules, &
+        s_initialize_mpi_domain, &
+        s_finalize_modules, &
+        s_apply_initial_condition, &
+        s_save_data, s_read_grid
 
     abstract interface ! ===================================================
 
-        subroutine s_read_abstract_grid_data_files()! ----------
+        subroutine s_read_abstract_grid_data_files! ----------
 
         end subroutine s_read_abstract_grid_data_files ! ---------------
 
@@ -78,11 +78,11 @@ module m_start_up
             ! Conservative variables
             type(scalar_field), &
                 dimension(sys_size), &
-                intent(INOUT) :: q_cons_vf
+                intent(inout) :: q_cons_vf
 
             ! IB markers
             type(integer_field), &
-                intent(INOUT) :: ib_markers
+                intent(inout) :: ib_markers
 
         end subroutine s_read_abstract_ic_data_files ! -----------------
 
@@ -103,7 +103,7 @@ contains
     !>  Reads the configuration file pre_process.inp, in order to
         !!      populate the parameters in module m_global_parameters.f90
         !!      with the user provided inputs
-    subroutine s_read_input_file() ! ---------------------------------------
+    subroutine s_read_input_file ! ---------------------------------------
 
         character(LEN=name_len) :: file_loc  !<
             !! Generic string used to store the address of a particular file
@@ -172,7 +172,7 @@ contains
     !!      individual choices are compatible with the code's options
     !!      and that the combination of these choices results into a
     !!      valid configuration for the pre-process
-    subroutine s_check_input_file() ! --------------------------------------
+    subroutine s_check_input_file ! --------------------------------------
 
         character(LEN=len_trim(case_dir)) :: file_loc !<
             !! Generic string used to store the address of a particular file
@@ -206,7 +206,7 @@ contains
     !> The goal of this subroutine is to read in any preexisting
         !!      grid data as well as based on the imported grid, complete
         !!      the necessary global computational domain parameters.
-    subroutine s_read_serial_grid_data_files() ! ---
+    subroutine s_read_serial_grid_data_files ! ---
 
         ! Generic string used to store the address of a particular file
         character(LEN=len_trim(case_dir) + 3*name_len) :: file_loc
@@ -350,7 +350,7 @@ contains
         !!      at the (non-)uniform cell-width distributions for all the
         !!      active coordinate directions and making sure that all of
         !!      the cell-widths are positively valued
-    subroutine s_check_grid_data_files() ! -----------------
+    subroutine s_check_grid_data_files ! -----------------
 
         ! Cell-boundary Data Consistency Check in x-direction ==============
 
@@ -400,10 +400,10 @@ contains
 
         type(scalar_field), &
             dimension(sys_size), &
-            intent(INOUT) :: q_cons_vf
+            intent(inout) :: q_cons_vf
 
         type(integer_field), &
-            intent(INOUT) :: ib_markers
+            intent(inout) :: ib_markers
 
         character(LEN=len_trim(case_dir) + 3*name_len) :: file_loc !<
         ! Generic string used to store the address of a particular file
@@ -529,7 +529,7 @@ contains
         !!      at the (non-)uniform cell-width distributions for all the
         !!      active coordinate directions and making sure that all of
         !!      the cell-widths are positively valued
-    subroutine s_read_parallel_grid_data_files()
+    subroutine s_read_parallel_grid_data_files ! ----------------------------------
 
 #ifdef MFC_MPI
 
@@ -637,10 +637,10 @@ contains
 
         type(scalar_field), &
             dimension(sys_size), &
-            intent(INOUT) :: q_cons_vf
+            intent(inout) :: q_cons_vf
 
         type(integer_field), &
-            intent(INOUT) :: ib_markers
+            intent(inout) :: ib_markers
 
 #ifdef MFC_MPI
 
@@ -748,7 +748,7 @@ contains
 
     end subroutine s_read_parallel_ic_data_files ! -------------------------
 
-    subroutine s_initialize_modules()
+    subroutine s_initialize_modules ! ----------------------------------
         ! Computation of parameters, allocation procedures, and/or any other tasks
         ! needed to properly setup the modules
         call s_initialize_global_parameters_module()
@@ -812,9 +812,10 @@ contains
 
     subroutine s_apply_initial_condition(start, finish, proc_time, time_avg, time_final, file_exists)
 
-        logical, intent(INOUT) :: file_exists
-        real(kind(0d0)), intent(INOUT) :: start, finish, time_avg, time_final
-        real(kind(0d0)), dimension(:), intent(INOUT) :: proc_time
+        real(kind(0d0)), intent(inout) :: start, finish
+        real(kind(0d0)), dimension(:), intent(inout) :: proc_time
+        real(kind(0d0)), intent(inout) :: time_avg, time_final
+        logical, intent(inout) :: file_exists
 
         ! Setting up the grid and the initial condition. If the grid is read in from
         ! preexisting grid data files, it is checked for consistency. If the grid is
@@ -847,9 +848,10 @@ contains
     end subroutine s_apply_initial_condition
 
     subroutine s_save_data(proc_time, time_avg, time_final, file_exists)
-        logical, intent(INOUT) :: file_exists
-        real(kind(0d0)), intent(INOUT) :: time_avg, time_final
-        real(kind(0d0)), dimension(:), intent(INOUT) :: proc_time
+
+        real(kind(0d0)), dimension(:), intent(inout) :: proc_time
+        real(kind(0d0)), intent(inout) :: time_avg, time_final
+        logical, intent(inout) :: file_exists
 
         call s_mpi_barrier()
 
@@ -879,7 +881,7 @@ contains
         end if
     end subroutine s_save_data
 
-    subroutine s_initialize_mpi_domain()
+    subroutine s_initialize_mpi_domain
         ! Initialization of the MPI environment
 
         call s_mpi_initialize()
@@ -905,7 +907,7 @@ contains
         call s_mpi_decompose_computational_domain()
     end subroutine s_initialize_mpi_domain
 
-    subroutine s_finalize_modules()
+    subroutine s_finalize_modules
         ! Disassociate pointers for serial and parallel I/O
         s_generate_grid => null()
         s_read_grid_data_files => null()

--- a/src/pre_process/m_start_up.fpp
+++ b/src/pre_process/m_start_up.fpp
@@ -50,20 +50,21 @@ module m_start_up
 
     implicit none
 
-    private; public :: s_read_input_file, &
-        s_check_input_file, &
-        s_read_grid_data_files, &
-        s_read_ic_data_files, &
-        s_read_serial_grid_data_files, &
-        s_read_serial_ic_data_files, &
-        s_read_parallel_grid_data_files, &
-        s_read_parallel_ic_data_files, &
-        s_check_grid_data_files, &
-        s_initialize_modules, &
-        s_initialize_mpi_domain, &
-        s_finalize_modules, &
-        s_apply_initial_condition, &
-        s_save_data, s_read_grid
+    private; 
+    public :: s_read_input_file, &
+              s_check_input_file, &
+              s_read_grid_data_files, &
+              s_read_ic_data_files, &
+              s_read_serial_grid_data_files, &
+              s_read_serial_ic_data_files, &
+              s_read_parallel_grid_data_files, &
+              s_read_parallel_ic_data_files, &
+              s_check_grid_data_files, &
+              s_initialize_modules, &
+              s_initialize_mpi_domain, &
+              s_finalize_modules, &
+              s_apply_initial_condition, &
+              s_save_data, s_read_grid
 
     abstract interface ! ===================================================
 
@@ -71,16 +72,16 @@ module m_start_up
 
         end subroutine s_read_abstract_grid_data_files ! ---------------
 
+        !! @param q_cons_vf Conservative variables
+        !! @param ib_markers track if a cell is within the immersed boundary
         subroutine s_read_abstract_ic_data_files(q_cons_vf, ib_markers) ! -----------
 
             import :: scalar_field, integer_field, sys_size, pres_field
 
-            ! Conservative variables
             type(scalar_field), &
                 dimension(sys_size), &
                 intent(inout) :: q_cons_vf
 
-            ! IB markers
             type(integer_field), &
                 intent(inout) :: ib_markers
 
@@ -396,6 +397,7 @@ contains
         !!      the pre-process as a starting point in the creation of an
         !!      all new initial condition.
         !! @param q_cons_vf Conservative variables
+        !! @param ib_markers track if a cell is within the immersed boundary
     subroutine s_read_serial_ic_data_files(q_cons_vf, ib_markers) ! ---------------------------
 
         type(scalar_field), &
@@ -633,6 +635,7 @@ contains
         !!      the pre-process as a starting point in the creation of an
         !!      all new initial condition.
         !! @param q_cons_vf Conservative variables
+        !! @param ib_markers track if a cell is within the immersed boundary
     subroutine s_read_parallel_ic_data_files(q_cons_vf, ib_markers) ! ------------------
 
         type(scalar_field), &


### PR DESCRIPTION
## Description

Added Intent to all subroutine arguments that didn't already have it
Added Missing @ param comments on subroutines
Formatted Code to be a bit more uniform inline with my how I formatted the Common Directory

Fixes #478 

### Type of change

- [x] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

Tested On Github Actions, and Tested Locally

**Test Configuration**:

Ubuntu 22.04.4 LTS, gcc14
Github Actions

## Checklist

- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count