### PR TITLE
Fix checker for restarted case

### DIFF
--- a/src/pre_process/m_checker.fpp
+++ b/src/pre_process/m_checker.fpp
@@ -76,7 +76,7 @@ contains
                         "${DIR}$_domain%${BOUND}$ must not be set when ${VAR}$ > 0 and old_grid = T")
                     @:PROHIBIT(${VAR}$ > 0 .and. (.not. old_grid) .and. f_is_default(${DIR}$_domain%${BOUND}$), &
                         "${DIR}$_domain%${BOUND}$ must be set when ${VAR}$ > 0 and old_grid = F")
-                    @:PROHIBIT(${VAR}$ > 0 .and. ${DIR}$_domain%beg >= ${DIR}$_domain%end, &
+                    @:PROHIBIT(${VAR}$ > 0 .and. (.not. old_grid) .and. ${DIR}$_domain%beg >= ${DIR}$_domain%end, &
                         "${DIR}$_domain%beg must be less than ${DIR}$_domain%end when both are set")
                 #:endfor
             end if


### PR DESCRIPTION
## Description

Fixes a checker condition that incorrectly prevented restart cases from running. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Something else
