### PR TITLE
Fix bug in performance printing

### DIFF
--- a/docs/documentation/expectedPerformance.md
+++ b/docs/documentation/expectedPerformance.md
@@ -29,7 +29,7 @@ These are reported as (X/Y cores), where X is the used cores, and Y is the total
 | NVIDIA P100                                  | 1 GPU           | 2.35           | NVHPC 23.5           | GT CSE Internal  |
 | NVIDIA A40 (SP GPU)                          | 1 GPU           | 3.3            | NVHPC 22.11          | NCSA Delta  |
 | NVIDIA RTX6000 (SP GPU)                      | 1 GPU           | 3.9            | NVHPC 22.11          | GT Phoenix  |
-| Apple M1 Max                                 | 10/10 cores     | 14.3           | GNU 14.1.0           | N/A         |
+| Apple M1 Max                                 |  8/10 cores     | 14.3           | GNU 14.1.0           | N/A         |
 | IBM Power9                                   | 20/21 cores     | 21.2           | GNU 9.1.0            | OLCF Summit |
 
 Processors To-do:

--- a/docs/documentation/expectedPerformance.md
+++ b/docs/documentation/expectedPerformance.md
@@ -13,10 +13,9 @@ This case is located in `examples/3D_performance_test`.
 Results are for MFC v4.9.3 (July 2024 release), though numbers have not changed meaningfully since then.
 All results are for the compiler that gave the best performance.
 Note:
-* CPU results may be performed on CPUs with more cores than reported in the table; we report results for the best performance given the full processor die by checking the performance for different core counts on that device.
+* CPU results may be performed on CPUs with more cores than reported in the table; we report results for the best performance given the full processor die by checking the performance for different core counts on that device. CPU results are for the best performance we achieved using a single socket (or die).
 These are reported as (X/Y cores), where X is the used cores, and Y is the total on the die.
-* GPU results on single-precision (SP) GPUs performed computation in double-precision via conversion in compiler/software; these numbers are _not_ for single-precision computation.
-AMD MI250X GPUs have two graphics compute dies (GCDs) per MI250X device; we report results for one GCD, though one can quickly estimate full MI250X runtime by halving the single GCD grind time number.
+* GPU results are for a single GPU device. For single-precision (SP) GPUs, we performed computation in double-precision via conversion in compiler/software; these numbers are _not_ for single-precision computation. AMD MI250X GPUs have two graphics compute dies (GCDs) per MI250X device; we report results for one GCD, though one can quickly estimate full MI250X runtime by halving the single GCD grind time number.
 
 | Hardware                                     |                 | Grind Time     | Compiler             | Computer     |
 | ---:                                         | ----:           | ----:         | :---                 | :---         | 
@@ -30,18 +29,24 @@ AMD MI250X GPUs have two graphics compute dies (GCDs) per MI250X device; we repo
 | NVIDIA P100                                  | 1 GPU           | 2.35           | NVHPC 23.5           | GT CSE Internal  |
 | NVIDIA A40 (SP GPU)                          | 1 GPU           | 3.3            | NVHPC 22.11          | NCSA Delta  |
 | NVIDIA RTX6000 (SP GPU)                      | 1 GPU           | 3.9            | NVHPC 22.11          | GT Phoenix  |
