### PR TITLE
typing is part of stdlib

### DIFF
--- a/toolchain/pyproject.toml
+++ b/toolchain/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "rich",
     "wheel",
     "typos",
-    "typing",
     "PyYAML",
     "argparse",
     "dataclasses",


### PR DESCRIPTION
Don't need to install `typing` anymore. It throws a pip warning and is part of stdlib anyway.