### PR TITLE
Enable Restart Probe Files

### DIFF
--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -175,6 +175,7 @@ contains
             !! Relative path to the probe data file in the case directory
 
         integer :: i !< Generic loop iterator
+        logical :: file_exist
 
         do i = 1, num_probes
             ! Generating the relative path to the data file
@@ -183,9 +184,19 @@ contains
 
             ! Creating the formatted data file and setting up its
             ! structure
-            open (i + 30, FILE=trim(file_path), &
-                  FORM='formatted', &
-                  STATUS='unknown')
+            inquire(file=trim(file_path), exist=file_exist)
+
+            if (file_exist) then
+                open (i + 30, FILE=trim(file_path), &
+                            FORM='formatted', &
+                            STATUS='old', &
+                            POSITION='append')
+            else
+                open (i + 30, FILE=trim(file_path), &
+                                FORM='formatted', &
+                                STATUS='unknown')
+            endif
+
             ! POSITION = 'append', &
             !WRITE(i+30,'(A,I0,A)') 'Probe ',i, ' located at:'
             !WRITE(i+30,'(A,F10.6)') 'x = ',probe(i)%x

--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -196,21 +196,6 @@ contains
                                 FORM='formatted', &
                                 STATUS='unknown')
             endif
-
-            ! POSITION = 'append', &
-            !WRITE(i+30,'(A,I0,A)') 'Probe ',i, ' located at:'
-            !WRITE(i+30,'(A,F10.6)') 'x = ',probe(i)%x
-            !WRITE(i+30,'(A,F10.6)') 'y = ',probe(i)%y
-            !WRITE(i+30,'(A,F10.6)') 'z = ',probe(i)%z
-            !WRITE(i+30, *)
-            !WRITE(i+30,'(A)') '=== Non-Dimensional Time ' // &
-            !                '=== Density ' // &
-            !                '=== Velocity ' // &
-            !                '=== Pressure ' // &
-            !                '=== Gamma ' // &
-            !                '=== Stiffness ' // &
-            !                '=== Sound Speed ' // &
-            !                '=== Acceleration ==='
         end do
 
         if (integral_wrt) then

--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -184,18 +184,18 @@ contains
 
             ! Creating the formatted data file and setting up its
             ! structure
-            inquire(file=trim(file_path), exist=file_exist)
+            inquire (file=trim(file_path), exist=file_exist)
 
             if (file_exist) then
                 open (i + 30, FILE=trim(file_path), &
-                            FORM='formatted', &
-                            STATUS='old', &
-                            POSITION='append')
+                      FORM='formatted', &
+                      STATUS='old', &
+                      POSITION='append')
             else
                 open (i + 30, FILE=trim(file_path), &
-                                FORM='formatted', &
-                                STATUS='unknown')
-            endif
+                      FORM='formatted', &
+                      STATUS='unknown')
+            end if
         end do
 
         if (integral_wrt) then


### PR DESCRIPTION
## Description

This allows data to be appended in the existing probe files instead of overwriting them when the simulation restarts.

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

Restart simulation and check if the previous data is still in the existing probe files.

**Test Configuration**:

* What computers and compilers did you use to test this: MacOS and GCC

## Checklist

- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count