### PR TITLE
Fix 3D IBM Infinite CFL Number on GPUs

### DIFF
--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -1417,6 +1417,10 @@ contains
             !$acc update device(palpha_eps, ptgalpha_eps)
         end if
 
+        if (ib) then
+            !$acc update device(ib_markers%sf)
+        end if
+
     end subroutine s_initialize_gpu_vars
 
     subroutine s_finalize_modules

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -303,14 +303,6 @@ contains
 
         call s_compute_rhs(q_cons_ts(1)%vf, q_prim_vf, rhs_vf, pb_ts(1)%sf, rhs_pb, mv_ts(1)%sf, rhs_mv, t_step, time_avg)
 
-        if (ib .and. t_step == 1) then
-            if (qbmm .and. .not. polytropic) then
-                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf, pb_ts(1)%sf, mv_ts(1)%sf)
-            else
-                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf)
-            end if
-        end if
-
 #ifdef DEBUG
         print *, 'got rhs'
 #endif
@@ -419,14 +411,6 @@ contains
         call nvtxStartRange("Time_Step")
 
         call s_compute_rhs(q_cons_ts(1)%vf, q_prim_vf, rhs_vf, pb_ts(1)%sf, rhs_pb, mv_ts(1)%sf, rhs_mv, t_step, time_avg)
-
-        if (ib .and. t_step == 1) then
-            if (qbmm .and. .not. polytropic) then
-                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf, pb_ts(1)%sf, mv_ts(1)%sf)
-            else
-                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf)
-            end if
-        end if
 
         if (run_time_info) then
             call s_write_run_time_information(q_prim_vf, t_step)
@@ -609,14 +593,6 @@ contains
         end if
 
         call s_compute_rhs(q_cons_ts(1)%vf, q_prim_vf, rhs_vf, pb_ts(1)%sf, rhs_pb, mv_ts(1)%sf, rhs_mv, t_step, time_avg)
-
-        if (ib .and. t_step == 1) then
-            if (qbmm .and. .not. polytropic) then
-                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf, pb_ts(1)%sf, mv_ts(1)%sf)
-            else
-                call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf)
-            end if
-        end if
 
         if (run_time_info) then
             call s_write_run_time_information(q_prim_vf, t_step)


### PR DESCRIPTION
## Description

Fixes 3D IBM infinite CFL number when running on GPUs. These modifications were suggested by @haochey and @anandrdbz via slack

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

- [x] Tested by running the 3D_ibm example on two A100 GPUs
![visit0000](https://github.com/user-attachments/assets/fa429362-ac3e-411e-9b9a-92d615b01642)

**Test Configuration**:

* What computers and compilers did you use to test this:

The test was run using Nvidia A100 GPUs on HiPerGator at UF
`python/3.8, nvhpc/24.5, openmpi/4.1.6, cmake/3.26.4`

## Checklist
- [x] I ran ```./mfc.sh format``` before committing my code
- [x] This PR does not introduce any repeated code (it follows the [DRY])
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x] Checked that the code compiles using NVHPC compilers