### PR TITLE
Fix requirement for node20 for checkout

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on:
       group:  phoenix
       labels: gt
+    env:
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Clone - PR
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,9 +140,12 @@ jobs:
     runs-on:
       group:  phoenix
       labels: ${{ matrix.lbl }}
+    env:
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Build & Test
         if:   matrix.lbl == 'gt'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
       labels: ${{ matrix.lbl }}
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build & Test
         if:   matrix.lbl == 'gt'


### PR DESCRIPTION
Trying to fix error with GH self-hosted Phoenix runner seen here: https://github.com/MFlowCode/MFC/actions/runs/9794226632/job/27043820008

```console
Run actions/checkout@v3
  with:
    repository: MFlowCode/MFC
    token: ***
    ssh-strict: true
    persist-credentials: true
    clean: true
    sparse-checkout-cone-mode: true
    fetch-depth: [1](https://github.com/MFlowCode/MFC/actions/runs/9794226632/job/27043820008#step:2:1)
    fetch-tags: false
    lfs: false
    submodules: false
    set-safe-directory: true
/storage/scratch1/6/sbryngelson3/runners/actions-runner-1/externals/node[2](https://github.com/MFlowCode/MFC/actions/runs/9794226632/job/27043820008#step:2:2)0/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /storage/scratch1/6/sbryngelson[3](https://github.com/MFlowCode/MFC/actions/runs/9794226632/job/27043820008#step:2:3)/runners/actions-runner-1/externals/node20/bin/node)
/storage/scratch1/6/sbryngelson3/runners/actions-runner-1/externals/node20/bin/node: /lib6[4](https://github.com/MFlowCode/MFC/actions/runs/9794226632/job/27043820008#step:2:4)/libc.so.6: version `GLIBC_2.28' not found (required by /storage/scratch1/6/sbryngelson3/runners/actions-runner-1/externals/node20/bin/node)
/storage/scratch1/6/sbryngelson3/runners/actions-runner-1/externals/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.2[5](https://github.com/MFlowCode/MFC/actions/runs/9794226632/job/27043820008#step:2:5)' not found (required by /storage/scratch1/[6](https://github.com/MFlowCode/MFC/actions/runs/9794226632/job/27043820008#step:2:6)/sbryngelson3/runners/actions-runner-1/externals/node20/bin/node)
```