### PR TITLE
Bump GH checkout CI action version

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,12 +33,12 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Clone - PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: pr
 
       - name: Clone - Master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: MFlowCode/MFC
           ref: master

--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -28,11 +28,11 @@ jobs:
           master_everything: 0
       steps:
           - name: Clone - PR
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
               path: pr
           - name: Clone - Master
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
               repository: MFlowCode/MFC
               ref: master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build & Test
         if:   matrix.lbl == 'gt'


### PR DESCRIPTION
Bumps the GH checkout action to v4 from v3. Will see if it works as intended when CI runs.