### PR TITLE
Fixes `<string>:1: SyntaxWarning: invalid escape sequence '\('`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
     name: Self Hosted
     if: github.repository == 'MFlowCode/MFC' && needs.file-changes.outputs.checkall == 'true'
     needs: file-changes
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       matrix:
         device: ['cpu', 'gpu']

--- a/src/common/include/macros.fpp
+++ b/src/common/include/macros.fpp
@@ -31,10 +31,10 @@
 #ifdef CRAY_ACC_WAR
     allocate (${', '.join(('p_' + arg.strip() for arg in args))}$)
     #:for arg in args
-        ${re.sub('\(.*\)','',arg)}$ => ${ 'p_' + re.sub('\(.*\)','',arg.strip()) }$
+        ${re.sub('\\(.*\\)','',arg)}$ => ${ 'p_' + re.sub('\\(.*\\)','',arg.strip()) }$
     #:endfor
-    !$acc enter data create(${', '.join(('p_' + re.sub('\(.*\)','',arg.strip()) for arg in args))}$) &
-    !$acc& attach(${', '.join(map(lambda x: re.sub('\(.*\)','',x), args))}$)
+    !$acc enter data create(${', '.join(('p_' + re.sub('\\(.*\\)','',arg.strip()) for arg in args))}$) &
+    !$acc& attach(${', '.join(map(lambda x: re.sub('\\(.*\\)','',x), args))}$)
 #else
     allocate (${', '.join(args)}$)
     !$acc enter data create(${', '.join(args)}$)


### PR DESCRIPTION
Fixes a syntax warning that was very annoying in python 3.12.