### PR TITLE
Fully simplify and fix `mfc.sh clean`

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -36,6 +36,8 @@ elif [ "$1" '==' "docker" ]; then
     shift; . "$(pwd)/toolchain/bootstrap/docker.sh"  $@; exit 0
 elif [ "$1" '==' "venv" ]; then
     shift; . "$(pwd)/toolchain/bootstrap/python.sh"  $@; return
+elif [ "$1" '==' "clean" ]; then
+    rm -rf "$(pwd)/build"; exit 0
 fi
 
 mkdir -p "$(pwd)/build"

--- a/mfc.sh
+++ b/mfc.sh
@@ -36,8 +36,6 @@ elif [ "$1" '==' "docker" ]; then
     shift; . "$(pwd)/toolchain/bootstrap/docker.sh"  $@; exit 0
 elif [ "$1" '==' "venv" ]; then
     shift; . "$(pwd)/toolchain/bootstrap/python.sh"  $@; return
-elif [ "$1" '==' "clean" ]; then
-    rm -rf "$(pwd)/build"; exit 0
 fi
 
 mkdir -p "$(pwd)/build"

--- a/toolchain/main.py
+++ b/toolchain/main.py
@@ -49,7 +49,7 @@ def __checks():
 
 def __run():
     {"test":   test.test,     "run":        run.run,          "build":      build.build,
-     "clean":  build.clean,   "bench":      bench.bench,      "count":      count.count,
+     "bench":      bench.bench,      "count":      count.count,
      "packer": packer.packer, "count_diff": count.count_diff, "bench_diff": bench.diff
     }[ARG("command")]()
 

--- a/toolchain/main.py
+++ b/toolchain/main.py
@@ -48,9 +48,9 @@ def __checks():
 
 
 def __run():
