### PR TITLE
Faster Phoenix CPU benchmarking

### DIFF
--- a/.github/workflows/phoenix/bench.sh
+++ b/.github/workflows/phoenix/bench.sh
@@ -9,7 +9,7 @@ if [ "$job_device" == "gpu" ]; then
 fi
 
 if ["$job_device" == "gpu"]; then
-    ./mfc.sh bench --mem 8 -j $(nproc) -o "$job_slug.yaml" -- -c phoenix $device_opts -n $n_ranks
+    ./mfc.sh bench --mem 12 -j $(nproc) -o "$job_slug.yaml" -- -c phoenix $device_opts -n $n_ranks
 else
     ./mfc.sh bench --mem 1 -j $(nproc) -o "$job_slug.yaml" -- -c phoenix $device_opts -n $n_ranks
 fi

--- a/.github/workflows/phoenix/bench.sh
+++ b/.github/workflows/phoenix/bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-n_ranks=4
+n_ranks=12
 
 if [ "$job_device" == "gpu" ]; then
     n_ranks=$(nvidia-smi -L | wc -l)        # number of GPUs on node

--- a/benchmarks/5eq_rk3_weno3_hllc/case.py
+++ b/benchmarks/5eq_rk3_weno3_hllc/case.py
@@ -194,8 +194,8 @@ print(json.dumps({
     'cyl_coord'                    : 'F',
     'dt'                           : dt,
     't_step_start'                 : 0,
-    't_step_stop'                  : int(60*(95*size + 5)),
-    't_step_save'                  : int(60*(95*size + 5)),
+    't_step_stop'                  : int(30*(95*size + 5)),
+    't_step_save'                  : int(30*(95*size + 5)),
     # ==========================================================
 
     # Simulation Algorithm Parameters ==========================

--- a/benchmarks/hypo_hll/case.py
+++ b/benchmarks/hypo_hll/case.py
@@ -47,8 +47,8 @@ print(json.dumps({
                     'p'                            : Nz,
                     'dt'                           : 1e-8,
                     't_step_start'                 : 0,
-                    't_step_stop'                  : int(60*(95*size + 5)),
-                    't_step_save'                  : int(60*(95*size + 5)),
+                    't_step_stop'                  : int(30*(95*size + 5)),
+                    't_step_save'                  : int(30*(95*size + 5)),
 		    # ==========================================================
 
                     # Simulation Algorithm Parameters ==========================

--- a/benchmarks/ibm/case.py
+++ b/benchmarks/ibm/case.py
@@ -51,8 +51,8 @@ print(json.dumps({
             'p'                            : Nz,                         
             'dt'                           : mydt,                      
             't_step_start'                 : 0,                         
-            't_step_stop'                  : int(40*(95*size + 5)),
-            't_step_save'                  : int(40*(95*size + 5)),
+            't_step_stop'                  : int(20*(95*size + 5)),
+            't_step_save'                  : int(20*(95*size + 5)),
 		    # ==========================================================
                                                                                 
             # Simulation Algorithm Parameters ==========================

--- a/benchmarks/viscous_weno5_sgb_acoustic/case.py
+++ b/benchmarks/viscous_weno5_sgb_acoustic/case.py
@@ -113,8 +113,8 @@ print(json.dumps({
     'p'                            : Nz,
     'dt'                           : dt,
     't_step_start'                 : 0,
-    't_step_stop'                  : int(30*(25*size + 5)),
-    't_step_save'                  : int(30*(25*size + 5)),
+    't_step_stop'                  : int(15*(25*size + 5)),
+    't_step_save'                  : int(15*(25*size + 5)),
     # ==========================================================
 
     # Simulation Algorithm Parameters ==========================


### PR DESCRIPTION
This makes CPU benchmarking a bit faster, using 12 ranks instead of 4 (it is already grabbing 24 cores). The previous runtime was 2.5 hours, so I'm trying to get that down a bit.