### PR TITLE
Increase granularity of halo-exchange timing info

### DIFF
--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -27,6 +27,8 @@ module m_mpi_proxy
 
     use m_mpi_common
 
+    use m_nvtx
+
     use ieee_arithmetic
     ! ==========================================================================
 
@@ -1077,10 +1079,12 @@ contains
                     !$acc update host(q_cons_buff_send, ib_buff_send)
                 #:endif
 
+                call nvtxStartRange("RHS-MPI-SENDRECV")
                 call MPI_SENDRECV( &
                     p_send, buffer_count, MPI_DOUBLE_PRECISION, dst_proc, send_tag, &
                     p_recv, buffer_count, MPI_DOUBLE_PRECISION, src_proc, recv_tag, &
                     MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
+                call nvtxEndRange
 
                 #:if rdma_mpi
                     !$acc end host_data

--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -807,7 +807,7 @@ contains
             ix, iy, iz)
         call nvtxEndRange
 
-        call nvtxStartRange("RHS-MPI")
+        call nvtxStartRange("RHS-MPI+BufPack")
         call s_populate_variables_buffers(q_prim_qp%vf, pb, mv)
 
         call nvtxEndRange
@@ -1065,8 +1065,8 @@ contains
         if (run_time_info .or. probe_wrt .or. ib) then
 
             ix%beg = -buff_size; iy%beg = 0; iz%beg = 0
-            if (n > 0) iy%beg = -buff_size; 
-            if (p > 0) iz%beg = -buff_size; 
+            if (n > 0) iy%beg = -buff_size;
+            if (p > 0) iz%beg = -buff_size;
             ix%end = m - ix%beg; iy%end = n - iy%beg; iz%end = p - iz%beg
             !$acc update device(ix, iy, iz)
 


### PR DESCRIPTION
## Description

Previously, the NVTX ranges measuring the so-called 'MPI' time included the time to unpack and pack the contiguous buffers actually exchanged during the MPI_SENDRECV operation. While this may make sense, to avoid confusion and always be able to get proper communication time, I renamed the 'RHS-MPI' NVTX range to 'RHS-MPI+BufPack' and added an NVTX range only around the MPI_SENDRECV operation called 'RHS-MPI_SENDRECV.'


### Type of change

- [x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I ran an example case under nsys with and without this change. The reported timing from the new RHS-MPI_SENDRECV NVTX range was within 5% error of the MPI trace time reporting for this example.

See below for screenshots from the NSYS reports. In this example, the MPI_SENDRECV time is ~1.4% of the total 'MPI' time.

This shows the NSYS MPI trace timing info. Note the highlighted line's 'total time'
<img width="1627" alt="Screenshot 2024-09-30 at 5 47 37 PM" src="https://github.com/user-attachments/assets/36da2d66-48a9-4090-ac42-7df63bf09f45">
This is the NVTX range timing information. Note that the RHS-MPI_SENDRECV range total time is similar to the new NVTX range result:
<img width="1627" alt="Screenshot 2024-09-30 at 5 50 07 PM" src="https://github.com/user-attachments/assets/fb719360-31d8-49d7-9f2c-133a7c19f3c0">
<img width="1627" alt="Screenshot 2024-09-30 at 5 50 35 PM" src="https://github.com/user-attachments/assets/e549aebe-bc0e-440f-adad-e0b2594e3575">

**Test Configuration**:
4 V100 nodes on Phoenix running the 2D shockbubble case for 700 timesteps.

## Checklist

- [ x] I ran `./mfc.sh format` before committing my code
- [ x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [ x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ x] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ x] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ x] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran an Omniperf profile using `./mfc.sh run XXXX --gpu -t simulation --omniperf`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
