### PR TITLE
Update required CodeCov CI patch coverage for pass

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         target: 1%
         threshold: 1%
+    patch:
+      default:
+        target: 1%
+        threshold: 1%


### PR DESCRIPTION
https://stackoverflow.com/questions/51635964/setting-codecov-patch-target-to-a-fixed-number

CodeCov fails project and/or patch if the PR does not hit a certain percent threshold. You can manually tune this to a specific number, else it is based upon previous coverage numbers. I want coverage to always pass (I see the numbers regardless). This PR enforces this `codecov.yml`