-| Apple M1 Max                                 | 8/10 cores      | 72             | GNU 14.1.0           | N/A         |
-| AMD EPYC 9534 (Genoa)                        | 64/64 cores     | 96             | GNU 12.3.0           | GT Phoenix  |
-| AMD EPYC 7763 (Milan)                        | 24/64 cores     | 108            | GNU 11.4.0           | NCSA Delta  |
-| Intel Xeon Platinum 8462Y+ (Sapphire Rapids) | 16/32 cores     | 110            | GNU 12.3.0           | GT ICE  |
-| Intel Xeon Gold 6454S (Sapphire Rapids)      | 16/32 cores     | 111            | NVHPC 24.5           | GT Rogues Gallery  |
-| NVIDIA Grace CPU (Arm, Neoverse V2)          | 18/72 cores     | 116            | NVHPC 24.1           | GT Rogues Gallery  |
-| AMD EPYC 7452 (Rome)                         | 16/32 cores     | 126            | GNU 12.3.0           | GT ICE  |
-| Intel Xeon Platinum 8352Y (Ice Lake)         | 12/32 cores     | 128            | NVHPC 24.5           | GT Rogues Gallery  |
-| AMD EPYC 7713 (Milan)                        | 32/64 cores     | 137            | GNU 12.1.0           | GT Phoenix  |
-| Intel Xeon Gold 6226 (Cascade Lake)          | 12/12 cores     | 152            | Intel oneAPI 2022.1  | GT Phoenix  |
-| Ampere Altra Max (Arm, Neoverse-N1)          |  8/80 cores     | 183            | GNU 12.2.0           | OLCF Wombat  | 
-| Intel Xeon E5-2650V4 (Broadwell)             |  8/12 cores     | 230            | NVHPC 23.5           | GT CSE Internal  |
+| IBM Power9                                   | 20/21 cores     | 21.2           | GNU 9.1.0            | OLCF Summit |
+
+Processors To-do:
+
+| Hardware                                     |                 | Grind Time     | Compiler             | Computer     |
+| ---:                                         | ----:           | ----:         | :---                 | :---         | 
+| Apple M1 Max                                 | 8/10 cores      | n/a            | GNU 14.1.0           | N/A         |
+| AMD EPYC 9534 (Genoa)                        | 64/64 cores     | n/a            | GNU 12.3.0           | GT Phoenix  |
+| AMD EPYC 7763 (Milan)                        | 24/64 cores     | n/a            | GNU 11.4.0           | NCSA Delta  |
+| Intel Xeon Platinum 8462Y+ (Sapphire Rapids) | 16/32 cores     | n/a            | GNU 12.3.0           | GT ICE  |
+| Intel Xeon Gold 6454S (Sapphire Rapids)      | 16/32 cores     | n/a            | NVHPC 24.5           | GT Rogues Gallery  |
+| NVIDIA Grace CPU (Arm, Neoverse V2)          | 18/72 cores     | n/a            | NVHPC 24.1           | GT Rogues Gallery  |
+| AMD EPYC 7452 (Rome)                         | 16/32 cores     | n/a            | GNU 12.3.0           | GT ICE  |
+| Intel Xeon Platinum 8352Y (Ice Lake)         | 12/32 cores     | n/a            | NVHPC 24.5           | GT Rogues Gallery  |
+| AMD EPYC 7713 (Milan)                        | 32/64 cores     | n/a            | GNU 12.1.0           | GT Phoenix  |
+| Intel Xeon Gold 6226 (Cascade Lake)          | 12/12 cores     | n/a            | Intel oneAPI 2022.1  | GT Phoenix  |
+| Ampere Altra Max (Arm, Neoverse-N1)          |  8/80 cores     | n/a            | GNU 12.2.0           | OLCF Wombat  | 
+| Intel Xeon E5-2650V4 (Broadwell)             |  8/12 cores     | n/a            | NVHPC 23.5           | GT CSE Internal  |
 
 __All grind times are in nanoseconds (ns) per grid point (gp) per equation (eq) per right-hand side (rhs) evaluation, so X ns/gp/eq/rhs. Lower is better.__
 

--- a/docs/documentation/expectedPerformance.md
+++ b/docs/documentation/expectedPerformance.md
@@ -29,13 +29,13 @@ These are reported as (X/Y cores), where X is the used cores, and Y is the total
 | NVIDIA P100                                  | 1 GPU           | 2.35           | NVHPC 23.5           | GT CSE Internal  |
 | NVIDIA A40 (SP GPU)                          | 1 GPU           | 3.3            | NVHPC 22.11          | NCSA Delta  |
 | NVIDIA RTX6000 (SP GPU)                      | 1 GPU           | 3.9            | NVHPC 22.11          | GT Phoenix  |
+| Apple M1 Max                                 | 10/10 cores     | 14.3           | GNU 14.1.0           | N/A         |
 | IBM Power9                                   | 20/21 cores     | 21.2           | GNU 9.1.0            | OLCF Summit |
 
 Processors To-do:
 
 | Hardware                                     |                 | Grind Time     | Compiler             | Computer     |
 | ---:                                         | ----:           | ----:         | :---                 | :---         | 
-| Apple M1 Max                                 | 8/10 cores      | n/a            | GNU 14.1.0           | N/A         |
 | AMD EPYC 9534 (Genoa)                        | 64/64 cores     | n/a            | GNU 12.3.0           | GT Phoenix  |
 | AMD EPYC 7763 (Milan)                        | 24/64 cores     | n/a            | GNU 11.4.0           | NCSA Delta  |
 | Intel Xeon Platinum 8462Y+ (Sapphire Rapids) | 16/32 cores     | n/a            | GNU 12.3.0           | GT ICE  |

--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -1028,7 +1028,7 @@ contains
         end if
         call cpu_time(t_finish)
         if (t_step >= 4) then
-            time_avg = (abs(t_finish - t_start)/((ix%end - ix%beg)*(iy%end - iy%beg)*(iz%end - iz%beg)) + (t_step - 4)*time_avg)/(t_step - 3)
+            time_avg = (abs(t_finish - t_start) + (t_step - 4)*time_avg)/(t_step - 3)
         else
             time_avg = 0d0
         end if

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -1152,7 +1152,7 @@ contains
                 time_final = maxval(proc_time)
                 io_time_final = maxval(io_proc_time)
             end if
-            print *, "Performance: ", time_final*1.0d9/sys_size, " ns/gp/eq/rhs"
+            print *, "Performance: ", time_final*1.0d9/(sys_size*maxval((/1,m_glb/))*maxval((/1,n_glb/))*maxval((/1,p_glb/))), " ns/gp/eq/rhs"
             inquire (FILE='time_data.dat', EXIST=file_exists)
             if (file_exists) then
                 open (1, file='time_data.dat', position='append', status='old')


### PR DESCRIPTION
Fixes two bugs in performance printing
* Now allows for 1/2D performance
* Before, it was printing simulation time _per_ MPI rank, but what we really want is time (per grid point per rhs per eqn) for the entire simulation, without taking into account how many MPI ranks there are. I used `m_glb`... for this to get the full problem size