### PR TITLE
Fail a CI self-hosted job if frontier doesn't get a node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
     name: Self Hosted
     if: github.repository == 'MFlowCode/MFC' && needs.file-changes.outputs.checkall == 'true'
     needs: file-changes
-    continue-on-error: true
+    continue-on-error: false
     timeout-minutes: 1400
     strategy:
       matrix:


### PR DESCRIPTION
Fail a CI self-hosted job if frontier doesn't get a node

Related to my comments on the issue here:

https://github.com/MFlowCode/MFC/issues/498

Let me know if you think there is a better way.