### PR TITLE
Cleanliness CI Fix Error & Now Can't error outside of build

### DIFF
--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -34,40 +34,40 @@ jobs:
                 sed -i '/\/master\//d' master.txt
             
             - name: Unused Variables Diff
+              continue-on-error: true
               run: |
                 grep -F 'Wunused-variable' master.txt > mUnused.txt
                 grep -F 'Wunused-variable' pr.txt > prUnused.txt
                 diff prUnused.txt mUnused.txt
-                true
             
             - name: Unused Dummy Arguments Diff
+              continue-on-error: true
               run: |
                 grep -F 'Wunused-dummy-argument' pr.txt > prDummy.txt 
                 grep -F 'Wunused-dummy-argument' master.txt > mDummy.txt
                 diff prDummy.txt mDummy.txt
-                true
 
             - name: Unused Value Diff
+              continue-on-error: true
               run: |
                 grep -F 'Wunused-value' pr.txt > prUnused_val.txt
                 grep -F 'Wunused-value' master.txt > mUnused_val.txt
                 diff prUnused_val.txt mUnused_val.txt
-                true
 
             - name: Maybe Uninitialized Variables Diff
+              continue-on-error: true
               run: |
                 grep -F 'Wmaybe-uninitialized' pr.txt > prMaybe.txt
                 grep -F 'Wmaybe-uninitialized' master.txt > mMaybe.txt
                 diff prMaybe.txt mMaybe.txt
-                true
 
 
             - name: Everything Diff
+              continue-on-error: true
               run: |
                 grep '\-W' pr.txt > pr_every.txt
                 grep '\-W' master.txt > m_every.txt
                 diff pr_every.txt m_every.txt
-                true
 
             - name: List of Warnings
               run: |
@@ -75,6 +75,7 @@ jobs:
                 
 
             - name: Summary
+              continue-on-error: true
               run: |  
                 pr_variable=$(grep -c -F 'Wunused-variable' pr.txt)
                 pr_argument=$(grep -c -F 'Wunused-dummy-argument' pr.txt)
@@ -99,7 +100,6 @@ jobs:
                 echo "Unused Value: $pr_value, Difference: $((pr_value - master_value))"
                 echo "Maybe Uninitialized: $pr_uninit, Difference: $((pr_uninit - master_uninit))"
                 echo "Everything: $pr_everything, Difference: $((pr_everything - master_everything))"
-                true
             
             
             - name: Check Differences

--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -34,40 +34,40 @@ jobs:
                 sed -i '/\/master\//d' master.txt
             
             - name: Unused Variables Diff
-              continue-on-error: true
               run: |
                 grep -F 'Wunused-variable' master.txt > mUnused.txt
                 grep -F 'Wunused-variable' pr.txt > prUnused.txt
                 diff prUnused.txt mUnused.txt
+                true
             
             - name: Unused Dummy Arguments Diff
-              continue-on-error: true
               run: |
                 grep -F 'Wunused-dummy-argument' pr.txt > prDummy.txt 
                 grep -F 'Wunused-dummy-argument' master.txt > mDummy.txt
                 diff prDummy.txt mDummy.txt
+                true
 
             - name: Unused Value Diff
-              continue-on-error: true
               run: |
                 grep -F 'Wunused-value' pr.txt > prUnused_val.txt
                 grep -F 'Wunused-value' master.txt > mUnused_val.txt
                 diff prUnused_val.txt mUnused_val.txt
+                true
 
             - name: Maybe Uninitialized Variables Diff
-              continue-on-error: true
               run: |
                 grep -F 'Wmaybe-uninitialized' pr.txt > prMaybe.txt
                 grep -F 'Wmaybe-uninitialized' master.txt > mMaybe.txt
                 diff prMaybe.txt mMaybe.txt
+                true
 
 
             - name: Everything Diff
-              continue-on-error: true
               run: |
                 grep '\-W' pr.txt > pr_every.txt
                 grep '\-W' master.txt > m_every.txt
                 diff pr_every.txt m_every.txt
+                true
 
             - name: List of Warnings
               run: |
@@ -75,7 +75,6 @@ jobs:
                 
 
             - name: Summary
-              continue-on-error: true
               run: |  
                 pr_variable=$(grep -c -F 'Wunused-variable' pr.txt)
                 pr_argument=$(grep -c -F 'Wunused-dummy-argument' pr.txt)
@@ -100,6 +99,7 @@ jobs:
                 echo "Unused Value: $pr_value, Difference: $((pr_value - master_value))"
                 echo "Maybe Uninitialized: $pr_uninit, Difference: $((pr_uninit - master_uninit))"
                 echo "Everything: $pr_everything, Difference: $((pr_everything - master_everything))"
+                true
             
             
             - name: Check Differences

--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -34,35 +34,40 @@ jobs:
                 sed -i '/\/master\//d' master.txt
             
             - name: Unused Variables Diff
+              continue-on-error: true
               run: |
-                grep -F 'Wunused-variable' master.txt > mUnused.txt || true
-                grep -F 'Wunused-variable' pr.txt > prUnused.txt || true
-                diff prUnused.txt mUnused.txt || true
+                grep -F 'Wunused-variable' master.txt > mUnused.txt
+                grep -F 'Wunused-variable' pr.txt > prUnused.txt
+                diff prUnused.txt mUnused.txt
             
             - name: Unused Dummy Arguments Diff
