### PR TITLE
Fix documentation home page (gh issue #675)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -273,7 +273,7 @@
                     <a class="px-4 flex flex-row items-center py-4 border-b-2 hover:border-amber-400" href="https://github.com/MFlowCode/MFC/releases/latest">
                         <i class="pr-4 fa-solid fa-download"></i>
                         <div class="flex-1">
-                            <span class="hidden sm:inline-block">Download </span>
+                            <span class="hidden sm:inline-block">Download</span>
                             <span id="release-ver"></span>
                         </div>
                     </a>
@@ -281,7 +281,7 @@
                         <i class="pr-4 fa-solid fa-rocket"></i>
                         <span class="flex-1">Quick Start</span>
                     </a>
-                    <a class="px-4 flex flex-row items-center py-4 border-b-2 hover:border-amber-400" href="documentation/index.html">
+                    <a class="px-4 flex flex-row items-center py-4 border-b-2 hover:border-amber-400" href="documentation/md_readme.html">
                         <i class="pr-4 fa-solid fa-book"></i>
                         <span class="flex-1">Documentation</span>
                     </a>


### PR DESCRIPTION
Fix https://github.com/MFlowCode/MFC/issues/675 

Documentation page when navigating from mflowcode.github.io to `Documentation` sent you to a mostly blank page. This fixes that (I'm pretty sure).