### PR TITLE
Fix seg fault when fd_order is on

### DIFF
--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -1057,6 +1057,11 @@ contains
             buff_size = weno_polyn + 2
         end if
 
+        if (probe_wrt) then
+            fd_number = max(1, fd_order/2)
+            buff_size = buff_size + fd_number
+        end if
+
         ! Configuring Coordinate Direction Indexes =========================
         idwint(1)%beg = 0; idwint(2)%beg = 0; idwint(3)%beg = 0
         idwint(1)%end = m; idwint(2)%end = n; idwint(3)%end = p
@@ -1077,11 +1082,6 @@ contains
                 & idwbuff(1)%beg:idwbuff(1)%end, &
                 & idwbuff(2)%beg:idwbuff(2)%end, &
                 & idwbuff(3)%beg:idwbuff(3)%end))
-        end if
-
-        if (probe_wrt) then
-            fd_number = max(1, fd_order/2)
-            buff_size = buff_size + fd_number
         end if
 
         startx = -buff_size

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -1070,7 +1070,6 @@ contains
 
         if (probe_wrt) then
             fd_number = max(1, fd_order/2)
-            buff_size = buff_size + fd_number
         end if
 
         ! Configuring Coordinate Direction Indexes =========================


### PR DESCRIPTION
## Description

The buffer_size is not initialized for all the variable bound constant (e.g. `idwbuff(2)%beg:idwbuff(2)%end` from [PR# 653](https://github.com/MFlowCode/MFC/commit/e2ceaf555330d70fb6faf407b980a487d4aa9d73#diff-fe8ed9906ee74f3d3f0dbc702d75863fc90286a345cc7067acc6e6cfe80b6d52L762)) when fd_order is on. This will cause seg fault issue on variables like `flux_gsrc_n`. Maybe @henryleberre can confirm this.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Turn on `fd_order` and the seg fault issue is resolved.

**Test Configuration**:

* What computers and compilers did you use to test this: MacOS CPU/GCC, Phoenix CPU/GCC, and Delta A100/NVHPC

## Checklist
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)
To make sure the code is performing as expected on GPU devices, I have:
- [x] Checked that the code compiles using NVHPC compilers
- [x] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
