### PR TITLE
Specify CUDA version for login node builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,10 +196,8 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
     endif()
 
     if (DEFINED ENV{MFC_CUDA_CC})
-    	# Need to find CUDA to get the version to specify for login node builds
-     	find_package(CUDA)
         string(REGEX MATCHALL "[0-9]+" MFC_CUDA_CC $ENV{MFC_CUDA_CC})
-        message(STATUS "Found $MFC_CUDA_CC specified. GPU code will be generated for compute capability ${MFC_CUDA_CC} and CUDA version ${CUDA_VERSION}.")
+        message(STATUS "Found $MFC_CUDA_CC specified. GPU code will be generated for compute capability(ies) ${MFC_CUDA_CC}.")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
 
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(
-            -Wall 
+            -Wall
             -fcheck=all,no-array-temps
             -fbacktrace
             -fimplicit-none
@@ -142,7 +142,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
         add_compile_options(
             $<$<COMPILE_LANGUAGE:Fortran>:-fallow-invalid-boz>
             $<$<COMPILE_LANGUAGE:Fortran>:-fallow-argument-mismatch>
-            $<$<COMPILE_LANGUAGE:Fortran>:-fcheck=bounds>            
+            $<$<COMPILE_LANGUAGE:Fortran>:-fcheck=bounds>
         )
     endif()
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
@@ -155,7 +155,7 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
     )
 
     add_link_options("SHELL:-hkeepfiles")
