### PR TITLE
Fix NVTX ranges

### DIFF
--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -731,6 +731,8 @@ contains
         integer :: i, j, k, l, q, ii, id !< Generic loop iterators
         integer :: term_index
 
+        call nvtxStartRange("Compute_RHS")
+
         ! Configuring Coordinate Direction Indexes =========================
         ix%beg = -buff_size; iy%beg = 0; iz%beg = 0
 
@@ -1033,6 +1035,7 @@ contains
         end if
         ! ==================================================================
 
+        call nvtxEndRange
     end subroutine s_compute_rhs
 
     subroutine s_compute_advection_source_term(idir, rhs_vf, q_cons_vf, q_prim_vf, flux_src_n_vf)

--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -804,7 +804,7 @@ contains
                                                  q_prim_qp, &
                                                  dq_prim_dx_qp, dq_prim_dy_qp, dq_prim_dz_qp, &
                                                  ix, iy, iz)
-        call nvtxEndRange()
+        call nvtxEndRange
 
         call nvtxStartRange("Surface_Tension")
         if (.not. f_is_default(sigma)) call s_get_capilary(q_prim_qp%vf)
@@ -833,16 +833,13 @@ contains
                     qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
                     qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
                     id)
-                call nvtxEndRange
             else
-
                 iv%beg = 1; iv%end = E_idx - 1
                 call s_reconstruct_cell_boundary_values( &
                     q_prim_qp%vf(iv%beg:iv%end), &
                     qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
                     qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
                     id)
-                call nvtxEndRange
 
                 iv%beg = E_idx; iv%end = E_idx
                 call s_reconstruct_cell_boundary_values_first_order( &
@@ -850,7 +847,6 @@ contains
                     qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
                     qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
                     id)
-                call nvtxEndRange
 
                 iv%beg = E_idx + 1; iv%end = sys_size
                 call s_reconstruct_cell_boundary_values( &
@@ -858,8 +854,6 @@ contains
                     qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
                     qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
                     id)
-                call nvtxEndRange
-
             end if
 
             ! Reconstruct viscous derivatives for viscosity
@@ -889,7 +883,7 @@ contains
                 end if
             end if
 
-            call nvtxEndRange
+            call nvtxEndRange ! WENO
 
             ! Configuring Coordinate Direction Indexes ======================
             if (id == 1) then
@@ -901,6 +895,7 @@ contains
             end if
             ix%end = m; iy%end = n; iz%end = p
             ! ===============================================================
+            call nvtxStartRange("RHS_riemann_solver")
 
             ! Computing Riemann Solver Flux and Source Flux =================
 
@@ -930,7 +925,7 @@ contains
                                                  q_cons_qp, &
                                                  q_prim_qp, &
                                                  flux_src_n(id))
-            call nvtxEndRange()
+            call nvtxEndRange
 
             ! RHS additions for hypoelasticity
             call nvtxStartRange("RHS_Hypoelasticity")


### PR DESCRIPTION
## Description

The boundaries for the NVTX ranges for WENO and the Riemann solver were broken during the process of adding MI200 support.

Fixes #501 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] Profile the 3D performance test for 10 time steps, yield the same profile as the one attached to this PR.
[fixed_prof.zip](https://github.com/user-attachments/files/16301332/fixed_prof.zip)


**Test Configuration**:

* What computers and compilers did you use to test this:
* Rogue's Gallery UWing Nodes (GH200) -- NVHPC 24.1

## Checklist

- [x] I have added comments for the new code
- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x] Checked that the code compiles using NVHPC compilers
- [x] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [x] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [x] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this [PR](url)
