### PR TITLE
Migrate GT runners to RHEL9

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -42,10 +42,8 @@ e-gpu gpu/0.15.4 cuda/11.0.2 nvhpc/22.2 openmpi/4.0.5 cmake/3.19.8
 e-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 p     GT Phoenix
-p-all python 
-p-cpu gcc/12.1.0-qgxpzk mvapich2/2.3.7-733lcv
-p-gpu nvhpc/22.11 cuda
-p-gpu MFC_CUDA_CC=70,80 CC=nvc CXX=nvc++ FC=nvfortran
+p-cpu gcc/12.3.0 openmpi/4.1.5
+p-gpu nvhpc/24.5 hpcx/2.19-cuda cuda/12.1.1
 
 f     OLCF Frontier
 f-gpu rocm/5.5.1 craype-accel-amd-gfx90a


### PR DESCRIPTION
## Description

Migrate GT runners to RHEL9 because the current RHEL7 nodes are becoming deprecated and can no longer build MFC from scratch without errors. Note: `export MFC_CUDA_CC=70,80` causes `nvfortran` to fail with errors. See:

```console
hberre3 $ nvc -acc test.c -o test
hberre3 $ nvc -acc -gpu=cc80 test.c -o test
nvc-Error-A CUDA toolkit matching the current driver version (0) or a supported older version (11.8) was not installed with this HPC SDK.
```

where test.c is:
```c
int main() { return 0; }
```