### PR TITLE
Fix broken builds due to Fortran_MODULE_DIRECTORY

### DIFF
--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -102,7 +102,6 @@ class MFCTarget:
         install_prefixes = ';'.join([
             t.get_install_dirpath(case) for t in self.requires.compute()
         ])
-        mod_dirs         = f"{HIPFORT.get_install_dirpath(case)}/include/hipfort/amdgcn"
 
         flags: list = self.flags.copy() + [
             # Disable CMake warnings intended for developers (us).
@@ -133,9 +132,6 @@ class MFCTarget:
             # Location prefix to install bin/, lib/, include/, etc.
             # See: https://cmake.org/cmake/help/latest/command/install.html.
             f"-DCMAKE_INSTALL_PREFIX={install_dirpath}",
-            # Fortran .mod include directories. Currently used for the HIPFORT
-            # dependency that has this missing from its config files.
-            f"-DCMAKE_Fortran_MODULE_DIRECTORY={mod_dirs}",
         ]
 
         if ARG("verbose"):


### PR DESCRIPTION
## Description

Fixes the build issue preventing #638. My comment (https://github.com/MFlowCode/MFC/pull/638#issuecomment-2390478983) from said PR:
> Haha, thanks. To be honest, I am not sure why this was not a problem in the past. When we added support for CCE and built Hipfort, there was a bug that required us to manually add its modules directory (the one containing .mod files) to our include path. I did this using `CMAKE_Fortran_MODULE_DIRECTORY` without realizing the full scope of its effects, and applied this on all platforms and all targets (no matter whether Hipfort was needed or not). Had `CMAKE_Fortran_MODULE_DIRECTORY` done what I thought it did, I could have gotten away with this.
>
> In reality, `CMAKE_Fortran_MODULE_DIRECTORY` sets the directory where the compiler will create `.mod` files. So, no matter the target (`pre_process`, `simulation`, or `post_process`) and no matter the build flags (`--mpi`, `--gpu`, `--debug`, `--case-optimization`, ...), the SAME directory (`build/staging/hipfort/include/hipfort/amdgcn`) would be used to keep these files - which is, let's say, _somewhat undesirable_ and not something CMake _encourages_.
>
> What was happening in your case when you built `post_process` after `simulation` is that the modules whose names are shared between the two (like `m_global_parameters` containing the `startx` symbol..), would overwrite the `.mod` files from `simulation` with those from `post_process` since they share the same module directory and the same module name. Then, when you modified `m_weno`, CMake regenerates the f90 source using Fypp and then tries to build it. In doing so, to process `use` directives in that file, the compiler would leverage the `.mod` files already present in the folder, without knowing they were actually from the wrong program! Hence, the very strange error messages, and the requirement to build `simulation`, then `post_process`, then `simulation` to trigger the bug.
>
> I found this quickly because `post_process` changing how `simulation` (doesn't) build is something that should never happen and hints towards them sharing something they shouldn't be. I made copies of my build folder until I reproduced the error, and simply diff'ed one where it worked and one where it didn't. From there, the Hipfort issue was obvious:
>```
>$ diff --recursive --brief build-good-space/ build-fail-sim/
>Only in build-fail-sim/install: 03b34a2688
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_compile_specific.mod and >build-fail-sim/install/hipfort/include/hipfort/amdgcn/m_compile_specific.mod differ
>Only in build-fail-sim/install/hipfort/include/hipfort/amdgcn: m_data_input.mod
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_data_output.mod and build->fail-sim/install/hipfort/include/hipfort/amdgcn/m_data_output.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_derived_variables.mod and >build-fail-sim/install/hipfort/include/hipfort/amdgcn/m_derived_variables.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_finite_differences.mod and >build-fail-sim/install/hipfort/include/hipfort/amdgcn/m_finite_differences.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_global_parameters.mod and >build-fail-sim/install/hipfort/include/hipfort/amdgcn/m_global_parameters.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_helper.mod and build-fail->sim/install/hipfort/include/hipfort/amdgcn/m_helper.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_mpi_common.mod and build->fail-sim/install/hipfort/include/hipfort/amdgcn/m_mpi_common.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_mpi_proxy.mod and build->fail-sim/install/hipfort/include/hipfort/amdgcn/m_mpi_proxy.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_phase_change.mod and build->fail-sim/install/hipfort/include/hipfort/amdgcn/m_phase_change.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_start_up.mod and build-fail->sim/install/hipfort/include/hipfort/amdgcn/m_start_up.mod differ
>Files build-good-space/install/hipfort/include/hipfort/amdgcn/m_variables_conversion.mod and >build-fail-sim/install/hipfort/include/hipfort/amdgcn/m_variables_conversion.mod differ
>Only in build-good-space/install/hipfort/include/hipfort/amdgcn: m_weno.mod
>Only in build-fail-sim/staging: 03b34a2688
>Only in build-fail-sim/staging/98998883b5/CMakeFiles: Progress
>Only in build-good-space/staging/98998883b5/CMakeFiles/simulation.dir/fypp/simulation: >m_weno.fpp.f90.o
>Files build-good-space/staging/98998883b5/fypp/simulation/m_weno.fpp.f90 and build-fail->sim/staging/98998883b5/fypp/simulation/m_weno.fpp.f90 differ
>Only in build-fail-sim/staging: hdf5
>Only in build-fail-sim/staging: silo
>```
>
>Fortunately, logging into Frontier, I saw that removing this hack no longer breaks builds.