### PR TITLE
Migrate back to RH7 modules on Phoenix

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -44,7 +44,7 @@ e-gpu CC=nvc CXX=nvc++ FC=nvfortran
 p     GT Phoenix
 p-all python 
 p-cpu gcc openmpi
-p-gpu nvhpc hpcx cuda
+p-gpu nvhpc/22.11 cuda
 p-gpu MFC_CUDA_CC=70,80 CC=nvc CXX=nvc++ FC=nvfortran
 
 f     OLCF Frontier

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -43,7 +43,7 @@ e-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 p     GT Phoenix
 p-all python 
-p-cpu gcc openmpi
+p-cpu gcc/12.1.0-qgxpzk mvapich2/2.3.7-733lcv
 p-gpu nvhpc/22.11 cuda
 p-gpu MFC_CUDA_CC=70,80 CC=nvc CXX=nvc++ FC=nvfortran
 


### PR DESCRIPTION
This PR fixes the module problem on RHEL7 nodes on Phoenix. Runners were moved back to the RH7 nodes. RH9 modules are not working with `./mfc.sh test -a` due to a problem with `hpcx` and `parallel_IO`, which will be fixed in a future PR.

All existing PRs should pull this from master to run CI.