+              continue-on-error: true
               run: |
-                grep -F 'Wunused-dummy-argument' pr.txt > prDummy.txt || true
-                grep -F 'Wunused-dummy-argument' master.txt > mDummy.txt || true 
-                diff prDummy.txt mDummy.txt || true
+                grep -F 'Wunused-dummy-argument' pr.txt > prDummy.txt 
+                grep -F 'Wunused-dummy-argument' master.txt > mDummy.txt
+                diff prDummy.txt mDummy.txt
 
             - name: Unused Value Diff
+              continue-on-error: true
               run: |
-                grep -F 'Wunused-value' pr.txt > prUnused_val.txt || true
-                grep -F 'Wunused-value' master.txt > mUnused_val.txt || true
-                diff prUnused_val.txt mUnused_val.txt || true
+                grep -F 'Wunused-value' pr.txt > prUnused_val.txt
+                grep -F 'Wunused-value' master.txt > mUnused_val.txt
+                diff prUnused_val.txt mUnused_val.txt
 
             - name: Maybe Uninitialized Variables Diff
+              continue-on-error: true
               run: |
-                grep -F 'Wmaybe-uninitialized' pr.txt > prMaybe.txt || true
-                grep -F 'Wmaybe-uninitialized' master.txt > mMaybe.txt || true
-                diff prMaybe.txt mMaybe.txt || true
+                grep -F 'Wmaybe-uninitialized' pr.txt > prMaybe.txt
+                grep -F 'Wmaybe-uninitialized' master.txt > mMaybe.txt
+                diff prMaybe.txt mMaybe.txt
 
 
             - name: Everything Diff
+              continue-on-error: true
               run: |
-                grep '\-W' pr.txt > pr_every.txt || true
-                grep '\-W' master.txt > m_every.txt || true
-                diff pr_every.txt m_every.txt || true
+                grep '\-W' pr.txt > pr_every.txt
+                grep '\-W' master.txt > m_every.txt
+                diff pr_every.txt m_every.txt
 
             - name: List of Warnings
               run: |
@@ -70,6 +75,7 @@ jobs:
                 
 
             - name: Summary
+              continue-on-error: true
               run: |  
                 pr_variable=$(grep -c -F 'Wunused-variable' pr.txt)
                 pr_argument=$(grep -c -F 'Wunused-dummy-argument' pr.txt)
@@ -100,6 +106,5 @@ jobs:
               if: env.pr_everything > env.master_everything 
               run: |
                 echo "Difference between warning count in PR is greater than in master."
-                exit 1
 
 

--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -35,33 +35,33 @@ jobs:
             
             - name: Unused Variables Diff
               run: |
-                grep -F 'Wunused-variable' master.txt > mUnused.txt
-                grep -F 'Wunused-variable' pr.txt > prUnused.txt
+                grep -F 'Wunused-variable' master.txt > mUnused.txt || true
+                grep -F 'Wunused-variable' pr.txt > prUnused.txt || true
                 diff prUnused.txt mUnused.txt || true
             
             - name: Unused Dummy Arguments Diff
               run: |
-                grep -F 'Wunused-dummy-argument' pr.txt > prDummy.txt
-                grep -F 'Wunused-dummy-argument' master.txt > mDummy.txt
+                grep -F 'Wunused-dummy-argument' pr.txt > prDummy.txt || true
+                grep -F 'Wunused-dummy-argument' master.txt > mDummy.txt || true 
                 diff prDummy.txt mDummy.txt || true
 
             - name: Unused Value Diff
               run: |
-                grep -F 'Wunused-value' pr.txt > prUnused_val.txt
-                grep -F 'Wunused-value' master.txt > mUnused_val.txt
+                grep -F 'Wunused-value' pr.txt > prUnused_val.txt || true
+                grep -F 'Wunused-value' master.txt > mUnused_val.txt || true
                 diff prUnused_val.txt mUnused_val.txt || true
 
             - name: Maybe Uninitialized Variables Diff
               run: |
-                grep -F 'Wmaybe-uninitialized' pr.txt > prMaybe.txt
-                grep -F 'Wmaybe-uninitialized' master.txt > mMaybe.txt
+                grep -F 'Wmaybe-uninitialized' pr.txt > prMaybe.txt || true
+                grep -F 'Wmaybe-uninitialized' master.txt > mMaybe.txt || true
                 diff prMaybe.txt mMaybe.txt || true
 
 
             - name: Everything Diff
               run: |
-                grep '\-W' pr.txt > pr_every.txt 
-                grep '\-W' master.txt > m_every.txt
+                grep '\-W' pr.txt > pr_every.txt || true
+                grep '\-W' master.txt > m_every.txt || true
                 diff pr_every.txt m_every.txt || true
 
             - name: List of Warnings


### PR DESCRIPTION
## Description

Fixed the bug with Cleanliness CI erroring also can't error outside of the build step

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
### Scope
- [x] This PR comprises a set of related changes with a common goal
## How Has This Been Tested?
- [x] Github Action
## Checklist

- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count
