### PR TITLE
Extend time-out limit

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on:
       group:  phoenix
       labels: gt
+    timeout-minutes: 1400
     env:
       ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
     if: github.repository == 'MFlowCode/MFC' && needs.file-changes.outputs.checkall == 'true'
     needs: file-changes
     continue-on-error: true
+    timeout-minutes: 1400
     strategy:
       matrix:
         device: ['cpu', 'gpu']

--- a/src/pre_process/m_check_ib_patches.fpp
+++ b/src/pre_process/m_check_ib_patches.fpp
@@ -5,7 +5,7 @@ module m_check_ib_patches
     ! Dependencies =============================================================
     use m_derived_types          !< Definitions of the derived types
 
-    use m_global_parameters      !< Global parameters for the code
+    use m_global_parameters      !< Global parameters
 
     use m_mpi_proxy              !< Message passing interface (MPI) module proxy
 


### PR DESCRIPTION
Sometimes self-hosted runners fail because they don't get on a node within 6 hours (the default GitHub actions timeout). This is particularly an issue on Frontier. This PR extends this limit to 1440 minutes, which is ~24 hours which appears to be the maximum (and if it takes longer than that, something else is probably wrong anyway). 

Since we submit to Frontier debug queue, we can only submit a single job at once, so if the runner stops before the job finishes then we have a hanging job in the queue and subsequent trials will also fail until that job in the queue runs.

Relevant docs:
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
* https://stackoverflow.com/questions/59073731/set-default-timeout-on-github-action-pipeline