### PR TITLE
Update the Cleanliness CI run

### DIFF
--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -1,10 +1,10 @@
-name: Cleanness
+name: Cleanliness
 
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-    cleanness:
-        name: Code Cleanness Test
+    cleanliness:
+        name: Code Cleanliness Test
         runs-on: "ubuntu-latest"
         env:
             pr_everything: 0
@@ -25,7 +25,6 @@ jobs:
               run: |
                 sudo apt update -y
                 sudo apt install -y tar wget make cmake gcc g++ python3 python3-dev "openmpi-*" libopenmpi-dev
-                
             
             - name: Build
               run: |
@@ -36,33 +35,33 @@ jobs:
             
             - name: Unused Variables Diff
               run: |
-                grep -F 'Wunused-variable' master.txt -B 4 > mUnused.txt
-                grep -F 'Wunused-variable' pr.txt -B 4 > prUnused.txt
+                grep -F 'Wunused-variable' master.txt > mUnused.txt
+                grep -F 'Wunused-variable' pr.txt > prUnused.txt
                 diff prUnused.txt mUnused.txt || true
             
             - name: Unused Dummy Arguments Diff
               run: |
-                grep -F 'Wunused-dummy-argument' pr.txt -B 4 > prDummy.txt
-                grep -F 'Wunused-dummy-argument' master.txt -B 4 > mDummy.txt
+                grep -F 'Wunused-dummy-argument' pr.txt > prDummy.txt
+                grep -F 'Wunused-dummy-argument' master.txt > mDummy.txt
                 diff prDummy.txt mDummy.txt || true
 
             - name: Unused Value Diff
               run: |
-                grep -F 'Wunused-value' pr.txt -B 4 > prUnused_val.txt
-                grep -F 'Wunused-value' master.txt -B 4 > mUnused_val.txt
+                grep -F 'Wunused-value' pr.txt > prUnused_val.txt
+                grep -F 'Wunused-value' master.txt > mUnused_val.txt
                 diff prUnused_val.txt mUnused_val.txt || true
 
             - name: Maybe Uninitialized Variables Diff
               run: |
-                grep -F 'Wmaybe-uninitialized' pr.txt -B 4 > prMaybe.txt
-                grep -F 'Wmaybe-uninitialized' master.txt -B 4 > mMaybe.txt
+                grep -F 'Wmaybe-uninitialized' pr.txt > prMaybe.txt
+                grep -F 'Wmaybe-uninitialized' master.txt > mMaybe.txt
                 diff prMaybe.txt mMaybe.txt || true
 
 
             - name: Everything Diff
               run: |
-                grep '\-W' pr.txt -B 4 > pr_every.txt 
-                grep '\-W' master.txt -B 4 > m_every.txt
+                grep '\-W' pr.txt > pr_every.txt 
+                grep '\-W' master.txt > m_every.txt
                 diff pr_every.txt m_every.txt || true
 
             - name: List of Warnings
@@ -72,22 +71,24 @@ jobs:
 
             - name: Summary
               run: |  
-                pr_variable=$(grep -c -F 'Wunused-variable' pr.txt -B 4)
-                pr_argument=$(grep -c -F 'Wunused-dummy-argument' pr.txt -B 4)
-                pr_value=$(grep -c -F 'Wunused-value' pr.txt -B 4)
-                pr_uninit=$(grep -c -F 'Wmaybe-uninitialized' pr.txt -B 4)
-                pr_everything=$(grep -c '\-W' pr.txt -B 4)
+                pr_variable=$(grep -c -F 'Wunused-variable' pr.txt)
+                pr_argument=$(grep -c -F 'Wunused-dummy-argument' pr.txt)
+                pr_value=$(grep -c -F 'Wunused-value' pr.txt)
+                pr_uninit=$(grep -c -F 'Wmaybe-uninitialized' pr.txt)
+                pr_everything=$(grep -c '\-W' pr.txt)
 
-                master_variable=$(grep -c -F 'Wunused-variable' master.txt -B 4)
-                master_argument=$(grep -c -F 'Wunused-dummy-argument' master.txt -B 4)
-                master_value=$(grep -c -F 'Wunused-value' master.txt -B 4)
-                master_uninit=$(grep -c -F 'Wmaybe-uninitialized' master.txt -B 4)
-                master_everything=$(grep -c '\-W' master.txt -B 4)    
+                master_variable=$(grep -c -F 'Wunused-variable' master.txt)
+                master_argument=$(grep -c -F 'Wunused-dummy-argument' master.txt)
+                master_value=$(grep -c -F 'Wunused-value' master.txt)
+                master_uninit=$(grep -c -F 'Wmaybe-uninitialized' master.txt)
+                master_everything=$(grep -c '\-W' master.txt  )    
 
                 echo "pr_everything=$pr_everything" >> $GITHUB_ENV
                 echo "master_everything=$master_everything" >> $GITHUB_ENV
 
-                echo "Difference is how many warnings were added or removed from master to pr, negative numbers are better since you are removing warnings" 
+                echo "Difference is how many warnings were added or removed from master to PR."
+                echo "Negative numbers are better since you are removing warnings." 
+                echo " "
                 echo "Unused Variable Count: $pr_variable, Difference: $((pr_variable - master_variable))"
                 echo "Unused Dummy Argument: $pr_argument, Difference: $((pr_argument - master_argument))"
                 echo "Unused Value: $pr_value, Difference: $((pr_value - master_value))"


### PR DESCRIPTION
Removes some context in the CI run/print statements but makes it so the test doesn't give fall failures (I think).