### PR TITLE
Go back to single debug QOS Frontier runner

### DIFF
--- a/.github/workflows/frontier/submit.sh
+++ b/.github/workflows/frontier/submit.sh
@@ -23,6 +23,7 @@ sbatch <<EOT
 #SBATCH -n 8                       # Number of cores required
 #SBATCH -t 02:00:00                # Duration of the job (Ex: 15 mins)
 #SBATCH -o$job_slug.out            # Combined output and error messages file
+#SBATCH -q debug                   # Use debug QOS - only one job per user allowed in queue!
 #SBATCH -W                         # Do not exit until the submitted job terminates.
 
 set -e

--- a/.github/workflows/frontier/submit.sh
+++ b/.github/workflows/frontier/submit.sh
@@ -21,7 +21,7 @@ sbatch <<EOT
 #SBATCH -A CFD154                  # charge account
 #SBATCH -N 1                       # Number of nodes required
 #SBATCH -n 8                       # Number of cores required
-#SBATCH -t 02:00:00                # Duration of the job (Ex: 15 mins)
+#SBATCH -t 01:00:00                # Duration of the job (Ex: 15 mins)
 #SBATCH -o$job_slug.out            # Combined output and error messages file
 #SBATCH -q debug                   # Use debug QOS - only one job per user allowed in queue!
 #SBATCH -W                         # Do not exit until the submitted job terminates.


### PR DESCRIPTION
I went to many Frontier runners in a previous PR, but they weren't able to use the debug QOS (which highly prioritizes the job). This seemed to have backfired, and even though we could put many jobs in the queue at once, they would stay there for days and never run CI. The debug queue works quite fast. I have removed the other runners besides 1 Frontier runner and it uses the debug queue again.