### PR TITLE
DRY m_check_patches & m_check_ib_patches

### DIFF
--- a/src/pre_process/m_check_ib_patches.fpp
+++ b/src/pre_process/m_check_ib_patches.fpp
@@ -207,7 +207,11 @@ contains
             (patch_ib(patch_id)%length_x <= 0d0 .and. &
              patch_ib(patch_id)%length_y <= 0d0 .and. &
              patch_ib(patch_id)%length_z <= 0d0) &
-            .or. &
+             .or. &
+             patch_ib(patch_id)%radius <= 0d0, &
+            'in cylinder IB patch '//trim(iStr))
+
+        @:PROHIBIT( &
             (patch_ib(patch_id)%length_x > 0d0 .and. &
              ((.not. f_is_default(patch_ib(patch_id)%length_y)) .or. &
               (.not. f_is_default(patch_ib(patch_id)%length_z)))) &
@@ -218,9 +222,7 @@ contains
             .or. &
             (patch_ib(patch_id)%length_z > 0d0 .and. &
              ((.not. f_is_default(patch_ib(patch_id)%length_x)) .or. &
-              (.not. f_is_default(patch_ib(patch_id)%length_y)))) &
-            .or. &
-            patch_ib(patch_id)%radius <= 0d0, &
+              (.not. f_is_default(patch_ib(patch_id)%length_y)))), &
             'in cylinder IB patch '//trim(iStr))
 
     end subroutine s_check_cylinder_ib_patch_geometry

--- a/src/pre_process/m_check_ib_patches.fpp
+++ b/src/pre_process/m_check_ib_patches.fpp
@@ -54,15 +54,15 @@ contains
                 else if (patch_ib(i)%geometry == 4) then
                     call s_check_airfoil_ib_patch_geometry(i)
                 else if (patch_ib(i)%geometry == 11) then