-    {"test":       test.test,        "run":        run.run,          "build":  build.build,
-     "bench":      bench.bench,      "count":      count.count,      "packer": packer.packer, 
-     "count_diff": count.count_diff, "bench_diff": bench.diff
+    {"test":   test.test,     "run":        run.run,          "build":      build.build,
+     "clean":  build.clean,   "bench":      bench.bench,      "count":      count.count,
+     "packer": packer.packer, "count_diff": count.count_diff, "bench_diff": bench.diff
     }[ARG("command")]()
 
 

--- a/toolchain/main.py
+++ b/toolchain/main.py
@@ -48,9 +48,9 @@ def __checks():
 
 
 def __run():
-    {"test":   test.test,     "run":        run.run,          "build":      build.build,
-     "clean":  build.clean,   "bench":      bench.bench,      "count":      count.count,
-     "packer": packer.packer, "count_diff": count.count_diff, "bench_diff": bench.diff
+    {"test":       test.test,        "run":        run.run,          "build":  build.build,
+     "bench":      bench.bench,      "count":      count.count,      "packer": packer.packer, 
+     "count_diff": count.count_diff, "bench_diff": bench.diff
     }[ARG("command")]()
 
 

--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -21,6 +21,7 @@ started, run ./mfc.sh build -h.""",
     run        = parsers.add_parser(name="run",        help="Run a case with MFC.",                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     test       = parsers.add_parser(name="test",       help="Run MFC's test suite.",                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     build      = parsers.add_parser(name="build",      help="Build MFC and its dependencies.",      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    clean      = parsers.add_parser(name="clean",      help="Clean build artifacts.",               formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     bench      = parsers.add_parser(name="bench",      help="Benchmark MFC (for CI).",              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     bench_diff = parsers.add_parser(name="bench_diff", help="Compare MFC Benchmarks (for CI).",     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     count      = parsers.add_parser(name="count",      help="Count LOC in MFC.",                    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -72,6 +73,9 @@ started, run ./mfc.sh build -h.""",
     build.add_argument("-i", "--input", type=str, default=None, help="(GPU Optimization) Build a version of MFC optimized for a case.")
     build.add_argument("--case-optimization", action="store_true", default=False, help="(GPU Optimization) Compile MFC targets with some case parameters hard-coded (requires --input).")
 
+    # === CLEAN ===
+    add_common_arguments(clean, "jg")
+
     # === TEST ===
     test_cases = list_cases()
 
@@ -112,7 +116,7 @@ started, run ./mfc.sh build -h.""",
     run.add_argument("--wait",                     action="store_true",                    default=False,      help="(Batch) Wait for the job to finish.")
     run.add_argument("-c", "--computer",           metavar="COMPUTER",           type=str, default="default",  help=f"(Batch) Path to a custom submission file template or one of {format_list_to_string(list(get_baked_templates().keys()))}.")
     run.add_argument("-o", "--output-summary",     metavar="OUTPUT",             type=str, default=None,       help="Output file (YAML) for summary.")
-    # run.add_argument("--clean",                    action="store_true",                    default=False,      help="Clean the case before running.")
+    run.add_argument("--clean",                    action="store_true",                    default=False,      help="Clean the case before running.")
     run.add_argument("--ncu",                      nargs=argparse.REMAINDER,     type=str,                     help="Profile with NVIDIA Nsight Compute.")
     run.add_argument("--nsys",                     nargs=argparse.REMAINDER,     type=str,                     help="Profile with NVIDIA Nsight Systems.")
     run.add_argument("--omni",                     nargs=argparse.REMAINDER,     type=str,                     help="Profile with ROCM omniperf.")
@@ -144,7 +148,7 @@ started, run ./mfc.sh build -h.""",
 
     # Add default arguments of other subparsers
     for name, parser in [("run",    run),   ("test",   test), ("build", build),
-                         ("count", count), ("count_diff", count_diff)]:
+                         ("clean",  clean), ("count", count), ("count_diff", count_diff)]:
         if args["command"] == name:
             continue
 

--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -73,9 +73,6 @@ started, run ./mfc.sh build -h.""",
     build.add_argument("-i", "--input", type=str, default=None, help="(GPU Optimization) Build a version of MFC optimized for a case.")
     build.add_argument("--case-optimization", action="store_true", default=False, help="(GPU Optimization) Compile MFC targets with some case parameters hard-coded (requires --input).")
 
-    # === CLEAN ===
-    add_common_arguments(clean, "jg")
-
     # === TEST ===
     test_cases = list_cases()
 

--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -21,7 +21,6 @@ started, run ./mfc.sh build -h.""",
     run        = parsers.add_parser(name="run",        help="Run a case with MFC.",                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     test       = parsers.add_parser(name="test",       help="Run MFC's test suite.",                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     build      = parsers.add_parser(name="build",      help="Build MFC and its dependencies.",      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    clean      = parsers.add_parser(name="clean",      help="Clean build artifacts.",               formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     bench      = parsers.add_parser(name="bench",      help="Benchmark MFC (for CI).",              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     bench_diff = parsers.add_parser(name="bench_diff", help="Compare MFC Benchmarks (for CI).",     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     count      = parsers.add_parser(name="count",      help="Count LOC in MFC.",                    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -73,9 +72,6 @@ started, run ./mfc.sh build -h.""",
     build.add_argument("-i", "--input", type=str, default=None, help="(GPU Optimization) Build a version of MFC optimized for a case.")
     build.add_argument("--case-optimization", action="store_true", default=False, help="(GPU Optimization) Compile MFC targets with some case parameters hard-coded (requires --input).")
 
-    # === CLEAN ===
-    add_common_arguments(clean, "jg")
-
     # === TEST ===
     test_cases = list_cases()
 
@@ -116,7 +112,7 @@ started, run ./mfc.sh build -h.""",
     run.add_argument("--wait",                     action="store_true",                    default=False,      help="(Batch) Wait for the job to finish.")
     run.add_argument("-c", "--computer",           metavar="COMPUTER",           type=str, default="default",  help=f"(Batch) Path to a custom submission file template or one of {format_list_to_string(list(get_baked_templates().keys()))}.")
     run.add_argument("-o", "--output-summary",     metavar="OUTPUT",             type=str, default=None,       help="Output file (YAML) for summary.")
-    run.add_argument("--clean",                    action="store_true",                    default=False,      help="Clean the case before running.")
+    # run.add_argument("--clean",                    action="store_true",                    default=False,      help="Clean the case before running.")
     run.add_argument("--ncu",                      nargs=argparse.REMAINDER,     type=str,                     help="Profile with NVIDIA Nsight Compute.")
     run.add_argument("--nsys",                     nargs=argparse.REMAINDER,     type=str,                     help="Profile with NVIDIA Nsight Systems.")
     run.add_argument("--omni",                     nargs=argparse.REMAINDER,     type=str,                     help="Profile with ROCM omniperf.")
@@ -148,7 +144,7 @@ started, run ./mfc.sh build -h.""",
 
     # Add default arguments of other subparsers
     for name, parser in [("run",    run),   ("test",   test), ("build", build),
-                         ("clean",  clean), ("count", count), ("count_diff", count_diff)]:
+                         ("count", count), ("count_diff", count_diff)]:
         if args["command"] == name:
             continue
 

--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -112,7 +112,6 @@ started, run ./mfc.sh build -h.""",
     run.add_argument("--wait",                     action="store_true",                    default=False,      help="(Batch) Wait for the job to finish.")
     run.add_argument("-c", "--computer",           metavar="COMPUTER",           type=str, default="default",  help=f"(Batch) Path to a custom submission file template or one of {format_list_to_string(list(get_baked_templates().keys()))}.")
     run.add_argument("-o", "--output-summary",     metavar="OUTPUT",             type=str, default=None,       help="Output file (YAML) for summary.")
-    # run.add_argument("--clean",                    action="store_true",                    default=False,      help="Clean the case before running.")
     run.add_argument("--ncu",                      nargs=argparse.REMAINDER,     type=str,                     help="Profile with NVIDIA Nsight Compute.")
     run.add_argument("--nsys",                     nargs=argparse.REMAINDER,     type=str,                     help="Profile with NVIDIA Nsight Systems.")
     run.add_argument("--omni",                     nargs=argparse.REMAINDER,     type=str,                     help="Profile with ROCM omniperf.")

--- a/toolchain/mfc/args.py
+++ b/toolchain/mfc/args.py
@@ -112,6 +112,7 @@ started, run ./mfc.sh build -h.""",
     run.add_argument("--wait",                     action="store_true",                    default=False,      help="(Batch) Wait for the job to finish.")
     run.add_argument("-c", "--computer",           metavar="COMPUTER",           type=str, default="default",  help=f"(Batch) Path to a custom submission file template or one of {format_list_to_string(list(get_baked_templates().keys()))}.")
     run.add_argument("-o", "--output-summary",     metavar="OUTPUT",             type=str, default=None,       help="Output file (YAML) for summary.")
+    # run.add_argument("--clean",                    action="store_true",                    default=False,      help="Clean the case before running.")
     run.add_argument("--ncu",                      nargs=argparse.REMAINDER,     type=str,                     help="Profile with NVIDIA Nsight Compute.")
     run.add_argument("--nsys",                     nargs=argparse.REMAINDER,     type=str,                     help="Profile with NVIDIA Nsight Systems.")
     run.add_argument("--omni",                     nargs=argparse.REMAINDER,     type=str,                     help="Profile with ROCM omniperf.")

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -287,6 +287,3 @@ def build(targets = None, case: input.MFCInputFile = None, history: typing.Set[s
     if len(history) == 0:
         cons.print(no_indent=True)
 
-
-def clean():
-    shutil.rmtree('build')

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -182,21 +182,6 @@ class MFCTarget:
 
         cons.print(no_indent=True)
 
-    def clean(self, case: input.MFCInputFile):
-        build_dirpath = self.get_staging_dirpath(case)
-
-        if not os.path.isdir(build_dirpath):
-            return
-
-        command = ["cmake", "--build",  build_dirpath, "--target", "clean",
-                            "--config", "Debug" if ARG("debug") else "Release" ]
-
-        if ARG("verbose"):
-            command.append("--verbose")
-
-        if system(command).returncode != 0:
-            raise MFCException(f"Failed to clean the [bold magenta]{self.name}[/bold magenta] target.")
-
 #                         name             flags                       isDep  isDef  isReq  dependencies                        run order
 FFTW          = MFCTarget('fftw',          ['-DMFC_FFTW=ON'],          True,  False, False, MFCTarget.Dependencies([], [], []), -1)
 HDF5          = MFCTarget('hdf5',          ['-DMFC_HDF5=ON'],          True,  False, False, MFCTarget.Dependencies([], [], []), -1)

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -287,3 +287,6 @@ def build(targets = None, case: input.MFCInputFile = None, history: typing.Set[s
     if len(history) == 0:
         cons.print(no_indent=True)
 
+
+def clean():
+    shutil.rmtree('build')

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -1,4 +1,4 @@
-import os, typing, hashlib, dataclasses
+import os, typing, hashlib, dataclasses, shutil
 
 from .printer import cons
 from .common  import MFCException, system, delete_directory, create_directory, \
@@ -197,6 +197,7 @@ class MFCTarget:
         if system(command).returncode != 0:
             raise MFCException(f"Failed to clean the [bold magenta]{self.name}[/bold magenta] target.")
 
+#                         name             flags                       isDep  isDef  isReq  dependencies                        run order
 FFTW          = MFCTarget('fftw',          ['-DMFC_FFTW=ON'],          True,  False, False, MFCTarget.Dependencies([], [], []), -1)
 HDF5          = MFCTarget('hdf5',          ['-DMFC_HDF5=ON'],          True,  False, False, MFCTarget.Dependencies([], [], []), -1)
 SILO          = MFCTarget('silo',          ['-DMFC_SILO=ON'],          True,  False, False, MFCTarget.Dependencies([HDF5], [], []), -1)
@@ -302,16 +303,5 @@ def build(targets = None, case: input.MFCInputFile = None, history: typing.Set[s
         cons.print(no_indent=True)
 
 
-def clean(targets = None, case: input.MFCInputFile = None):
-    targets = get_targets(list(REQUIRED_TARGETS) + (targets or ARG("targets")))
-    case    = case or input.load(ARG("input"), ARG("arguments"), {})
-
-    cons.print(__generate_header("Clean", targets))
-    cons.print(no_indent=True)
-
-    for target in targets:
-        if target.is_configured():
-            target.clean()
-
-    cons.print(no_indent=True)
-    cons.unindent()
+def clean():
+    shutil.rmtree('build')

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -1,7 +1,7 @@
 import os, typing, hashlib, dataclasses, shutil
 
 from .printer import cons
-from .common  import MFCException, system, delete_directory, create_directory, \
+from .common  import MFC_ROOTDIR, MFCException, system, delete_directory, create_directory, \
                      format_list_to_string
 from .state   import ARG, CFG
 from .run     import input
@@ -289,4 +289,4 @@ def build(targets = None, case: input.MFCInputFile = None, history: typing.Set[s
 
 
 def clean():
-    shutil.rmtree('build')
+    shutil.rmtree(os.path.join(MFC_ROOTDIR, 'build'))

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -1,7 +1,7 @@
-import os, typing, hashlib, dataclasses, shutil
+import os, typing, hashlib, dataclasses
 
 from .printer import cons
-from .common  import MFC_ROOTDIR, MFCException, system, delete_directory, create_directory, \
+from .common  import MFCException, system, delete_directory, create_directory, \
                      format_list_to_string
 from .state   import ARG, CFG
 from .run     import input
@@ -286,7 +286,3 @@ def build(targets = None, case: input.MFCInputFile = None, history: typing.Set[s
 
     if len(history) == 0:
         cons.print(no_indent=True)
-
-
-def clean():
-    shutil.rmtree(os.path.join(MFC_ROOTDIR, 'build'))


### PR DESCRIPTION
## Description

We discovered a problem where `rmtree` would fail to delete all directories on some machines. This tiny PR just makes `mfc.sh` call `rm -rf` instead. I had previously rolled this back since I thought the toolchain needed "clean" to be defined in the dictionary at the top, but I discovered that I was only being blocked by argparse.

Fixes #521

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

### Scope

- [ ] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

**Test Configuration**:

* What computers and compilers did you use to test this:
* Violet (the Rogue's Gallery machine that had the issue)
