### PR TITLE
Add ib_markers to Silo Output

### DIFF
--- a/src/common/m_mpi_common.fpp
+++ b/src/common/m_mpi_common.fpp
@@ -133,7 +133,6 @@ contains
         end if
 #endif
 
-#ifndef MFC_POST_PROCESS
         if (present(ib_markers)) then
 
 #ifdef MFC_PRE_PROCESS
@@ -146,7 +145,6 @@ contains
             call MPI_TYPE_COMMIT(MPI_IO_IB_DATA%view, ierr)
 
         end if
-#endif
 
 #ifndef MFC_POST_PROCESS
         if (present(ib_markers)) then

--- a/src/post_process/m_global_parameters.fpp
+++ b/src/post_process/m_global_parameters.fpp
@@ -128,6 +128,7 @@ module m_global_parameters
 #ifdef MFC_MPI
 
     type(mpi_io_var), public :: MPI_IO_DATA
+    type(mpi_io_ib_var), public :: MPI_IO_IB_DATA
 
 #endif
 
@@ -191,6 +192,7 @@ module m_global_parameters
     logical :: qm_wrt
     logical :: schlieren_wrt
     logical :: cf_wrt
+    logical :: ib
     !> @}
 
     real(kind(0d0)), dimension(num_fluids_max) :: schlieren_alpha    !<
@@ -334,6 +336,7 @@ contains
         qm_wrt = .false.
         schlieren_wrt = .false.
         cf_wrt = .false.
+        ib = .false.
 
         schlieren_alpha = dflt_real
 
@@ -598,6 +601,8 @@ contains
             allocate (MPI_IO_DATA%var(i)%sf(0:m, 0:n, 0:p))
             MPI_IO_DATA%var(i)%sf => null()
         end do
+
+        if (ib) allocate (MPI_IO_IB_DATA%var%sf(0:m, 0:n, 0:p))
 #endif
 
         ! Size of the ghost zone layer is non-zero only when post-processing
@@ -752,6 +757,7 @@ contains
             deallocate (MPI_IO_DATA%view)
         end if
 
+        if (ib) MPI_IO_IB_DATA%var%sf => null()
 #endif
 
     end subroutine s_finalize_global_parameters_module

--- a/src/post_process/m_mpi_proxy.fpp
+++ b/src/post_process/m_mpi_proxy.fpp
@@ -168,7 +168,7 @@ contains
             & 'heat_ratio_wrt', 'pi_inf_wrt', 'pres_inf_wrt', 'cons_vars_wrt', &
             & 'prim_vars_wrt', 'c_wrt', 'qm_wrt','schlieren_wrt', 'bubbles', 'qbmm',   &
             & 'polytropic', 'polydisperse', 'file_per_process', 'relax', 'cf_wrt',     &
-            & 'adv_n' ]
+            & 'adv_n', 'ib' ]
             call MPI_BCAST(${VAR}$, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
         #:endfor
 

--- a/src/post_process/m_start_up.f90
+++ b/src/post_process/m_start_up.f90
@@ -74,7 +74,7 @@ contains
             parallel_io, rhoref, pref, bubbles, qbmm, sigR, &
             R0ref, nb, polytropic, thermal, Ca, Web, Re_inv, &
             polydisperse, poly_sigma, file_per_process, relax, &
-            relax_model, cf_wrt, sigma, adv_n
+            relax_model, cf_wrt, sigma, adv_n, ib
 
         ! Inquiring the status of the post_process.inp file
         file_loc = 'post_process.inp'
@@ -495,6 +495,12 @@ contains
             end do
         end if
         ! ----------------------------------------------------------------------
+
+        if (ib) then
+            q_sf = real(ib_markers%sf(-offset_x%beg:m + offset_x%end, -offset_y%beg:n + offset_y%end, -offset_z%beg:p + offset_z%end))
+            varname = 'ib_markers'
+            call s_write_variable_to_formatted_database_file(varname, t_step)
+        end if
 
         ! Adding Q_M to the formatted database file ------------------
         if (p > 0 .and. qm_wrt) then

--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -931,7 +931,11 @@ contains
         else
             ! Initialize MPI data I/O
 
-            call s_initialize_mpi_data(q_cons_vf)
+            if (ib) then
+                call s_initialize_mpi_data(q_cons_vf, ib_markers)
+            else
+                call s_initialize_mpi_data(q_cons_vf)
+            end if
 
             ! Open the file to write all flow variables
             write (file_loc, '(I0,A)') t_step, '.dat'

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -308,7 +308,8 @@ POST_PROCESS.update({
     'omega_wrt': ParamType.LOG,
     'qbmm': ParamType.LOG,
     'qm_wrt': ParamType.LOG,
-    'cf_wrt': ParamType.LOG
+    'cf_wrt': ParamType.LOG,
+    'ib': ParamType.LOG
 })
 
 for cmp_id in range(1,3+1):


### PR DESCRIPTION
## Description

This PR add ib_makers to Silo output working with `parallel_io = T` and `= F`. It fixes a minor bug in src/simulation/m_data_output.fpp found by @anandrdbz.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


### Scope

- [x] This PR comprises a set of related changes with a common goal


## How Has This Been Tested?

Use multiple ranks to post_process the a case with IBM turned on. Got the ib_markers in the silo correctly. 


https://github.com/MFlowCode/MFC/assets/98496194/53e2eee1-57e2-4f28-b730-1f59ce035f8e



**Test Configuration**: 

* What computers and compilers did you use to test this: MacOS 12.2.1
