### PR TITLE
Fix RDMA MPI

### DIFF
--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -872,8 +872,6 @@ contains
 
         integer :: pack_offsets(1:3), unpack_offsets(1:3)
         integer :: pack_offset, unpack_offset
-        real(kind(0d0)), pointer :: p_send, p_recv
-        integer, pointer, dimension(:) :: p_i_send, p_i_recv
 
 #ifdef MFC_MPI
 
@@ -1073,8 +1071,6 @@ contains
         ! Send/Recv
         #:for rdma_mpi in [False, True]
             if (rdma_mpi .eqv. ${'.true.' if rdma_mpi else '.false.'}$) then
-                p_send => q_cons_buff_send(0)
-                p_recv => q_cons_buff_recv(0)
                 #:if rdma_mpi
                     !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                 #:else

--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -1076,20 +1076,18 @@ contains
                 p_send => q_cons_buff_send(0)
                 p_recv => q_cons_buff_recv(0)
                 #:if rdma_mpi
-                    !$acc data attach(p_send, p_recv)
-                    !$acc host_data use_device(p_send, p_recv)
+                    !$acc host_data use_device(q_cons_buff_send, q_cons_buff_recv)
                 #:else
                     !$acc update host(q_cons_buff_send, ib_buff_send)
                 #:endif
 
                 call MPI_SENDRECV( &
-                    p_send, buffer_count, MPI_DOUBLE_PRECISION, dst_proc, send_tag, &
-                    p_recv, buffer_count, MPI_DOUBLE_PRECISION, src_proc, recv_tag, &
+                    q_cons_buff_send, buffer_count, MPI_DOUBLE_PRECISION, dst_proc, send_tag, &
+                    q_cons_buff_recv, buffer_count, MPI_DOUBLE_PRECISION, src_proc, recv_tag, &
                     MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
 
                 #:if rdma_mpi
                     !$acc end host_data
-                    !$acc end data
                     !$acc wait
                 #:else
                     !$acc update device(q_cons_buff_recv)


### PR DESCRIPTION
## Description

Previously when trying to run with 'rdma_mpi' equal to true, I would get illegal buffer pointer values in the halo communication routines. After a small change that makes sense to me, CUDA-aware MPI now seems to work on both Delta and Phoenix. 


### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

I built and ran 2 cases that differed only by the 'rdma_mpi' status on both Phoenix and Delta. On Delta, it was 3D_TGV and on Phoenix it was 2D_riemman test. h5diff on the resulting hd5f files of the last step showed no difference on Phoenix. Additionally, I took nsys reports on phoenix to show the lack of H2D/D2H copies.

First without RDMA_MPI, the code moves the GPU data to the CPU before MPI exchange:
<img width="1463" alt="Screenshot 2024-11-07 at 12 29 07 PM" src="https://github.com/user-attachments/assets/a73b1402-09e0-41e3-b39a-ad948ce39819">

With RDMA_MPI enabled, there are no data copies. This led to a marginal improvement in the RHS-MPI time for this case:
<img width="1463" alt="Screenshot 2024-11-07 at 12 29 04 PM" src="https://github.com/user-attachments/assets/832e9064-f9c4-4509-adf0-ac27fb268f5e">

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran an Omniperf profile using `./mfc.sh run XXXX --gpu -t simulation --omniperf`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