-                    call s_check_3D_airfoil_ib_patch_geometry(i)
+                    call s_check_3d_airfoil_ib_patch_geometry(i)
                 else if (patch_ib(i)%geometry == 10) then
                     call s_check_cylinder_ib_patch_geometry(i)
                 else if (patch_ib(i)%geometry == dflt_int) then
                     call s_prohibit_abort("IB patch undefined", &
-                                          "patch_icpp("//trim(iStr)//")%geometry must not be set.")
+                                          "patch_ib("//trim(iStr)//")%geometry must be set.")
                 else
                     call s_prohibit_abort("Invalid IB patch", &
-                                          "patch_icpp("//trim(iStr)//")%geometry must be "// &
+                                          "patch_ib("//trim(iStr)//")%geometry must be "// &
                                           "2-4, 8, 10, or 11.")
                 end if
             else
@@ -70,7 +70,7 @@ contains
                     call s_check_inactive_ib_patch_geometry(i)
                 else
                     call s_prohibit_abort("Inactive IB patch defined", &
-                                          "patch_icpp("//trim(iStr)//")%geometry "// &
+                                          "patch_ib("//trim(iStr)//")%geometry "// &
                                           "must not be set for inactive patches.")
                 end if
             end if
@@ -92,7 +92,7 @@ contains
             .or. patch_ib(patch_id)%radius <= 0d0 &
             .or. f_is_default(patch_ib(patch_id)%x_centroid) &
             .or. f_is_default(patch_ib(patch_id)%y_centroid), &
-            'in circle patch '//trim(iStr))
+            'in circle IB patch '//trim(iStr))
 
     end subroutine s_check_circle_ib_patch_geometry
 
@@ -113,7 +113,7 @@ contains
             .or. patch_ib(patch_id)%m <= 0d0 &
             .or. f_is_default(patch_ib(patch_id)%x_centroid) &
             .or. f_is_default(patch_ib(patch_id)%y_centroid), &
-            'in airfoil patch '//trim(iStr))
+            'in airfoil IB patch '//trim(iStr))
 
     end subroutine s_check_airfoil_ib_patch_geometry
 
@@ -127,7 +127,7 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        @:PROHIBIT(n == 0 .or. p > 0 &
+        @:PROHIBIT(n == 0 .or. p == 0 &
             .or. patch_ib(patch_id)%c <= 0d0 &
             .or. patch_ib(patch_id)%p <= 0d0 &
             .or. patch_ib(patch_id)%t <= 0d0 &
@@ -136,7 +136,7 @@ contains
             .or. f_is_default(patch_ib(patch_id)%y_centroid) &
             .or. f_is_default(patch_ib(patch_id)%z_centroid) &
             .or. f_is_default(patch_ib(patch_id)%length_z), &
-            'in 3d airfoil patch '//trim(iStr))
+            'in 3d airfoil IB patch '//trim(iStr))
 
     end subroutine s_check_3d_airfoil_ib_patch_geometry
 
@@ -159,7 +159,7 @@ contains
             patch_ib(patch_id)%length_x <= 0d0 &
             .or. &
             patch_ib(patch_id)%length_y <= 0d0, &
-            'in rectangle patch '//trim(iStr))
+            'in rectangle IB patch '//trim(iStr))
 
     end subroutine s_check_rectangle_ib_patch_geometry
 
@@ -173,7 +173,7 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        @:PROHIBIT(n == 0 .or. p > 0 &
+        @:PROHIBIT(n == 0 .or. p == 0 &
             .or. &
             f_is_default(patch_ib(patch_id)%x_centroid) &
             .or. &
@@ -182,7 +182,7 @@ contains
             f_is_default(patch_ib(patch_id)%z_centroid) &
             .or. &
             patch_ib(patch_id)%radius <= 0d0, &
-            'in sphere patch '//trim(iStr))
+            'in sphere IB patch '//trim(iStr))
 
     end subroutine s_check_sphere_ib_patch_geometry
 
@@ -221,7 +221,7 @@ contains
               (.not. f_is_default(patch_ib(patch_id)%length_y)))) &
             .or. &
             patch_ib(patch_id)%radius <= 0d0, &
-            'in cylinder patch '//trim(iStr))
+            'in cylinder IB patch '//trim(iStr))
 
     end subroutine s_check_cylinder_ib_patch_geometry
 
@@ -247,7 +247,7 @@ contains
             (.not. f_is_default(patch_ib(patch_id)%length_z)) &
             .or. &
             (.not. f_is_default(patch_ib(patch_id)%radius)), &
-            'in inactive patch '//trim(iStr))
+            'in inactive IB patch '//trim(iStr))
 
     end subroutine s_check_inactive_ib_patch_geometry
 

--- a/src/pre_process/m_check_ib_patches.fpp
+++ b/src/pre_process/m_check_ib_patches.fpp
@@ -1,5 +1,8 @@
 !> @brief This module contains subroutines that read, and check consistency
 !!              of, the user provided inputs and data.
+
+#:include 'macros.fpp'
+
 module m_check_ib_patches
 
     ! Dependencies =============================================================
@@ -40,6 +43,7 @@ contains
             if (i <= num_ibs) then
                 ! call s_check_patch_geometry(i)
                 call s_int_to_str(i, iStr)
+
                 ! Constraints on the geometric initial condition patch parameters
                 if (patch_ib(i)%geometry == 2) then
                     call s_check_circle_ib_patch_geometry(i)
@@ -53,18 +57,21 @@ contains
                     call s_check_3D_airfoil_ib_patch_geometry(i)
                 else if (patch_ib(i)%geometry == 10) then
                     call s_check_cylinder_ib_patch_geometry(i)
+                else if (patch_ib(i)%geometry == dflt_int) then
+                    call s_prohibit_abort("IB patch undefined", &
+                                          "patch_icpp("//trim(iStr)//")%geometry must not be set.")
                 else
-                    call s_mpi_abort('Unsupported choice of the '// &
-                                     'geometry of active patch '//trim(iStr)// &
-                                     ' detected. Exiting ...')
+                    call s_prohibit_abort("Invalid IB patch", &
+                                          "patch_icpp("//trim(iStr)//")%geometry must be "// &
+                                          "2-4, 8, 10, or 11.")
                 end if
             else
                 if (patch_ib(i)%geometry == dflt_int) then
                     call s_check_inactive_ib_patch_geometry(i)
                 else
-                    call s_mpi_abort('Unsupported choice of the '// &
-                                     'geometry of inactive patch '//trim(iStr)// &
-                                     ' detected. Exiting ...')
+                    call s_prohibit_abort("Inactive IB patch defined", &
+                                          "patch_icpp("//trim(iStr)//")%geometry "// &
+                                          "must not be set for inactive patches.")
                 end if
             end if
         end do
@@ -81,18 +88,11 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the circle patch
-        if (n == 0 .or. p > 0 .or. patch_ib(patch_id)%radius <= 0d0 &
-            .or. &
-            f_is_default(patch_ib(patch_id)%x_centroid) &
-            .or. &
-            f_is_default(patch_ib(patch_id)%y_centroid)) then
-
-            call s_mpi_abort('Inconsistency(ies) detected in '// &
-                             'geometric parameters of circle '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-
-        end if
+        @:PROHIBIT(n == 0 .or. p > 0 &
+            .or. patch_ib(patch_id)%radius <= 0d0 &
+            .or. f_is_default(patch_ib(patch_id)%x_centroid) &
+            .or. f_is_default(patch_ib(patch_id)%y_centroid), &
+            'in circle patch '//trim(iStr))
 
     end subroutine s_check_circle_ib_patch_geometry
 
@@ -106,17 +106,14 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the airfoil patch
-        if (n == 0 .or. p > 0 .or. patch_ib(patch_id)%c <= 0d0 &
-            .or. patch_ib(patch_id)%p <= 0d0 .or. patch_ib(patch_id)%t <= 0d0 &
-            .or. patch_ib(patch_id)%m <= 0d0 .or. f_is_default(patch_ib(patch_id)%x_centroid) &
-            .or. f_is_default(patch_ib(patch_id)%y_centroid)) then
-
-            call s_mpi_abort('Inconsistency(ies) detected in '// &
-                             'geometric parameters of airfoil '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-
-        end if
+        @:PROHIBIT(n == 0 .or. p > 0 &
+            .or. patch_ib(patch_id)%c <= 0d0 &
+            .or. patch_ib(patch_id)%p <= 0d0 &
+            .or. patch_ib(patch_id)%t <= 0d0 &
+            .or. patch_ib(patch_id)%m <= 0d0 &
+            .or. f_is_default(patch_ib(patch_id)%x_centroid) &
+            .or. f_is_default(patch_ib(patch_id)%y_centroid), &
+            'in airfoil patch '//trim(iStr))
 
     end subroutine s_check_airfoil_ib_patch_geometry
 
@@ -130,18 +127,16 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the 3d airfoil patch
-        if (n == 0 .or. p == 0 .or. patch_ib(patch_id)%c <= 0d0 &
-            .or. patch_ib(patch_id)%p <= 0d0 .or. patch_ib(patch_id)%t <= 0d0 &
-            .or. patch_ib(patch_id)%m <= 0d0 .or. f_is_default(patch_ib(patch_id)%x_centroid) &
-            .or. f_is_default(patch_ib(patch_id)%y_centroid) .or. f_is_default(patch_ib(patch_id)%z_centroid) &
-            .or. f_is_default(patch_ib(patch_id)%length_z)) then
-
-            call s_mpi_abort('Inconsistency(ies) detected in '// &
-                             'geometric parameters of airfoil '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-
-        end if
+        @:PROHIBIT(n == 0 .or. p > 0 &
+            .or. patch_ib(patch_id)%c <= 0d0 &
+            .or. patch_ib(patch_id)%p <= 0d0 &
+            .or. patch_ib(patch_id)%t <= 0d0 &
+            .or. patch_ib(patch_id)%m <= 0d0 &
+            .or. f_is_default(patch_ib(patch_id)%x_centroid) &
+            .or. f_is_default(patch_ib(patch_id)%y_centroid) &
+            .or. f_is_default(patch_ib(patch_id)%z_centroid) &
+            .or. f_is_default(patch_ib(patch_id)%length_z), &
+            'in 3d airfoil patch '//trim(iStr))
 
     end subroutine s_check_3d_airfoil_ib_patch_geometry
 
@@ -155,8 +150,7 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the rectangle patch
-        if (n == 0 .or. p > 0 &
+        @:PROHIBIT(n == 0 .or. p > 0 &
             .or. &
             f_is_default(patch_ib(patch_id)%x_centroid) &
             .or. &
@@ -164,13 +158,8 @@ contains
             .or. &
             patch_ib(patch_id)%length_x <= 0d0 &
             .or. &
-            patch_ib(patch_id)%length_y <= 0d0) then
-
-            call s_mpi_abort('Inconsistency(ies) detected in '// &
-                             'geometric parameters of rectangle '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-
-        end if
+            patch_ib(patch_id)%length_y <= 0d0, &
+            'in rectangle patch '//trim(iStr))
 
     end subroutine s_check_rectangle_ib_patch_geometry
 
@@ -184,8 +173,7 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the sphere patch
-        if (n == 0 .or. p == 0 &
+        @:PROHIBIT(n == 0 .or. p > 0 &
             .or. &
             f_is_default(patch_ib(patch_id)%x_centroid) &
             .or. &
@@ -193,13 +181,8 @@ contains
             .or. &
             f_is_default(patch_ib(patch_id)%z_centroid) &
             .or. &
-            patch_ib(patch_id)%radius <= 0d0) then
-
-            call s_mpi_abort('Inconsistency(ies) detected in '// &
-                             'geometric parameters of rectangle '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-
-        end if
+            patch_ib(patch_id)%radius <= 0d0, &
+            'in sphere patch '//trim(iStr))
 
     end subroutine s_check_sphere_ib_patch_geometry
 
@@ -213,8 +196,7 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the cylinder patch
-        if (p == 0 &
+        @:PROHIBIT(p == 0 &
             .or. &
             f_is_default(patch_ib(patch_id)%x_centroid) &
             .or. &
@@ -238,13 +220,8 @@ contains
              ((.not. f_is_default(patch_ib(patch_id)%length_x)) .or. &
               (.not. f_is_default(patch_ib(patch_id)%length_y)))) &
             .or. &
-            patch_ib(patch_id)%radius <= 0d0) then
-
-            call s_mpi_abort('Inconsistency(ies) detected in '// &
-                             'geometric parameters of cylinder '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-
-        end if
+            patch_ib(patch_id)%radius <= 0d0, &
+            'in cylinder patch '//trim(iStr))
 
     end subroutine s_check_cylinder_ib_patch_geometry
 
@@ -257,8 +234,7 @@ contains
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the inactive patch
-        if ((.not. f_is_default(patch_ib(patch_id)%x_centroid)) &
+        @:PROHIBIT((.not. f_is_default(patch_ib(patch_id)%x_centroid)) &
             .or. &
             (.not. f_is_default(patch_ib(patch_id)%y_centroid)) &
             .or. &
@@ -270,13 +246,8 @@ contains
             .or. &
             (.not. f_is_default(patch_ib(patch_id)%length_z)) &
             .or. &
-            (.not. f_is_default(patch_ib(patch_id)%radius))) then
-
-            call s_mpi_abort('Inconsistency(ies) detected in '// &
-                             'geometric parameters of inactive '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-
-        end if
+            (.not. f_is_default(patch_ib(patch_id)%radius)), &
+            'in inactive patch '//trim(iStr))
 
     end subroutine s_check_inactive_ib_patch_geometry
 

--- a/src/pre_process/m_check_ib_patches.fpp
+++ b/src/pre_process/m_check_ib_patches.fpp
@@ -207,8 +207,8 @@ contains
             (patch_ib(patch_id)%length_x <= 0d0 .and. &
              patch_ib(patch_id)%length_y <= 0d0 .and. &
              patch_ib(patch_id)%length_z <= 0d0) &
-             .or. &
-             patch_ib(patch_id)%radius <= 0d0, &
+            .or. &
+            patch_ib(patch_id)%radius <= 0d0, &
             'in cylinder IB patch '//trim(iStr))
 
         @:PROHIBIT( &

--- a/src/pre_process/m_check_patches.fpp
+++ b/src/pre_process/m_check_patches.fpp
@@ -1,5 +1,8 @@
 !> @brief This module contains subroutines that read, and check consistency
 !!              of, the user provided inputs and data.
+
+#:include 'macros.fpp'
+
 module m_check_patches
 
     ! Dependencies =============================================================
@@ -34,6 +37,9 @@ contains
     subroutine s_check_patches
 
         integer :: i
+        character(len=10) :: num_patches_str
+
+        call s_int_to_str(num_patches, num_patches_str)
 
         do i = 1, num_patches_max
             if (i <= num_patches) then
@@ -84,16 +90,18 @@ contains
                     call s_check_2D_TaylorGreen_vortex_patch_geometry(i)
                 elseif (patch_icpp(i)%geometry == 21) then
                     call s_check_model_geometry(i)
+                elseif (patch_icpp(i)%geometry == dflt_int) then
+                    call s_prohibit_abort("Active patch undefined", "patch_icpp("//trim(iStr)//")%geometry must be set")
                 else
-                    call s_mpi_abort('patch_icpp('//trim(iStr)//')%geometry '// &
-                                     'must be between 1 and 21. Exiting ...')
+                    call s_prohibit_abort("Invalid patch geometry number", "patch_icpp("//trim(iStr)//")%geometry "// &
+                                          "must be between 1 and 21")
                 end if
             else
                 if (patch_icpp(i)%geometry == dflt_int) then
                     call s_check_inactive_patch_geometry(i)
                 else
-                    call s_mpi_abort('patch_icpp('//trim(iStr)//')%geometry '// &
-                                     'must must be set. Exiting ...')
+                    call s_prohibit_abort("Inactive patch defined", "patch_icpp("//trim(iStr)//")%geometry must not be set. "// &
+                                          "Patch "//trim(iStr)//" is inactive as the number of patches is "//trim(num_patches_str))
                 end if
             end if
         end do
@@ -137,360 +145,187 @@ contains
 
     end subroutine s_check_patches
 
-    !> This subroutine verifies that the geometric parameters of
-        !!      the line segment patch have consistently been inputted by
-        !!      the user.
+    !> This subroutine checks the line segment patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_line_segment_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
-        ! Constraints on the geometric parameters of the line segment patch
-        if (n > 0) then
-            call s_mpi_abort('n must be zero for line segment '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_x <= 0d0) then
-            call s_mpi_abort('length_x must be greater than zero for '// &
-                             'line segment patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for line segment '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (cyl_coord) then
-            call s_mpi_abort('cyl_coord is not supported for '// &
-                             'line segment patch '//trim(iStr)//'. Exiting ...')
-        end if
+
+        @:PROHIBIT(n > 0, "Line segment patch "//trim(iStr)//": n must be zero")
+        @:PROHIBIT(patch_icpp(patch_id)%length_x <= 0d0, "Line segment patch "//trim(iStr)//": length_x must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Line segment patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(cyl_coord, "Line segment patch "//trim(iStr)//": cyl_coord is not supported")
 
     end subroutine s_check_line_segment_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the circle patch have consistently been inputted by the
-        !!      user.
+    !>  This subroutine checks the circle patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_circle_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the circle patch
-        if (n == 0) then
-            call s_mpi_abort('n must be greater than zero for '// &
-                             'circle patch '//trim(iStr)//'. Exiting ...')
-        elseif (p > 0) then
-            call s_mpi_abort('p must be zero for circle patch '//trim(iStr)// &
-                             '. Exiting ...')
-        elseif (patch_icpp(patch_id)%radius <= 0d0) then
-            call s_mpi_abort('radius must be greater than zero for '// &
-                             'circle patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'circle patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'circle patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(n == 0, "Circle patch "//trim(iStr)//": n must be zero")
+        @:PROHIBIT(p > 0, "Circle patch "//trim(iStr)//": p must be zero")
+        @:PROHIBIT(patch_icpp(patch_id)%radius <= 0d0, "Circle patch "//trim(iStr)//": radius must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Circle patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Circle patch "//trim(iStr)//": y_centroid must be set")
 
     end subroutine s_check_circle_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the rectangle patch have consistently been inputted by
-        !!      the user.
+    !>  This subroutine checks the rectangle patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_rectangle_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the rectangle patch
-        if (n == 0) then
-            call s_mpi_abort('n must be greater than zero for '// &
-                             'rectangle patch '//trim(iStr)//'. Exiting ...')
-        elseif (p > 0) then
-            call s_mpi_abort('p must be zero for rectangle patch '//trim(iStr)// &
-                             '. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'rectangle patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'rectangle patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_x <= 0d0) then
-            call s_mpi_abort('length_x must be greater than zero for '// &
-                             'rectangle patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_y <= 0d0) then
-            call s_mpi_abort('length_y must be greater than zero for '// &
-                             'rectangle patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(n == 0, "Rectangle patch "//trim(iStr)//": n must be greater than zero")
+        @:PROHIBIT(p > 0, "Rectangle patch "//trim(iStr)//": p must be zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Rectangle patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Rectangle patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%length_x <= 0d0, "Rectangle patch "//trim(iStr)//": length_x must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%length_y <= 0d0, "Rectangle patch "//trim(iStr)//": length_y must be greater than zero")
 
     end subroutine s_check_rectangle_patch_geometry
 
-    !> This subroutine verifies that the geometric parameters of
-        !!      the line sweep patch have consistently been inputted by
-        !!      the user.
+    !> This subroutine checks the line sweep patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_line_sweep_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the line sweep patch
-        if (n == 0) then
-            call s_mpi_abort('n must be greater than zero for '// &
-                             'sweep line patch '//trim(iStr)//'. Exiting ...')
-        elseif (p > 0) then
-            call s_mpi_abort('p must be zero for sweep line patch '//trim(iStr)// &
-                             '. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'sweep line patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'sweep line patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%normal(1))) then
-            call s_mpi_abort('normal(1) must be set for '// &
-                             'sweep line patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%normal(2))) then
-            call s_mpi_abort('normal(2) must be set for '// &
-                             'sweep line patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%normal(3))) then
-            call s_mpi_abort('normal(3) must be equal to dflt_real for '// &
-                             'sweep line patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(n == 0, "Line sweep patch "//trim(iStr)//": n must be greater than zero")
+        @:PROHIBIT(p > 0, "Line sweep patch "//trim(iStr)//": p must be zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Line sweep patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Line sweep patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%normal(1)), "Line sweep patch "//trim(iStr)//": normal(1) must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%normal(2)), "Line sweep patch "//trim(iStr)//": normal(2) must be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%normal(3)), "Line sweep patch "//trim(iStr)//": normal(3) must not be set")
 
     end subroutine s_check_line_sweep_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the ellipse patch have consistently been inputted by
-        !!      the user.
+    !>  This subroutine checks the ellipse patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_ellipse_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the ellipse patch
-        if (n == 0) then
-            call s_mpi_abort('n must be greater than zero for '// &
-                             'ellipse patch '//trim(iStr)//'. Exiting ...')
-        elseif (p > 0) then
-            call s_mpi_abort('p must be zero for ellipse patch '//trim(iStr)// &
-                             '. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'ellipse patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'ellipse patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%radii(1))) then
-            call s_mpi_abort('radii(1) must be set for '// &
-                             'ellipse patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%radii(2))) then
-            call s_mpi_abort('radii(2) must be set for '// &
-                             'ellipse patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%radii(3))) then
-            call s_mpi_abort('radii(3) must be equal to dflt_real for '// &
-                             'ellipse patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(n == 0, "Ellipse patch "//trim(iStr)//": n must be greater than zero")
+        @:PROHIBIT(p > 0, "Ellipse patch "//trim(iStr)//": p must be zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Ellipse patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Ellipse patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%radii(1) <= 0d0, "Ellipse patch "//trim(iStr)//": radii(1) must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%radii(2) <= 0d0, "Ellipse patch "//trim(iStr)//": radii(2) must be greater than zero")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%radii(3)), "Ellipse patch "//trim(iStr)//": radii(3) must not be set")
 
     end subroutine s_check_ellipse_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the Taylor Green vortex patch have been entered by the user
-        !!      consistently.
+    !>  This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_2D_TaylorGreen_vortex_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the TaylorGreen vortex patch geometric parameters
-        if (n == 0) then
-            call s_mpi_abort('n must be greater than zero for '// &
-                             'vortex patch '//trim(iStr)//'. Exiting ...')
-        elseif (p > 0) then
-            call s_mpi_abort('p must be zero for vortex patch '//trim(iStr)// &
-                             '. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'vortex patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'vortex patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_x <= 0d0) then
-            call s_mpi_abort('length_x must be greater than zero for '// &
-                             'vortex patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_y <= 0d0) then
-            call s_mpi_abort('length_y must be greater than zero for '// &
-                             'vortex patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%vel(2) <= 0d0) then
-            call s_mpi_abort('vel(2) must be greater than zero for '// &
-                             'vortex patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(n == 0, "Taylor Green vortex patch "//trim(iStr)//": n must be greater than zero")
+        @:PROHIBIT(p > 0, "Taylor Green vortex patch "//trim(iStr)//": p must be zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Taylor Green vortex patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Taylor Green vortex patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%length_x <= 0d0, "Taylor Green vortex patch "//trim(iStr)//": length_x must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%length_y <= 0d0, "Taylor Green vortex patch "//trim(iStr)//": length_y must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%vel(2) <= 0d0, "Taylor Green vortex patch "//trim(iStr)//": vel(2) must be greater than zero")
 
     end subroutine s_check_2D_TaylorGreen_vortex_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the analytical patch have consistently been inputted by
-        !!      the user.
+    !>  This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_1D_analytical_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the analytical patch
-        if (n > 0) then
-            call s_mpi_abort('n must be zero for 1D analytical patch '//trim(iStr)// &
-                             '. Exiting ...')
-        elseif (p > 0) then
-            call s_mpi_abort('p must be zero for 1D analytical patch '//trim(iStr)// &
-                             '. Exiting ...')
-        elseif (model_eqns /= 4 .and. model_eqns /= 2) then
-            call s_mpi_abort('model_eqns must be either 4 or 2 for '// &
-                             '1D analytical patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             '1D analytical patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_x <= 0d0) then
-            call s_mpi_abort('length_x must be greater than zero for '// &
-                             '1D analytical patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(n > 0, "1D analytical patch "//trim(iStr)//": n must be zero")
+        @:PROHIBIT(p > 0, "1D analytical patch "//trim(iStr)//": p must be zero")
+        @:PROHIBIT(model_eqns /= 4 .and. model_eqns /= 2, "1D analytical patch "//trim(iStr)//": model_eqns must be either 4 or 2")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "1D analytical patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%length_x <= 0d0, "1D analytical patch "//trim(iStr)//": length_x must be greater than zero")
+
     end subroutine s_check_1D_analytical_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the analytical patch have consistently been inputted by
-        !!      the user.
+    !>  This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_2D_analytical_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the analytical patch
-        if (n == 0) then
-            call s_mpi_abort('n must be greater than zero for '// &
-                             '2D analytical patch '//trim(iStr)//'. Exiting ...')
-        elseif (p > 0) then
-            call s_mpi_abort('p must be zero for 2D analytical patch '//trim(iStr)// &
-                             '. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             '2D analytical patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             '2D analytical patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_x <= 0d0) then
-            call s_mpi_abort('length_x must be greater than zero for '// &
-                             '2D analytical patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_y <= 0d0) then
-            call s_mpi_abort('length_y must be greater than zero for '// &
-                             '2D analytical patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(n == 0, "2D analytical patch "//trim(iStr)//": n must be greater than zero")
+        @:PROHIBIT(p > 0, "2D analytical patch "//trim(iStr)//": p must be zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "2D analytical patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "2D analytical patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%length_x <= 0d0, "2D analytical patch "//trim(iStr)//": length_x must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%length_y <= 0d0, "2D analytical patch "//trim(iStr)//": length_y must be greater than zero")
+
     end subroutine s_check_2D_analytical_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the analytical patch have consistently been inputted by
-        !!      the user.
+    !>  This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_3D_analytical_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the analytical patch
-        if (p == 0) then
-            call s_mpi_abort('p must be greater than zero for '// &
-                             '3D analytical '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             '3D analytical '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             '3D analytical '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%z_centroid)) then
-            call s_mpi_abort('z_centroid must be set for '// &
-                             '3D analytical '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_x <= 0d0) then
-            call s_mpi_abort('length_x must be greater than zero for '// &
-                             '3D analytical '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_y <= 0d0) then
-            call s_mpi_abort('length_y must be greater than zero for '// &
-                             '3D analytical '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_z <= 0d0) then
-            call s_mpi_abort('length_z must be greater than zero for '// &
-                             '3D analytical '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(p == 0, "3D analytical patch "//trim(iStr)//": p must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "3D analytical patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "3D analytical patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%z_centroid), "3D analytical patch "//trim(iStr)//": z_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%length_x <= 0d0, "3D analytical patch "//trim(iStr)//": length_x must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%length_y <= 0d0, "3D analytical patch "//trim(iStr)//": length_y must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%length_z <= 0d0, "3D analytical patch "//trim(iStr)//": length_z must be greater than zero")
+
     end subroutine s_check_3D_analytical_patch_geometry
 
-    !> This subroutine verifies that the geometric parameters of
-        !!      the sphere patch have consistently been inputted by the
-        !!      user.
+    !> This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_sphere_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the sphere patch
-        if (p == 0) then
-            call s_mpi_abort('p must be greater than zero for '// &
-                             'sphere patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%radius <= 0d0) then
-            call s_mpi_abort('radius must be greater than zero for '// &
-                             'sphere patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'sphere patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'sphere patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%z_centroid)) then
-            call s_mpi_abort('z_centroid must be set for '// &
-                             'sphere patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(p == 0, "Sphere patch "//trim(iStr)//": p must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%radius <= 0d0, "Sphere patch "//trim(iStr)//": radius must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Sphere patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Sphere patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%z_centroid), "Sphere patch "//trim(iStr)//": z_centroid must be set")
 
     end subroutine s_check_sphere_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the spherical harmonic patch have consistently been
-        !!      inputted by the user.
+    !>  This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_spherical_harmonic_patch_geometry(patch_id)
         integer, intent(in) :: patch_id
 
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the spherical harmonic patch
-        if (p == 0) then
-            call s_mpi_abort('p must be greater than zero for '// &
-                             'spherical harmonic patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%radius <= 0d0) then
-            call s_mpi_abort('radius must be greater than zero for '// &
-                             'spherical harmonic patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'spherical harmonic patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'spherical harmonic patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%z_centroid)) then
-            call s_mpi_abort('z_centroid must be set for '// &
-                             'spherical harmonic patch '//trim(iStr)//'. Exiting ...')
-        elseif (all(patch_icpp(patch_id)%epsilon /= (/1d0, 2d0, 3d0, 4d0, 5d0/))) then
-            call s_mpi_abort('epsilon must be one of 1, 2, 3, 4, 5 for '// &
-                             'spherical harmonic patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%beta < 0d0) then
-            call s_mpi_abort('beta must be greater than or equal to zero for '// &
-                             'spherical harmonic patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%beta > patch_icpp(patch_id)%epsilon) then
-            call s_mpi_abort('beta must be less than or equal to epsilon for '// &
-                             'spherical harmonic patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(p == 0, "Spherical harmonic patch "//trim(iStr)//": p must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%radius <= 0d0, "Spherical harmonic patch "//trim(iStr)//": radius must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Spherical harmonic patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Spherical harmonic patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%z_centroid), "Spherical harmonic patch "//trim(iStr)//": z_centroid must be set")
+        @:PROHIBIT(all(patch_icpp(patch_id)%epsilon /= (/1d0, 2d0, 3d0, 4d0, 5d0/)), &
+            "Spherical harmonic patch "//trim(iStr)//": epsilon must be one of 1, 2, 3, 4, 5")
+        @:PROHIBIT(patch_icpp(patch_id)%beta < 0d0, &
+            "Spherical harmonic patch "//trim(iStr)//": beta must be greater than or equal to zero")
+        @:PROHIBIT(patch_icpp(patch_id)%beta > patch_icpp(patch_id)%epsilon, &
+            "Spherical harmonic patch "//trim(iStr)//": beta must be less than or equal to epsilon")
 
     end subroutine s_check_spherical_harmonic_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the cuboid patch have consistently been inputted by the
-        !!      user.
+    !>  This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_cuboid_patch_geometry(patch_id)
 
@@ -498,35 +333,17 @@ contains
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the cuboid patch
-        if (p == 0) then
-            call s_mpi_abort('p must be greater than zero for '// &
-                             'cuboid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'cuboid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'cuboid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%z_centroid)) then
-            call s_mpi_abort('z_centroid must be set for '// &
-                             'cuboid patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_x <= 0d0) then
-            call s_mpi_abort('length_x must be greater than zero for '// &
-                             'cuboid patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_y <= 0d0) then
-            call s_mpi_abort('length_y must be greater than zero for '// &
-                             'cuboid patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%length_z <= 0d0) then
-            call s_mpi_abort('length_z must be greater than zero for '// &
-                             'cuboid patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(p == 0, "Cuboid patch "//trim(iStr)//": p must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Cuboid patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Cuboid patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%z_centroid), "Cuboid patch "//trim(iStr)//": z_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%length_x <= 0d0, "Cuboid patch "//trim(iStr)//": length_x must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%length_y <= 0d0, "Cuboid patch "//trim(iStr)//": length_y must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%length_z <= 0d0, "Cuboid patch "//trim(iStr)//": length_z must be greater than zero")
 
     end subroutine s_check_cuboid_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the cylinder patch have consistently been inputted by the
-        !!      user.
+    !>  This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_cylinder_patch_geometry(patch_id)
 
@@ -534,47 +351,29 @@ contains
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the cylinder patch
-        if (p == 0) then
-            call s_mpi_abort('p must be greater than zero for '// &
-                             'cylinder patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'cylinder patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'cylinder patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%z_centroid)) then
-            call s_mpi_abort('z_centroid must be set for '// &
-                             'cylinder patch '//trim(iStr)//'. Exiting ...')
-        elseif ((patch_icpp(patch_id)%length_x <= 0d0 .and. &
-                 patch_icpp(patch_id)%length_y <= 0d0 .and. &
-                 patch_icpp(patch_id)%length_z <= 0d0) &
-                .or. &
-                (patch_icpp(patch_id)%length_x > 0d0 .and. &
-                 ((.not. f_is_default(patch_icpp(patch_id)%length_y)) .or. &
-                  (.not. f_is_default(patch_icpp(patch_id)%length_z)))) &
-                .or. &
-                (patch_icpp(patch_id)%length_y > 0d0 .and. &
-                 ((.not. f_is_default(patch_icpp(patch_id)%length_x)) .or. &
-                  (.not. f_is_default(patch_icpp(patch_id)%length_z)))) &
-                .or. &
-                (patch_icpp(patch_id)%length_z > 0d0 .and. &
-                 ((.not. f_is_default(patch_icpp(patch_id)%length_x)) .or. &
-                  (.not. f_is_default(patch_icpp(patch_id)%length_y))))) then
-            call s_mpi_abort('At least one of length_x, length_y, or length_z '// &
-                             'must be defined for '// &
-                             'cylinder patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%radius <= 0d0) then
-            call s_mpi_abort('radius must be greater than zero for '// &
-                             'cylinder patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(p == 0, "Cylinder patch "//trim(iStr)//": p must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Cylinder patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Cylinder patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%z_centroid), "Cylinder patch "//trim(iStr)//": z_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%radius <= 0d0, "Cylinder patch "//trim(iStr)//": radius must be greater than zero")
+
+        ! Check if exactly one length is defined
+        @:PROHIBIT(count([                                                      &
+            patch_icpp(patch_id)%length_x > 0d0,                                &
+            patch_icpp(patch_id)%length_y > 0d0,                                &
+            patch_icpp(patch_id)%length_z > 0d0                                 &
+            ]) /= 1, "Cylinder patch "//trim(iStr)//": Exactly one of length_x, length_y, or length_z must be defined and positive")
+
+        ! Ensure the defined length is positive
+        @:PROHIBIT(                                                             &
+            (.not. f_is_default(patch_icpp(patch_id)%length_x) .and. patch_icpp(patch_id)%length_x <= 0d0) .or. &
+            (.not. f_is_default(patch_icpp(patch_id)%length_y) .and. patch_icpp(patch_id)%length_y <= 0d0) .or. &
+            (.not. f_is_default(patch_icpp(patch_id)%length_z) .and. patch_icpp(patch_id)%length_z <= 0d0),     &
+            "Cylinder patch "//trim(iStr)//": The defined length_{} must be greater than zero")
 
     end subroutine s_check_cylinder_patch_geometry
 
-    !>  This subroutine verifies that the geometric parameters of
-        !!      the plane sweep patch have consistently been inputted by
-        !!      the user.
+    !>  This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_plane_sweep_patch_geometry(patch_id)
 
@@ -582,64 +381,30 @@ contains
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the plane sweep patch
-        if (p == 0) then
-            call s_mpi_abort('p must be greater than zero for '// &
-                             'plane sweep patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'plane sweep patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'plane sweep patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%z_centroid)) then
-            call s_mpi_abort('z_centroid must be set for '// &
-                             'plane sweep patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%normal(1))) then
-            call s_mpi_abort('normal(1) must be set for '// &
-                             'plane sweep patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%normal(2))) then
-            call s_mpi_abort('normal(2) must be set for '// &
-                             'plane sweep patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%normal(3))) then
-            call s_mpi_abort('normal(3) must be set for '// &
-                             'plane sweep patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(p == 0, "Plane sweep patch "//trim(iStr)//": p must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Plane sweep patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Plane sweep patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%z_centroid), "Plane sweep patch "//trim(iStr)//": z_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%normal(1)), "Plane sweep patch "//trim(iStr)//": normal(1) must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%normal(2)), "Plane sweep patch "//trim(iStr)//": normal(2) must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%normal(3)), "Plane sweep patch "//trim(iStr)//": normal(3) must be set")
 
     end subroutine s_check_plane_sweep_patch_geometry
 
-    !> This subroutine verifies that the geometric parameters of
-        !!      the ellipsoid patch have consistently been inputted by
-        !!      the user.
+    !> This subroutine checks the model patch input
         !!  @param patch_id Patch identifier
     subroutine s_check_ellipsoid_patch_geometry(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the ellipsoid patch
-        if (p == 0) then
-            call s_mpi_abort('p must be greater than zero for '// &
-                             'ellipsoid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must be set for '// &
-                             'ellipsoid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must be set for '// &
-                             'ellipsoid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%z_centroid)) then
-            call s_mpi_abort('z_centroid must be set for '// &
-                             'ellipsoid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%radii(1))) then
-            call s_mpi_abort('radii(1) must be set for '// &
-                             'ellipsoid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%radii(2))) then
-            call s_mpi_abort('radii(2) must be set for '// &
-                             'ellipsoid patch '//trim(iStr)//'. Exiting ...')
-        elseif (f_is_default(patch_icpp(patch_id)%radii(3))) then
-            call s_mpi_abort('radii(3) must be set for '// &
-                             'ellipsoid patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(p == 0, "Ellipsoid patch "//trim(iStr)//": p must be greater than zero")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Ellipsoid patch "//trim(iStr)//": x_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Ellipsoid patch "//trim(iStr)//": y_centroid must be set")
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%z_centroid), "Ellipsoid patch "//trim(iStr)//": z_centroid must be set")
+        @:PROHIBIT(patch_icpp(patch_id)%radii(1) <= 0d0, "Ellipsoid patch "//trim(iStr)//": radii(1) must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%radii(2) <= 0d0, "Ellipsoid patch "//trim(iStr)//": radii(2) must be greater than zero")
+        @:PROHIBIT(patch_icpp(patch_id)%radii(3) <= 0d0, "Ellipsoid patch "//trim(iStr)//": radii(3) must be greater than zero")
 
     end subroutine s_check_ellipsoid_patch_geometry
 
@@ -651,79 +416,38 @@ contains
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the geometric parameters of the inactive patch
-        if (.not. f_is_default(patch_icpp(patch_id)%x_centroid)) then
-            call s_mpi_abort('x_centroid must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%y_centroid)) then
-            call s_mpi_abort('y_centroid must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%z_centroid)) then
-            call s_mpi_abort('z_centroid must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%length_x)) then
-            call s_mpi_abort('length_x must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%length_y)) then
-            call s_mpi_abort('length_y must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%length_z)) then
-            call s_mpi_abort('length_z must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%radius)) then
-            call s_mpi_abort('radius must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%epsilon)) then
-            call s_mpi_abort('epsilon must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%beta)) then
-            call s_mpi_abort('beta must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%normal(1))) then
-            call s_mpi_abort('normal(1) must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%normal(2))) then
-            call s_mpi_abort('normal(2) must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%normal(3))) then
-            call s_mpi_abort('normal(3) must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%radii(1))) then
-            call s_mpi_abort('radii(1) must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%radii(2))) then
-            call s_mpi_abort('radii(2) must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%radii(3))) then
-            call s_mpi_abort('radii(3) must not be set for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%x_centroid), "Inactive patch "//trim(iStr)//": x_centroid must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%y_centroid), "Inactive patch "//trim(iStr)//": y_centroid must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%z_centroid), "Inactive patch "//trim(iStr)//": z_centroid must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%length_x), "Inactive patch "//trim(iStr)//": length_x must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%length_y), "Inactive patch "//trim(iStr)//": length_y must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%length_z), "Inactive patch "//trim(iStr)//": length_z must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%radius), "Inactive patch "//trim(iStr)//": radius must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%epsilon), "Inactive patch "//trim(iStr)//": epsilon must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%beta), "Inactive patch "//trim(iStr)//": beta must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%normal(1)), "Inactive patch "//trim(iStr)//": normal(1) must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%normal(2)), "Inactive patch "//trim(iStr)//": normal(2) must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%normal(3)), "Inactive patch "//trim(iStr)//": normal(3) must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%radii(1)), "Inactive patch "//trim(iStr)//": radii(1) must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%radii(2)), "Inactive patch "//trim(iStr)//": radii(2) must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%radii(3)), "Inactive patch "//trim(iStr)//": radii(3) must not be set")
 
     end subroutine s_check_inactive_patch_geometry
 
-    !>  This subroutine verifies that any rights granted to the
-        !!      given active patch, to overwrite the preceding active
-        !!      patches, were consistently inputted by the user.
+    !>  This subroutine verifies the active patch's right to overwrite the preceding patches
         !!  @param patch_id Patch identifier
     subroutine s_check_active_patch_alteration_rights(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the alteration rights of an active patch
-        if (patch_icpp(patch_id)%alter_patch(0) .eqv. .false.) then
-            call s_mpi_abort('alter_patch(0) must be true for '// &
-                             'active patch '//trim(iStr)//'. Exiting ...')
-        elseif (any(patch_icpp(patch_id)%alter_patch(patch_id:))) then
-            call s_mpi_abort('alter_patch(i) must be false for i >= '// &
-                             'active patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(.not. patch_icpp(patch_id)%alter_patch(0), "Patch "//trim(iStr)//": alter_patch(0) must be true")
+        @:PROHIBIT(any(patch_icpp(patch_id)%alter_patch(patch_id:)), "Patch "//trim(iStr)// &
+            ":alter_patch(i) must be false for i >= "//trim(iStr)//". Only preceding patches can be altered")
 
     end subroutine s_check_active_patch_alteration_rights
 
-    !>  This subroutine verifies that the rights of the given
-        !!      inactive patch, to overwrite the preceding patches,
-        !!      remain unaltered by the user inputs.
+    !>  This subroutine verifies that inactive patches cannot overwrite other patches
         !!  @param patch_id Patch identifier
     subroutine s_check_inactive_patch_alteration_rights(patch_id)
 
@@ -731,54 +455,34 @@ contains
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the alteration rights of an inactive patch
-        if (patch_icpp(patch_id)%alter_patch(0) .eqv. .false. &
-            .or. &
-            any(patch_icpp(patch_id)%alter_patch(1:))) then
-
-            call s_mpi_abort('alter_patch(i) must not be set for i >= 1 for '// &
-                             'inactive patch '//trim(iStr)//'. Exiting ...')
-
-        end if
+        @:PROHIBIT(any(patch_icpp(patch_id)%alter_patch(1:)), "Inactive patch "//trim(iStr)//": cannot have alter_patch enabled")
 
     end subroutine s_check_inactive_patch_alteration_rights
 
-    !> This subroutine verifies that the smoothing parameters of
-        !!      the given patch, which supports the smoothing out of its
-        !!      boundaries, have consistently been inputted by the user.
+    !> This subroutine checks the smoothing parameters
         !!  @param patch_id Patch identifier
     subroutine s_check_supported_patch_smoothing(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the smoothing parameters of a supported patch
         if (patch_icpp(patch_id)%smoothen) then
-            if (patch_icpp(patch_id)%smooth_patch_id >= patch_id) then
-                call s_mpi_abort('smooth_patch_id must be less than '// &
-                                 'patch_id for supported patch '//trim(iStr)//'. Exiting ...')
-            elseif (patch_icpp(patch_id)%smooth_patch_id == 0) then
-                call s_mpi_abort('smooth_patch_id must be greater than zero for '// &
-                                 'supported patch '//trim(iStr)//'. Exiting ...')
-            elseif (patch_icpp(patch_id)%smooth_coeff <= 0d0) then
-                call s_mpi_abort('smooth_coeff must be greater than zero for '// &
-                                 'supported patch '//trim(iStr)//'. Exiting ...')
-            end if
+            @:PROHIBIT(patch_icpp(patch_id)%smooth_patch_id >= patch_id, &
+                "Smoothen enabled. Patch "//trim(iStr)//": smooth_patch_id must be less than patch_id")
+            @:PROHIBIT(patch_icpp(patch_id)%smooth_patch_id == 0, &
+                "Smoothen enabled. Patch "//trim(iStr)//": smooth_patch_id must be greater than zero")
+            @:PROHIBIT(patch_icpp(patch_id)%smooth_coeff <= 0d0, &
+                "Smoothen enabled. Patch "//trim(iStr)//": smooth_coeff must be greater than zero")
         else
-            if (patch_icpp(patch_id)%smooth_patch_id /= patch_id) then
-                call s_mpi_abort('smooth_patch_id must be equal to patch_id when '// &
-                                 'smoothen is false for supported patch '//trim(iStr)//'. Exiting ...')
-            elseif (.not. f_is_default(patch_icpp(patch_id)%smooth_coeff)) then
-                call s_mpi_abort('smooth_coeff must be equal to dflt_real when '// &
-                                 'smoothen is false for supported patch '//trim(iStr)//'. Exiting ...')
-            end if
+            @:PROHIBIT(patch_icpp(patch_id)%smooth_patch_id /= patch_id, &
+                "Smoothen disabled. Patch "//trim(iStr)//": smooth_patch_id must be equal to patch_id")
+            @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%smooth_coeff), &
+                "Smoothen disabled. Patch "//trim(iStr)//": smooth_coeff must not be set")
         end if
 
     end subroutine s_check_supported_patch_smoothing
 
-    !> This subroutine verifies that the smoothing parameters of
-        !!      the given patch, which does not support the smoothing out
-        !!      of its boundaries, remain unaltered by the user inputs.
+    !> This subroutine verifies that inactive patches cannot be smoothed
         !!  @param patch_id Patch identifier
     subroutine s_check_unsupported_patch_smoothing(patch_id)
 
@@ -786,85 +490,50 @@ contains
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the smoothing parameters of an unsupported patch
-        if (patch_icpp(patch_id)%smoothen) then
-            call s_mpi_abort('smoothen must be false for unsupported '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%smooth_patch_id /= patch_id) then
-            call s_mpi_abort('smooth_patch_id must be equal to patch_id for unsupported '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%smooth_coeff)) then
-            call s_mpi_abort('smooth_coeff must not be set for unsupported '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(patch_icpp(patch_id)%smoothen, &
+            "Inactive patch "//trim(iStr)//": cannot have smoothen enabled")
+        @:PROHIBIT(patch_icpp(patch_id)%smooth_patch_id /= patch_id, &
+            "Inactive patch "//trim(iStr)//": smooth_patch_id must be equal to patch_id")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%smooth_coeff), &
+            "Inactive patch "//trim(iStr)//": smooth_coeff must not be set")
 
     end subroutine s_check_unsupported_patch_smoothing
 
-    !>  This subroutine verifies that the primitive variables
-        !!      associated with the given active patch are physically
-        !!      consistent.
+    !>  This subroutine checks the primitive variables
         !!  @param patch_id Patch identifier
     subroutine s_check_active_patch_primitive_variables(patch_id)
 
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the primitive variables of an active patch
-        if (f_is_default(patch_icpp(patch_id)%vel(1))) then
-            call s_mpi_abort('vel(1) must be set for active patch '// &
-                             trim(iStr)//'. Exiting ...')
-        elseif (n == 0 .and. (.not. f_is_default(patch_icpp(patch_id)%vel(2))) .and. &
-                patch_icpp(patch_id)%vel(2) /= 0) then
-            call s_mpi_abort('vel(2) must not be set when n = 0 '// &
-                             'for active patch '//trim(iStr)//'. Exiting ...')
-        elseif (n > 0 .and. f_is_default(patch_icpp(patch_id)%vel(2))) then
-            call s_mpi_abort('vel(2) must be set when n > 0 for '// &
-                             'active patch '//trim(iStr)//'. Exiting ...')
-        elseif (p == 0 .and. (.not. f_is_default(patch_icpp(patch_id)%vel(3))) .and. &
-                patch_icpp(patch_id)%vel(3) /= 0) then
-            call s_mpi_abort('vel(3) must not be set when p = 0 '// &
-                             'for active patch '//trim(iStr)//'. Exiting ...')
-        elseif (p > 0 .and. f_is_default(patch_icpp(patch_id)%vel(3))) then
-            call s_mpi_abort('vel(3) must be set when p > 0 for '// &
-                             'active patch '//trim(iStr)//'. Exiting ...')
-        elseif (model_eqns == 1 .and. patch_icpp(patch_id)%rho <= 0d0) then
-            call s_mpi_abort('rho must be greater than zero when '// &
-                             'model_eqns = 1 for active patch '// &
-                             trim(iStr)//'. Exiting ...')
-        elseif (model_eqns == 1 .and. patch_icpp(patch_id)%gamma <= 0d0) then
-            call s_mpi_abort('gamma must be greater than zero when '// &
-                             'model_eqns = 1 for active patch '// &
-                             trim(iStr)//'. Exiting ...')
-        elseif (model_eqns == 1 .and. patch_icpp(patch_id)%pi_inf < 0d0) then
-            call s_mpi_abort('pi_inf must be greater than or equal to '// &
-                             'zero when model_eqns = 1 for active patch '// &
-                             trim(iStr)//'. Exiting ...')
-        elseif (patch_icpp(patch_id)%geometry == 5 .and. &
-                patch_icpp(patch_id)%pi_inf > 0) then
-            call s_mpi_abort('pi_inf must be less than or equal to zero '// &
-                             'when geometry = 5 for active patch '// &
-                             trim(iStr)//'. Exiting ...')
-        elseif (model_eqns == 2 .and. &
-                any(patch_icpp(patch_id)%alpha_rho(1:num_fluids) < 0d0)) then
-            call s_mpi_abort('alpha_rho(1:num_fluids) must be greater '// &
-                             'than or equal to zero when model_eqns = 2 '// &
-                             'for active patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(f_is_default(patch_icpp(patch_id)%vel(1)), &
+            "Patch "//trim(iStr)//": vel(1) must be set")
+        @:PROHIBIT(n == 0 .and. (.not. f_is_default(patch_icpp(patch_id)%vel(2))) .and. patch_icpp(patch_id)%vel(2) /= 0, &
+            "Patch "//trim(iStr)//": vel(2) must not be set when n = 0")
+        @:PROHIBIT(n > 0 .and. f_is_default(patch_icpp(patch_id)%vel(2)), &
+            "Patch "//trim(iStr)//": vel(2) must be set when n > 0")
+        @:PROHIBIT(p == 0 .and. (.not. f_is_default(patch_icpp(patch_id)%vel(3))) .and. patch_icpp(patch_id)%vel(3) /= 0, &
+            "Patch "//trim(iStr)//": vel(3) must not be set when p = 0")
+        @:PROHIBIT(p > 0 .and. f_is_default(patch_icpp(patch_id)%vel(3)), &
+            "Patch "//trim(iStr)//": vel(3) must be set when p > 0")
+        @:PROHIBIT(model_eqns == 1 .and. patch_icpp(patch_id)%rho <= 0d0, &
+            "Patch "//trim(iStr)//": rho must be greater than zero when model_eqns = 1")
+        @:PROHIBIT(model_eqns == 1 .and. patch_icpp(patch_id)%gamma <= 0d0, &
+            "Patch "//trim(iStr)//": gamma must be greater than zero when model_eqns = 1")
+        @:PROHIBIT(model_eqns == 1 .and. patch_icpp(patch_id)%pi_inf < 0d0, &
+            "Patch "//trim(iStr)//": pi_inf must be greater than or equal to zero when model_eqns = 1")
+        @:PROHIBIT(patch_icpp(patch_id)%geometry == 5 .and. patch_icpp(patch_id)%pi_inf > 0, &
+            "Patch "//trim(iStr)//": pi_inf must be less than or equal to zero when geometry = 5")
+        @:PROHIBIT(model_eqns == 2 .and. any(patch_icpp(patch_id)%alpha_rho(1:num_fluids) < 0d0), &
+            "Patch "//trim(iStr)//": alpha_rho(1:num_fluids) must be greater than or equal to zero when model_eqns = 2")
 
-        if (model_eqns == 2 .and. num_fluids < num_fluids) then
-            if (.not. f_all_default(patch_icpp(patch_id)%alpha_rho(num_fluids + 1:))) then
-                call s_mpi_abort('alpha_rho(num_fluids+1:) must not be '// &
-                                 'set when num_fluids < num_fluids '// &
-                                 'for active patch '//trim(iStr)//'. Exiting ...')
-            elseif (.not. f_all_default(patch_icpp(patch_id)%alpha(num_fluids + 1:))) then
-                call s_mpi_abort('alpha(num_fluids+1:) must not be '// &
-                                 'set when num_fluids < num_fluids '// &
-                                 'for active patch '//trim(iStr)//'. Exiting ...')
-            elseif (f_is_default(patch_icpp(patch_id)%alpha(num_fluids))) then
-                call s_mpi_abort('alpha(num_fluids) must be set '// &
-                                 'when num_fluids < num_fluids for active '// &
-                                 'patch '//trim(iStr)//'. Exiting ...')
-            end if
+        if (model_eqns == 2 .and. num_fluids < num_fluids_max) then
+            @:PROHIBIT(.not. f_all_default(patch_icpp(patch_id)%alpha_rho(num_fluids + 1:)), &
+                "Patch "//trim(iStr)//": alpha_rho(i) must not be set for i > num_fluids")
+            @:PROHIBIT(.not. f_all_default(patch_icpp(patch_id)%alpha(num_fluids + 1:)), &
+                "Patch "//trim(iStr)//": alpha(i) must not be set for i > num_fluids")
+            @:PROHIBIT(f_is_default(patch_icpp(patch_id)%alpha(num_fluids)), &
+                "Patch "//trim(iStr)//": alpha(num_fluids) must be set")
         end if
 
     end subroutine s_check_active_patch_primitive_variables
@@ -878,29 +547,20 @@ contains
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        ! Constraints on the primitive variables of an inactive patch
-        if (.not. f_all_default(patch_icpp(patch_id)%alpha_rho)) then
-            call s_mpi_abort('alpha_rho must not be altered for inactive '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%rho)) then
-            call s_mpi_abort('rho must not be altered for inactive '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_all_default(patch_icpp(patch_id)%vel)) then
-            call s_mpi_abort('vel must not be altered for inactive '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%pres)) then
-            call s_mpi_abort('pres must not be altered for inactive '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_all_default(patch_icpp(patch_id)%alpha)) then
-            call s_mpi_abort('alpha must not be altered for inactive '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%gamma)) then
-            call s_mpi_abort('gamma must not be altered for inactive '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        elseif (.not. f_is_default(patch_icpp(patch_id)%pi_inf)) then
-            call s_mpi_abort('pi_inf must not be altered for inactive '// &
-                             'patch '//trim(iStr)//'. Exiting ...')
-        end if
+        @:PROHIBIT(.not. f_all_default(patch_icpp(patch_id)%alpha_rho), &
+            "Inactive patch "//trim(iStr)//": alpha_rho must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%rho), &
+            "Inactive patch "//trim(iStr)//": rho must not be set")
+        @:PROHIBIT(.not. f_all_default(patch_icpp(patch_id)%vel), &
+            "Inactive patch "//trim(iStr)//": vel must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%pres), &
+            "Inactive patch "//trim(iStr)//": pres must not be set")
+        @:PROHIBIT(.not. f_all_default(patch_icpp(patch_id)%alpha), &
+            "Inactive patch "//trim(iStr)//": alpha must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%gamma), &
+            "Inactive patch "//trim(iStr)//": gamma must not be set")
+        @:PROHIBIT(.not. f_is_default(patch_icpp(patch_id)%pi_inf), &
+            "Inactive patch "//trim(iStr)//": pi_inf must not be set")
 
     end subroutine s_check_inactive_patch_primitive_variables
 
@@ -912,11 +572,8 @@ contains
 
         inquire (file=patch_icpp(patch_id)%model%filepath, exist=file_exists)
 
-        if (.not. file_exists) then
-            call s_mpi_abort('Model file '//trim(patch_icpp(patch_id)%model%filepath)// &
-                             ' requested by patch '//trim(iStr)//' does not exist. '// &
-                             'Exiting ...')
-        end if
+        @:PROHIBIT(.not. file_exists, "Model file "//trim(patch_icpp(patch_id)%model%filepath)// &
+            " requested by patch "//trim(iStr)//" does not exist")
 
     end subroutine s_check_model_geometry
 

--- a/src/pre_process/m_check_patches.fpp
+++ b/src/pre_process/m_check_patches.fpp
@@ -167,7 +167,7 @@ contains
         call s_int_to_str(patch_id, iStr)
 
         @:PROHIBIT(n == 0, "Circle patch "//trim(iStr)//": n must be zero")
-        @:PROHIBIT(p > 0, "Circle patch "//trim(iStr)//": p must be zero")
+        @:PROHIBIT(p > 0, "Circle patch "//trim(iStr)//": p must be greater than zero")
         @:PROHIBIT(patch_icpp(patch_id)%radius <= 0d0, "Circle patch "//trim(iStr)//": radius must be greater than zero")
         @:PROHIBIT(f_is_default(patch_icpp(patch_id)%x_centroid), "Circle patch "//trim(iStr)//": x_centroid must be set")
         @:PROHIBIT(f_is_default(patch_icpp(patch_id)%y_centroid), "Circle patch "//trim(iStr)//": y_centroid must be set")
@@ -358,17 +358,17 @@ contains
         @:PROHIBIT(patch_icpp(patch_id)%radius <= 0d0, "Cylinder patch "//trim(iStr)//": radius must be greater than zero")
 
         ! Check if exactly one length is defined
-        @:PROHIBIT(count([                                                      &
-            patch_icpp(patch_id)%length_x > 0d0,                                &
-            patch_icpp(patch_id)%length_y > 0d0,                                &
-            patch_icpp(patch_id)%length_z > 0d0                                 &
+        @:PROHIBIT(count([ &
+            patch_icpp(patch_id)%length_x > 0d0, &
+            patch_icpp(patch_id)%length_y > 0d0, &
+            patch_icpp(patch_id)%length_z > 0d0 &
             ]) /= 1, "Cylinder patch "//trim(iStr)//": Exactly one of length_x, length_y, or length_z must be defined and positive")
 
         ! Ensure the defined length is positive
-        @:PROHIBIT(                                                             &
+        @:PROHIBIT( &
             (.not. f_is_default(patch_icpp(patch_id)%length_x) .and. patch_icpp(patch_id)%length_x <= 0d0) .or. &
             (.not. f_is_default(patch_icpp(patch_id)%length_y) .and. patch_icpp(patch_id)%length_y <= 0d0) .or. &
-            (.not. f_is_default(patch_icpp(patch_id)%length_z) .and. patch_icpp(patch_id)%length_z <= 0d0),     &
+            (.not. f_is_default(patch_icpp(patch_id)%length_z) .and. patch_icpp(patch_id)%length_z <= 0d0), &
             "Cylinder patch "//trim(iStr)//": The defined length_{} must be greater than zero")
 
     end subroutine s_check_cylinder_patch_geometry
@@ -455,7 +455,8 @@ contains
         integer, intent(in) :: patch_id
         call s_int_to_str(patch_id, iStr)
 
-        @:PROHIBIT(any(patch_icpp(patch_id)%alter_patch(1:)), "Inactive patch "//trim(iStr)//": cannot have alter_patch enabled")
+        @:PROHIBIT(.not. patch_icpp(patch_id)%alter_patch(0), "Inactive patch "//trim(iStr)//": cannot have alter_patch(0) altered")
+        @:PROHIBIT(any(patch_icpp(patch_id)%alter_patch(1:)), "Inactive patch "//trim(iStr)//": cannot have any alter_patch(i) enabled")
 
     end subroutine s_check_inactive_patch_alteration_rights
 


### PR DESCRIPTION
## Description

Fixes https://github.com/MFlowCode/MFC/issues/591

Uses PROHIBIT to improve m_check_patches & m_check_ib_patches 

### Type of change

- [x] Code cleaning

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

- [x] Passed all test suites

## Checklist

- [x] I have added comments for the new code
- [x] I added Doxygen docstrings to the new code
- [x] I have made corresponding changes to the documentation (`docs/`)
- [x] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [x] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran an Omniperf profile using `./mfc.sh run XXXX --gpu -t simulation --omniperf`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