-    
+
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(
                 "SHELL:-h acc_model=auto_async_none"
@@ -231,7 +231,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
 	    else()
             message(STATUS "IPO / LTO is NOT available")
         endif()
-    endif() 
+    endif()
 endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -295,7 +295,7 @@ macro(HANDLE_SOURCES target useCommon)
 
     string(TOUPPER ${target} ${target}_UPPER)
 
-    # Gather: 
+    # Gather:
     # *          src/[<target>,(common)]/*.f90
     # * (if any) <build>/modules/<target>/*.f90
     file(GLOB ${target}_F90s CONFIGURE_DEPENDS "${${target}_DIR}/*.f90"
@@ -388,7 +388,7 @@ function(MFC_SETUP_TARGET)
     # A little hacky, but it *is* an edge-case for *one* compiler.
     if (NVHPC_USE_TWO_PASS_IPO)
         add_library(${ARGS_TARGET}_lib OBJECT ${ARGS_SOURCES})
-        target_compile_options(${ARGS_TARGET}_lib PRIVATE 
+        target_compile_options(${ARGS_TARGET}_lib PRIVATE
 		    $<$<COMPILE_LANGUAGE:Fortran>:-Mextract=lib:${ARGS_TARGET}_lib>
 	        $<$<COMPILE_LANGUAGE:Fortran>:-Minline>
     	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,7 +482,6 @@ function(MFC_SETUP_TARGET)
                 foreach (cc ${MFC_CUDA_CC})
                     target_compile_options(${a_target}
                         PRIVATE -gpu=cc${cc}
-			PRIVATE -gpu=cuda${CUDA_VERSION}
                     )
                 endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,8 +196,10 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
     endif()
 
     if (DEFINED ENV{MFC_CUDA_CC})
+    	# Need to find CUDA to get the version to specify for login node builds
+     	find_package(CUDA)
         string(REGEX MATCHALL "[0-9]+" MFC_CUDA_CC $ENV{MFC_CUDA_CC})
-        message(STATUS "Found $MFC_CUDA_CC specified. GPU code will be generated for ${MFC_CUDA_CC}.")
+        message(STATUS "Found $MFC_CUDA_CC specified. GPU code will be generated for compute capability ${MFC_CUDA_CC} and CUDA version ${CUDA_VERSION}.")
     endif()
 endif()
 
@@ -480,6 +482,7 @@ function(MFC_SETUP_TARGET)
                 foreach (cc ${MFC_CUDA_CC})
                     target_compile_options(${a_target}
                         PRIVATE -gpu=cc${cc}
+			PRIVATE -gpu=cuda${CUDA_VERSION}
                     )
                 endforeach()
 

--- a/src/pre_process/m_mpi_proxy.fpp
+++ b/src/pre_process/m_mpi_proxy.fpp
@@ -43,7 +43,7 @@ contains
         ! Logistics
         call MPI_BCAST(case_dir, len(case_dir), MPI_CHARACTER, 0, MPI_COMM_WORLD, ierr)
 
-        #:for VAR in ['t_step_old', 'm', 'n', 'p', 'm_glb', 'n_glb', 'p_glb',  &
+        #:for VAR in ['t_step_old', 't_step_start', 'm', 'n', 'p', 'm_glb', 'n_glb', 'p_glb',  &
             & 'loops_x', 'loops_y', 'loops_z', 'model_eqns', 'num_fluids',     &
             & 'weno_order', 'precision', 'perturb_flow_fluid', &
             & 'perturb_sph_fluid', 'num_patches', 'thermal', 'nb', 'dist_type',&

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -91,8 +91,8 @@ if ! module load $MODULES; then
 fi
 
 if [ $(echo "$VARIABLES" | grep = | wc -c) -gt 0 ]; then
-    log " $ export $VARIABLES"
-    export $VARIABLES > /dev/null
+    log " $ export $(eval "echo $VARIABLES")"
+    export $(eval "echo $VARIABLES") > /dev/null
 fi
 
 # Don't check for Cray paths on Carpenter, otherwise do check if they exist

--- a/toolchain/bootstrap/python.sh
+++ b/toolchain/bootstrap/python.sh
@@ -129,7 +129,7 @@ if ! cmp "$(pwd)/toolchain/pyproject.toml" "$(pwd)/build/pyproject.toml" > /dev/
         fi
     done
 
-    if ! PIP_DISABLE_PIP_VERSION_CHECK=1 MAKEFLAGS=$nthreads pip3 install -e "$(pwd)/toolchain"; then
+    if ! PIP_DISABLE_PIP_VERSION_CHECK=1 MAKEFLAGS=$nthreads pip3 install "$(pwd)/toolchain"; then
         error "(venv) Installation failed."
 
         log   "(venv) Exiting the$MAGENTA Python$COLOR_RESET virtual environment."

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -45,6 +45,7 @@ p     GT Phoenix
 p-all python/3.10.10
 p-cpu gcc/12.3.0 openmpi/4.1.5
 p-gpu nvhpc/24.5 hpcx/2.19-cuda cuda/12.1.1
+p-gpu MFC_CUDA_CC=70,80,89,90 CC=nvc CXX=nvc++ FC=nvfortran
 
 f     OLCF Frontier
 f-all cce/18.0.0 cpe/24.07 rocm/6.1.3 cray-mpich/8.1.28

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -45,7 +45,7 @@ p     GT Phoenix
 p-all python/3.10.10
 p-cpu gcc/12.3.0 openmpi/4.1.5
 p-gpu nvhpc/24.5 hpcx/2.19-cuda cuda/12.1.1
-p-gpu MFC_CUDA_CC=70,80,89,90 CC=nvc CXX=nvc++ FC=nvfortran
+p-gpu MFC_CUDA_CC=70,80,89,90 NVHPC_CUDA_HOME=$CUDA_HOME CC=nvc CXX=nvc++ FC=nvfortran
 
 f     OLCF Frontier
 f-all cce/18.0.0 cpe/24.07 rocm/6.1.3 cray-mpich/8.1.28

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -57,6 +57,7 @@ d-all python/3.11.6
 d-cpu gcc/11.4.0 openmpi
 d-gpu nvhpc/24.1 cuda/12.3.0 openmpi/4.1.5+cuda cmake
 d-gpu CC=nvc CXX=nvc++ FC=nvfortran
+d-gpu MFC_CUDA_CC=80,86
 
 c     DoD Carpenter
 c-all python/3.12.1


### PR DESCRIPTION
## Description
Currently, specifying the MFC_CUDA_CC flag can cause builds to fail on login nodes where the system can't determine the CUDA version to build for. This adds a compiler flag to specify the CUDA version explicitly. To ensure that rearranging the build process doesn't break, I force CMAKE to find CUDA when the MFC_CUDA_CC flag is set.

Fixes #(687)

Fixes https://github.com/MFlowCode/MFC/issues/687


### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Load modules for specific system
`rm -rf build/staging`
`export MFC_CUDA_CC=XX` where XX is a compute capability
Build GPU MFC on Phoenix and Delta


* What computers and compilers did you use to test this:
See above

## Checklist

- [x] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [ ] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [ ] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [ ] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran an Omniperf profile using `./mfc.sh run XXXX --gpu -t simulation --omniperf`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
