### PR TITLE
Fixes a parallel i/o issue

### DIFF
--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -1003,8 +1003,6 @@ contains
             call MPI_FILE_CLOSE(ifile, ierr)
         end if
 
-        call MPI_FILE_CLOSE(ifile, ierr)
-
 #endif
 
     end subroutine s_write_parallel_data_files


### PR DESCRIPTION
Fixes #547, which only sometimes throws errors.

Checked on known non-working case (before/after). Also checked that things still work on known working compilers.