### PR TITLE
add init (thanks henry)

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -47,6 +47,10 @@ mkdir -p "$(pwd)/build"
 . "$(pwd)/toolchain/bootstrap/cmake.sh"
 . "$(pwd)/toolchain/bootstrap/python.sh"
 
+if [ "$1" '==' 'init' ]; then
+    exit 0
+fi
+
 echo
 
 # Run the main.py bootstrap script


### PR DESCRIPTION
Gives an MFC command line option `./mfc.sh init` that initializes the Python situation without building anything.