### PR TITLE
Update modules for Carpenter

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,12 +40,11 @@ jobs:
         run: /bin/bash mfc.sh test -a -j $(nproc)
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
-          version: v0.6.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -16,7 +16,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Get computer (if not supplied in command-line)
+# Get computer (if not supplied in command line)
 if [ -v $u_c ]; then
     log   "Select a system:"
     log   "$G""ORNL$W:    Ascent     (a) | Frontier (f) | Summit (s) | Wombat (w)"
@@ -66,7 +66,7 @@ fi
 
 log "Loading modules (& env variables) for $M$COMPUTER$CR on $M$CG$CR"'s:'
 
-# Reset modules to default system configuration
+# Reset modules to default system configuration (unless Phoenix or Carpenter)
 if [ "$u_c" != 'p' ] && [ "$u_c" != 'c' ]; then
     module reset > /dev/null 2>&1
     code="$?"
@@ -102,6 +102,7 @@ for element in ${ELEMENTS[@]}; do
     fi
 done
 
+# Don't check for Cray paths on Carpenter, otherwise do check if they exist
 if [ ! -z ${CRAY_LD_LIBRARY_PATH+x} ] && [ "$u_c" != 'c' ]; then
     ok "Found $M\$CRAY_LD_LIBRARY_PATH$CR. Prepending to $M\$LD_LIBRARY_PATH$CR."
     export LD_LIBRARY_PATH="$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH"

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -67,7 +67,7 @@ fi
 log "Loading modules (& env variables) for $M$COMPUTER$CR on $M$CG$CR"'s:'
 
 # Reset modules to default system configuration
-if [ "$u_c" != 'p' ]; then
+if [ "$u_c" != 'p' ] && [ "$u_c" != 'c' ]; then
     module reset > /dev/null 2>&1
     code="$?"
 
@@ -102,7 +102,7 @@ for element in ${ELEMENTS[@]}; do
     fi
 done
 
-if [ ! -z ${CRAY_LD_LIBRARY_PATH+x} ]; then
+if [ ! -z ${CRAY_LD_LIBRARY_PATH+x} ] && [ "$u_c" != 'c' ]; then
     ok "Found $M\$CRAY_LD_LIBRARY_PATH$CR. Prepending to $M\$LD_LIBRARY_PATH$CR."
     export LD_LIBRARY_PATH="$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
 fi

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -62,5 +62,5 @@ d-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 c     DoD Carpenter
 c-all python/3.12.1
-c-cpu openmpi/4.1.6 gcc/12.2.0 cmake/3.28.1-gcc-12.2.0
-c-cpu CXX=g++
+c-cpu compiler-rt/2024.2.0 ifort/2024.2.0 icc/2023.1.0 mpi/latest cmake/3.28.1-intel-2023.0.0
+c-cpu CC=gcc CXX=g++ FC=gfortran

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -61,6 +61,6 @@ d-gpu nvhpc/22.11 openmpi+cuda/4.1.5+cuda cmake
 d-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 c     DoD Carpenter
-c-all python
-c-cpu gcc/12.2.0 cmake/3.28.1-gcc-12.2.0 openmpi/4.1.6
-c-gpu nvhpc/23.7 cuda/12.2
+c-all python/3.12.1
+c-cpu openmpi/4.1.6 gcc/12.2.0 cmake/3.28.1-gcc-12.2.0
+c-cpu CXX=g++

--- a/toolchain/templates/carpenter.mako
+++ b/toolchain/templates/carpenter.mako
@@ -29,16 +29,15 @@ cd "${MFC_ROOTDIR}"
 cd - > /dev/null
 echo
 
-    
 % for target in targets:
     ${helpers.run_prologue(target)}
 
     % if not mpi:
         (set -x; ${profiler} "${target.get_install_binpath(case)}")
     % else:
-        (set -x; ${profiler}                              \
-            mpirun -np ${nodes*tasks_per_node}            \
-                   "${target.get_install_binpath(case)}")
+        (set -x;                               \
+            mpirun -np ${nodes*tasks_per_node} \
+                 ${profiler} "${target.get_install_binpath(case)}")
     % endif
 
     ${helpers.run_epilogue(target)}

--- a/toolchain/templates/carpenter.mako
+++ b/toolchain/templates/carpenter.mako
@@ -33,13 +33,13 @@ echo
     ${helpers.run_prologue(target)}
 
     % if not mpi:
-        (set -x; ${profiler}  "${target.get_install_binpath(case)}")
+        (set -x; ${profiler} "${target.get_install_binpath(case)}")
     % else:
-        (set -x;                               \
-            mpirun -np ${nodes*tasks_per_node} \
-                 ${profiler} "${target.get_install_binpath(case)}")
+        (set -x; ${profiler}                              \
+            mpirun -np ${nodes*tasks_per_node}            \
+                   "${target.get_install_binpath(case)}")
     % endif
-
+            
     ${helpers.run_epilogue(target)}
 
     echo

--- a/toolchain/templates/carpenter.mako
+++ b/toolchain/templates/carpenter.mako
@@ -33,7 +33,7 @@ echo
     ${helpers.run_prologue(target)}
 
     % if not mpi:
-        (set -x; ${profiler} "${target.get_install_binpath(case)}")
+        (set -x; ${profiler}  "${target.get_install_binpath(case)}")
     % else:
         (set -x;                               \
             mpirun -np ${nodes*tasks_per_node} \


### PR DESCRIPTION
## Description

On Carpenter, the current set of modules causes warnings possibly due to compatibility issue among old compilers. Thus, this PR update the modules so that no warning appears.

Also, on carpenter,  `module purge` was not executed. So I edited the code in `toolchain/bootstrap/modules.sh`to execute `module purge` properly .

### Type of change

Please delete options that are not relevant.

- [x] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

- test suite passed
- tested with `examples/2D_shockbubble` for both interactive and batch jobs and worked well (no more warnings!)
