### PR TITLE
Update to rhel9 modules on Phoenix

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -42,9 +42,9 @@ e-gpu gpu/0.15.4 cuda/11.0.2 nvhpc/22.2 openmpi/4.0.5 cmake/3.19.8
 e-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 p     GT Phoenix
-p-all python/3.9.12-rkxvr6 
-p-cpu gcc/12.1.0-qgxpzk mvapich2/2.3.7-733lcv
-p-gpu cmake/3.23.1-327dbl cuda/11.7.0-7sdye3 nvhpc/22.11
+p-all python 
+p-cpu gcc openmpi
+p-gpu nvhpc hpcx
 p-gpu MFC_CUDA_CC=70,80 CC=nvc CXX=nvc++ FC=nvfortran
 
 f     OLCF Frontier


### PR DESCRIPTION
Phoenix was upgraded to RHEL9 (at least most nodes for now). You now log onto phoenix via `ssh username@login-phoenix-rh9.pace.gatech.edu` (for now). I migrated our runners to the RHEL9 deployment and the compilers on that system.