### PR TITLE
Fix case-opt WENOs on Frontier

### DIFF
--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -121,10 +121,10 @@ module m_global_parameters
         integer, parameter :: weno_polyn = ${weno_polyn}$ !< Degree of the WENO polynomials (polyn)
         integer, parameter :: weno_order = ${weno_order}$ !< Order of the WENO reconstruction
         integer, parameter :: num_fluids = ${num_fluids}$ !< number of fluids in the simulation
-        logical, parameter :: wenojs = ${wenojs}$           !< WENO-JS (default)
-        logical, parameter :: mapped_weno = ${mapped_weno}$ !< WENO-M (WENO with mapping of nonlinear weights)
-        logical, parameter :: wenoz = ${wenoz}$             !< WENO-Z
-        logical, parameter :: teno = ${teno}$               !< TENO (Targeted ENO)
+        logical, parameter :: wenojs = (${wenojs}$ /= 0)            !< WENO-JS (default)
+        logical, parameter :: mapped_weno = (${mapped_weno}$ /= 0)  !< WENO-M (WENO with mapping of nonlinear weights)
+        logical, parameter :: wenoz = (${wenoz}$ /= 0)              !< WENO-Z
+        logical, parameter :: teno = (${teno}$ /= 0)                !< TENO (Targeted ENO)
     #:else
         integer :: weno_polyn     !< Degree of the WENO polynomials (polyn)
         integer :: weno_order     !< Order of the WENO reconstruction


### PR DESCRIPTION
## Description

Fixes #534, where assigning ones and zeros to logicals in the generated case-optimized F90 files causes case optimization to not work on Frontier.

It now generates this f90 code intead:
```
logical, parameter :: wenojs = (0 /= 0)
logical, parameter :: mapped_weno = (0 /= 0)
logical, parameter :: wenoz = (1 /= 0)
logical, parameter :: teno = (0 /= 0)
```


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

- [x] Passes WENO test suits
- [x] Works with case-optimization & generates the expected f90 file

