### PR TITLE
Fix rotation and MPI for multiple IBs

### DIFF
--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -665,7 +665,7 @@ contains
 
                         call MPI_FILE_SET_VIEW(ifile, disp, MPI_INTEGER, MPI_IO_IB_DATA%view, &
                                                'native', mpi_info_int, ierr)
-                        call MPI_FILE_READ(ifile, MPI_IO_IB_DATA%var%sf, data_size * num_ibs, &
+                        call MPI_FILE_READ(ifile, MPI_IO_IB_DATA%var%sf, data_size, &
                                            MPI_INTEGER, status, ierr)
 
                     else
@@ -834,7 +834,7 @@ contains
 
                         call MPI_FILE_SET_VIEW(ifile, disp, mpi_p, MPI_IO_levelset_DATA%view, &
                                                'native', mpi_info_int, ierr)
-                        call MPI_FILE_READ(ifile, MPI_IO_levelset_DATA%var%sf, data_size, &
+                        call MPI_FILE_READ(ifile, MPI_IO_levelset_DATA%var%sf, data_size * num_ibs, &
                                            mpi_p, status, ierr)
 
                     else


### PR DESCRIPTION
## Description

Fixes issue #787 

This PR fixes two bugs: 
1. The rotation of STL patches and STL immersed boundaries.
- Why not working? 
      (a) The normal vector of the triangular facets are not rotated with the vertices. The ray-tracing become erroneous when 
            the unrotated normal vectors are used.
      (b) The rotation did not consider the original center of the geometry is not at the origin of the coordinate.

- What's the fix?
      (a) Include the normal vector in the process of the model transformation, but skip the scale and translation parts.
      (b) Shift the geometry to the origin before rotation and shift it back to its original position after the rotation.

2. MPI communication for >1 number of IBs. (a two-line fix that's left over from the IBM+STL PR).

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] Similar test case mentioned in issue #787 

**Test Configuration**: 

```
import json
import math
gam_a = 1.4
D = 2
Ma = 4
vel = Ma * math.sqrt(gam_a) 
tStop = 20/vel
print(
    json.dumps(
        {
            "run_time_info": "T",
            "x_domain%beg": -4,
            "x_domain%end": 8,
            "stretch_x" : 'T',
            'a_x': 20,
            'x_a': -10,
            'x_b': 6,
            "y_domain%beg": -3,
            "y_domain%end": 3,
            "stretch_y" : 'T',
            'a_y': 15,
            'y_a': -1.75,
            'y_b': 1.75,
            'loops_y': 2,
            "z_domain%beg": -3,
            "z_domain%end": 3,
            "stretch_z" : 'T',
            'a_z': 15,
            'z_a': -1.75,
            'z_b': 1.75,
            'loops_z': 2,
            "cyl_coord": "F",
            "m": 99,
            "n": 49,
            "p": 49,
            'cfl_adap_dt' : 'F', #'T',
            'n_start'     : 0,
            'cfl_target'  : 0.8,
            't_step_start': 0,
            't_step_stop' : 1, #tStop,
            't_step_save' : 1, #tStop/100,
            'dt' : 1e-9,
            't_stop'      : 1, #tStop,
            't_save'      : 1, #tStop/100,
            "num_patches": 1,
            "model_eqns": 2,
            "alt_soundspeed": "F",
            "num_fluids": 1,
            "mpp_lim": "F",
            "mixture_err": "F",
            "time_stepper": 3,
            "weno_order": 5,
            "weno_eps": 1.0e-16,
            "weno_Re_flux": "F",
            "weno_avg": "T",
            "avg_state": 2,
            "mapped_weno": "F",
            "null_weights": "F",
            "mp_weno": "F",
            "riemann_solver": 2,
            "wave_speeds": 1,
            "viscous": "F",
            "bc_x%beg": -3,
            "bc_x%end": -3,
            "bc_y%beg": -3,
            "bc_y%end": -3,
            "bc_z%beg": -3,
            "bc_z%end": -3,
            "ib": "T",
            "num_ibs": 1,
            "format": 1,
            "precision": 2,
            "prim_vars_wrt":'T',
            "parallel_io": "T",
            "patch_icpp(1)%geometry": 9,
            "patch_icpp(1)%x_centroid": 0.0,
            "patch_icpp(1)%y_centroid": 0.0,
            "patch_icpp(1)%z_centroid": 0.0,
            "patch_icpp(1)%length_x": 100,
            "patch_icpp(1)%length_y": 50,
            "patch_icpp(1)%length_z": 50,
            "patch_icpp(1)%vel(1)": vel,
            "patch_icpp(1)%vel(2)": 0,
            "patch_icpp(1)%vel(3)": 0,
            "patch_icpp(1)%pres": 1,
            "patch_icpp(1)%alpha_rho(1)": 1,
            "patch_icpp(1)%alpha(1)": 1,
            "patch_ib(1)%geometry": 12,
            "patch_ib(1)%model_filepath": "vehicle.stl",
            "patch_ib(1)%model_translate(1)": 3,
            "patch_ib(1)%model_translate(2)": 0,
            "patch_ib(1)%model_translate(3)": 0,
            "patch_ib(1)%model_rotate(3)": -0.5*math.pi,
            "patch_ib(1)%model_spc": 20,
            "patch_ib(1)%model_threshold": 0.01,
            "patch_ib(1)%slip": "F",
            "fluid_pp(1)%gamma": 1.0e00 / (gam_a - 1.0e00),
            "fluid_pp(1)%pi_inf": 0,
        }
    )
)
```

Without rotation and translation:
<img width="635" alt="Screen Shot 2025-01-08 at 10 37 42 PM" src="https://github.com/user-attachments/assets/45ba171f-8577-46b8-ac11-3c972ec38bad" />

With rotation and translation:
<img width="637" alt="Screen Shot 2025-01-08 at 10 30 01 PM" src="https://github.com/user-attachments/assets/c22eaa4e-a599-4a6d-b894-48457849921f" />

* What computers and compilers did you use to test this: MacOS with GCC

## Checklist

- [x] I have added comments for the new code
- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x] Checked that the code compiles using NVHPC compilers