### PR TITLE
Fix docs not publishing 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,9 +52,10 @@ jobs:
       with:
         args: -c .lychee.toml build/install/docs/mfc/
         fail: false
+      continue-on-error: true
 
     - name: Publish Documentation
-      if:   github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' && ( github.event_name == 'cron' || github.event_name == 'workflow_dispatch' )
+      if:   (github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' &&  github.event_name == 'cron' ) || github.event_name == 'workflow_dispatch'
       run:  |
         set +e
         git ls-remote "${{ secrets.DOC_PUSH_URL }}" -q


### PR DESCRIPTION
Docs were not publishing on cron job. Either due to skipped lychee or the syntax in the publish `if` statement. This attempts to fix both such possibilities.