### PR TITLE
Including DoD Nautilus in the list of computers for MFC

### DIFF
--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -375,9 +375,7 @@ contains
 
         if (grid_geometry == 3) call s_apply_fourier_filter(q_cons_ts(1)%vf)
 
-        if (model_eqns == 3 .and. (.not. relax)) then
-            call s_pressure_relaxation_procedure(q_cons_ts(2)%vf)
-        end if
+        if (model_eqns == 3) call s_pressure_relaxation_procedure(q_cons_ts(1)%vf)
 
         if (adv_n) call s_comp_alpha_from_n(q_cons_ts(1)%vf)
 

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -375,7 +375,9 @@ contains
 
         if (grid_geometry == 3) call s_apply_fourier_filter(q_cons_ts(1)%vf)
 
-        if (model_eqns == 3) call s_pressure_relaxation_procedure(q_cons_ts(1)%vf)
+        if (model_eqns == 3 .and. (.not. relax)) then
+            call s_pressure_relaxation_procedure(q_cons_ts(2)%vf)
+        end if
 
         if (adv_n) call s_comp_alpha_from_n(q_cons_ts(1)%vf)
 

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -24,7 +24,7 @@ if [ -v $u_c ]; then
     log   "$Y""Gatech$W:  Phoenix    (p)"
     log   "$R""Caltech$W: Richardson (r)"
     log   "$B""DoD$W:     Carpenter  (c) | Nautilus (n)"
-    log_n "($G""a$W/$G""f$W/$G""s$W/$G""w$W/$C""b$W/$C""e$CR/$C""d$CR/$Y""p$CR/$R""r$CR/$B""c$CR/$B""c$CR): "
+    log_n "($G""a$W/$G""f$W/$G""s$W/$G""w$W/$C""b$W/$C""e$CR/$C""d$CR/$Y""p$CR/$R""r$CR/$B""c$CR/$B""n$CR): "
     read u_c
     log
 fi

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -23,8 +23,8 @@ if [ -v $u_c ]; then
     log   "$C""ACCESS$W:  Bridges2   (b) | Expanse (e) | Delta  (d)"
     log   "$Y""Gatech$W:  Phoenix    (p)"
     log   "$R""Caltech$W: Richardson (r)"
-    log   "$B""DoD$W:     Carpenter  (c)"
-    log_n "($G""a$W/$G""f$W/$G""s$W/$G""w$W/$C""b$W/$C""e$CR/$C""d$CR/$Y""p$CR/$R""r$CR/$B""c$CR): "
+    log   "$B""DoD$W:     Carpenter  (c) | Nautilus (n)"
+    log_n "($G""a$W/$G""f$W/$G""s$W/$G""w$W/$C""b$W/$C""e$CR/$C""d$CR/$Y""p$CR/$R""r$CR/$B""c$CR/$B""c$CR): "
     read u_c
     log
 fi

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -64,3 +64,9 @@ c     DoD Carpenter
 c-all python
 c-cpu gcc/12.2.0 cmake/3.28.1-gcc-12.2.0 openmpi/4.1.6
 c-gpu nvhpc/23.7 cuda/12.2
+
+n     DoD Nautilus
+n-all slurm
+n-cpu penguin/openmpi/4.1.5/gcc-8.5.0
+n-gpu penguin/openmpi/4.1.5/nvhpc-22.3 nvidia/nvhpc/22.3 cuda/cuda-11.6
+n-gpu CC=nvc CXX=nvc++ FC=nvfortran

--- a/toolchain/templates/nautilus.mako
+++ b/toolchain/templates/nautilus.mako
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+<%namespace name="helpers" file="helpers.mako"/>
+
+% if engine == 'batch':
+#SBATCH --nodes=${nodes}
+#SBATCH --ntasks-per-node=${tasks_per_node}
+#SBATCH --cpus-per-task=1
+#SBATCH --job-name="${name}"
+#SBATCH --time=${walltime}
+% if partition:
+#SBATCH --qos=${partition}
+% endif
+% if account:
+#SBATCH --account="${account}"
+% endif
+% if gpu:
+#SBATCH --gpu-bind=verbose,closest
+#SBATCH --gres=gpu:v100-16:${tasks_per_node}
+% endif
+#SBATCH --output="${name}.out"
+#SBATCH --error="${name}.err"
+#SBATCH --export=ALL
+% if email:
+#SBATCH --mail-user=${email}
+#SBATCH --mail-type="BEGIN, END, FAIL"
+% endif
+% endif
+
+${helpers.template_prologue()}
+
+ok ":) Loading modules:\n"
+cd "${MFC_ROOTDIR}"
+. ./mfc.sh load -c n -m ${'g' if gpu else 'c'}
+cd - > /dev/null
+echo
+
+% for target in targets:
+    ${helpers.run_prologue(target)}
+
+    % if not mpi:
+        (set -x; ${profiler} "${target.get_install_binpath(case)}")
+    % else:
+        (set -x; ${profiler}                              \
+            mpirun -np ${nodes*tasks_per_node}            \
+                   "${target.get_install_binpath(case)}")
+    % endif
+
+    ${helpers.run_epilogue(target)}
+
+    echo
+% endfor
+
+${helpers.template_epilogue()}


### PR DESCRIPTION
## Description

This Pull Request introduces changes to the files toolchain/bootstrap/modules.sh and toolchain/modules and includes file toolchain/templates/nautilus.mako. They are updated/included so that MFC can be compiled on DoD Nautilus supercomputer. This commit does not add anything extra

### Type of change

- [X] Something else

### Scope

- [X] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

The changes have been tested by loading the associated modules and computers introduced in toolchain/bootstrap/modules.sh and toolchain/modules. MFC has been compiled on both CPU and GPU, and by performing the pipeline

./mfc.sh run /path_to_input/input.py run -t pre_process simulation -b mpirun

the simulations run adequately. We note that by simply doing

./mfc.sh test

does not work, with the following error reported:

Error: Submitting batch file for Interactive failed.

which happens as the command above cannot be appended to -b mpirun

**Test Configuration**:

* What computers and compilers did you use to test this:

DoD Nautilus

## Checklist

- [X] I have added comments for the new code
- [X] I ran `./mfc.sh format` before committing my code
- [X] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [X] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

No