### PR TITLE
Improve Only Flag for Test

### DIFF
--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -83,7 +83,7 @@ started, run ./mfc.sh build -h.""",
     test.add_argument("-l", "--list",         action="store_true", help="List all available tests.")
     test.add_argument("-f", "--from",         default=test_cases[0].get_uuid(), type=str, help="First test UUID to run.")
     test.add_argument("-t", "--to",           default=test_cases[-1].get_uuid(), type=str, help="Last test UUID to run.")
-    test.add_argument("-o", "--only",         nargs="+", type=str, default=[], metavar="L", help="Only run tests with UUIDs or hashes L.")
+    test.add_argument("-o", "--only",         nargs="+", type=str, default=[], metavar="L", help="Only run tests with specified properties.")
     test.add_argument("-r", "--relentless",   action="store_true", default=False, help="Run all tests, even if multiple fail.")
     test.add_argument("-a", "--test-all",     action="store_true", default=False, help="Run the Post Process Tests too.")
     test.add_argument("-%", "--percent",      type=int, default=100, help="Percentage of tests to run.")

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -41,7 +41,11 @@ def __filter(cases_) -> typing.List[TestCase]:
     if len(ARG("only")) > 0:
         for case in cases[:]:
             case: TestCase
-            if (not set(ARG("only")).issubset(set(case.trace.split(" -> ")))):
+
+            checkCase = case.trace.split(" -> ")
+            checkCase.append(case.get_uuid())
+            
+            if (not set(ARG("only")).issubset(set(checkCase))):
                 cases.remove(case)
 
 

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -39,17 +39,11 @@ def __filter(cases_) -> typing.List[TestCase]:
         raise MFCException("Testing: Your specified range [--from,--to] is incorrect. Please ensure both IDs exist and are in the correct order.")
 
     if len(ARG("only")) > 0:
-        for i, case in enumerate(cases[:]):
+        for case in cases[:]:
             case: TestCase
-
-            doKeep = False
-            for o in ARG("only"):
-                if str(o) == case.get_uuid():
-                    doKeep = True
-                    break
-
-            if not doKeep:
+            if (not set(ARG("only")).issubset(set(case.trace.split(" -> ")))):
                 cases.remove(case)
+
 
     for case in cases[:]:
         if case.ppn > 1 and not ARG("mpi"):

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -44,8 +44,7 @@ def __filter(cases_) -> typing.List[TestCase]:
 
             checkCase = case.trace.split(" -> ")
             checkCase.append(case.get_uuid())
-            
-            if (not set(ARG("only")).issubset(set(checkCase))):
+            if not set(ARG("only")).issubset(set(checkCase)):
                 cases.remove(case)
 
 


### PR DESCRIPTION
## Description

Improved the Only Flag for `./mfc.sh test'
-o can now filter for any part of trace or the UUID rather than only UUID

Examples:
```
./mfc.sh test -l -o IBM
 >77CE10D6   2D -> 1 Fluid(s) -> IBM                             
   F13DF273   2D -> 1 Fluid(s) -> Viscous -> IBM                  
   B0CE19C5   2D -> 1 Fluid(s) -> Viscous -> IBM -> model_eqns=3  
   B9D934CF   2D -> 2 Fluid(s) -> IBM                             
   09E3930B   2D -> 2 Fluid(s) -> Viscous -> IBM                  
   7DCE34B4   2D -> 2 Fluid(s) -> Viscous -> IBM -> model_eqns=3  
   7CAA00A5   3D -> 1 Fluid(s) -> IBM                             
   150A86A6   3D -> 1 Fluid(s) -> Viscous -> IBM                  
   725A3D56   3D -> 2 Fluid(s) -> IBM                             
   0F6C4340   3D -> 2 Fluid(s) -> Viscous -> IBM   
```
```
./mfc.sh test -l -o IBM 3D
 >7CAA00A5   3D -> 1 Fluid(s) -> IBM                             
   150A86A6   3D -> 1 Fluid(s) -> Viscous -> IBM                  
   725A3D56   3D -> 2 Fluid(s) -> IBM                             
   0F6C4340   3D -> 2 Fluid(s) -> Viscous -> IBM   
```

### Type of change


- [x] New feature (non-breaking change which adds functionality)


### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

- [x] Test for only UUID `./mfc.sh test -l -o 7CAA00A5` (might need to change uuid since uuid can be different on different machine ) 
- [x] Test for components of trace `./mfc.sh test -l -o IBM 3D`

**Test Configuration**:



## Checklist

- [x] I have added comments for the new code
- [x] I ran `./mfc.sh format` before committing my code
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count
