### PR TITLE
Publish docs nightly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * *'  # This runs every day at midnight UTC
   workflow_dispatch:
-  push: 
+  push:
+  pull_request:
 
 jobs:
   docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,15 @@
 name: Documentation
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  schedule:
+    - cron: '0 0 * * *'  # This runs every day at midnight UTC
+  workflow_dispatch:
+  push: 
 
 jobs:
   docs:
     name:    Build & Publish
     runs-on: ubuntu-latest
-
-    concurrency:
-      group: docs-publish
-      cancel-in-progress: true
 
     steps:
     - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
         echo "excluded-count = ${{ steps.sitemap.outputs.excluded-count }}"
 
     - name: Publish Documentation
-      if:   github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' && github.event_name == 'push'
+      if:   github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' && github.event_name == 'cron'
       run:  |
         set +e
         git ls-remote "${{ secrets.DOC_PUSH_URL }}" -q


### PR DESCRIPTION
Get rid of concurrency cancellation for docs builds. Only publish docs nightly.

Closes https://github.com/MFlowCode/MFC/issues/719 #719 