### PR TITLE
Fix runtime info dumping output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ examples/*/restart_data*
 examples/*/*.out
 examples/*/binary
 examples/*/fort.1
+examples/*/runtime_info.txt
 examples/*/*.sh
 examples/*/*.err
 examples/*/viz/

--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -1639,9 +1639,9 @@ contains
         real(kind(0d0)) :: run_time !< Run-time of the simulation
 
         character(len=*), parameter :: file_name = 'runtime_info.txt'
-        
+
         ! Reopen the file with the desired name associated with logical unit 1
-        open(unit=1, file=file_name, status='unknown', action='write')
+        open (unit=1, file=file_name, status='unknown', action='write')
 
         ! Writing the footer of and closing the run-time information file
         write (1, '(A)') '----------------------------------------'// &

--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -1638,6 +1638,11 @@ contains
 
         real(kind(0d0)) :: run_time !< Run-time of the simulation
 
+        character(len=*), parameter :: file_name = 'runtime_info.txt'
+        
+        ! Reopen the file with the desired name associated with logical unit 1
+        open(unit=1, file=file_name, status='unknown', action='write')
+
         ! Writing the footer of and closing the run-time information file
         write (1, '(A)') '----------------------------------------'// &
             '----------------------------------------'


### PR DESCRIPTION
runtime_info.txt

## Description

Issue #504 shows a default fortran file being outputted when running 1D_impact case. I renamed the output file from fortran.1 to runtime_info.txt, a more appropriate name.

Fixes #504

### Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] Test A:  Running ./mfc.sh run examples/1D_impact/case.py shows the file runtime_info.txt file instead of fortran.1

**Test Configuration**:

* What computers and compilers did you use to test this:

## Checklist

- [x] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [x] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)