### PR TITLE
ATOMIC commit that fixes a bug in the docs action event name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,10 +52,9 @@ jobs:
       with:
         args: -c .lychee.toml build/install/docs/mfc/
         fail: false
-      continue-on-error: true
 
     - name: Publish Documentation
-      if:   (github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' &&  github.event_name == 'cron' ) || github.event_name == 'workflow_dispatch'
+      if:   github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' &&  (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' )
       run:  |
         set +e
         git ls-remote "${{ secrets.DOC_PUSH_URL }}" -q


### PR DESCRIPTION
cron jobs in gh actions go by the event name 'schedule' not 'cron'...