### PR TITLE
Fix adding footer output to runtimeinfo Fixes #574

### DIFF
--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -1638,6 +1638,26 @@ contains
 
         real(kind(0d0)) :: run_time !< Run-time of the simulation
 
+        character(LEN=name_len) :: file_name = 'run_time.inf' !<
+            !! Name of the run-time information file
+
+        character(LEN=path_len + name_len) :: file_path !<
+            !! Relative path to a file in the case directory
+
+        logical :: file_exist !<
+            !! Logical used to check existence of run-time information file
+
+        ! Opening the run-time information file
+        file_path = trim(case_dir)//'/'//trim(file_name)
+
+        inquire (FILE=trim(file_path), EXIST=file_exist)
+
+        open (1, FILE=trim(file_path), &
+              FORM='formatted', &
+              POSITION='append', &
+              STATUS='unknown')
+
+
         ! Writing the footer of and closing the run-time information file
         write (1, '(A)') '----------------------------------------'// &
             '----------------------------------------'

--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -1657,7 +1657,6 @@ contains
               POSITION='append', &
               STATUS='unknown')
 
-
         ! Writing the footer of and closing the run-time information file
         write (1, '(A)') '----------------------------------------'// &
             '----------------------------------------'


### PR DESCRIPTION
## Description

Orignally, the subroutine s_close_run_time_info, which intended to write a footer to run_time.inf file, was writing output to fort.1 file. This is because the run_time.inf was only being opened under unit 1 in the subroutine s_open_run_time_info. However, the subroutine s_save_performance_metrics(t_step, time_avg, time_final, io_time_avg, & io_time_final, proc_time, io_proc_time, file_exists, start, finish, nt) , which is called in between s_open_run_time_info and s_close_run_time_info, opened then closed unit 1. As a result, s_close_run_time_info was attempting to write to an unopened file, and was thus outputting to fort.1

Solution:
Reopened run_time.inf file under unit in s_close_run_time_info subroutine

Fixes #574 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] Test A After running "./mfc.sh run examples/1D_impact/case.py" no fort.1 file is outputted and run_time.inf has footer.
- [ ] Test B

**Test Configuration**:

* What computers and compilers did you use to test this:

## Checklist

- [x] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [x] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [ ] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran an Omniperf profile using `./mfc.sh run XXXX --gpu -t simulation --omniperf`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
