### PR TITLE
Fix indexing bug in surface tension

### DIFF
--- a/src/simulation/m_surface_tension.fpp
+++ b/src/simulation/m_surface_tension.fpp
@@ -81,8 +81,8 @@ contains
         @:ALLOCATE_GLOBAL(gR_y(iy%beg:iy%end, ix%beg:ix%end, iz%beg:iz%end, num_dims + 1))
 
         if (p > 0) then
-            @:ALLOCATE_GLOBAL(gL_z(iz%beg:iz%end, ix%beg:ix%end, iy%beg:iy%end, num_dims + 1))
-            @:ALLOCATE_GLOBAL(gR_z(iz%beg:iz%end, ix%beg:ix%end, iy%beg:iy%end, num_dims + 1))
+            @:ALLOCATE_GLOBAL(gL_z(iz%beg:iz%end, iy%beg:iy%end, ix%beg:ix%end, num_dims + 1))
+            @:ALLOCATE_GLOBAL(gR_z(iz%beg:iz%end, iy%beg:iy%end, ix%beg:ix%end, num_dims + 1))
         end if
     end subroutine s_initialize_surface_tension_module
 


### PR DESCRIPTION
## Description

A mixup in the ordering in variable allocation in surface tension meant that it would only work if m, n, and p were the same in 3D.

Fixes #663 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

Ran a 3D case with surface tension on multiple processes where each process' local m, n, and p were not the same. Existing test cases passed, but they also weren't affected by this bug.
