### PR TITLE
Add Phoenix Quadro RTX6000 CUDA CC 75

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -45,7 +45,7 @@ p     GT Phoenix
 p-all python/3.10.10
 p-cpu gcc/12.3.0 openmpi/4.1.5
 p-gpu nvhpc/24.5 hpcx/2.19-cuda cuda/12.1.1
-p-gpu MFC_CUDA_CC=70,80,89,90 NVHPC_CUDA_HOME=$CUDA_HOME CC=nvc CXX=nvc++ FC=nvfortran
+p-gpu MFC_CUDA_CC=70,75,80,89,90 NVHPC_CUDA_HOME=$CUDA_HOME CC=nvc CXX=nvc++ FC=nvfortran
 
 f     OLCF Frontier
 f-all cce/18.0.0 cpe/24.07 rocm/6.1.3 cray-mpich/8.1.28


### PR DESCRIPTION
## Description
The RTX6000 GPUs in Phoenix are actually Quadro Pro RTX6000 GPUs. These are distinct from RTX6000 GPUs and have different CUDA compute capabilities. Now for Phoenix, we have the following CUDA compute capabilities for the following GPUs. To my knowledge, I'm not missing anything. Used this link for verification: https://gatech.service-now.com/home?id=kb_article_view&sysparm_article=KB0041976

cc70 => V100
cc75 => Quadro RTX6000
cc80 => A100
cc89 => L40
cc90 => H100
