### PR TITLE
Ignore syscheck_lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn.lock
 .vscode/
 src/*/include/case.fpp
 src/*/autogen/
+syscheck_lib/
 
 *.swo
 *.swp


### PR DESCRIPTION
## Description

I'm tired of seeing untracked files. This just ignores the 'syscheck_lib' folder.

