### PR TITLE
Fix FFTW compilation bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@
 
 cmake_minimum_required(VERSION 3.20)
 
+# Set minimum policy version to 3.5 to fix FFTW compilation with CMake 4.0+
+set(CMAKE_POLICY_VERSION_MINIMUM "3.5" CACHE STRING "Minimum CMake policy version")
 
 # We include C as a language because - for some reason -
 # FIND_LIBRARY_USE_LIB64_PATHS is otherwise ignored.

--- a/src/pre_process/include/1dHardcodedIC.fpp
+++ b/src/pre_process/include/1dHardcodedIC.fpp
@@ -1,6 +1,5 @@
 #:def Hardcoded1DVariables()
     ! Place any declaration of intermediate variables here
-    ! Test
 
 #:enddef
 

--- a/src/pre_process/include/1dHardcodedIC.fpp
+++ b/src/pre_process/include/1dHardcodedIC.fpp
@@ -1,5 +1,6 @@
 #:def Hardcoded1DVariables()
     ! Place any declaration of intermediate variables here
+    ! Test
 
 #:enddef
 

--- a/toolchain/dependencies/CMakeLists.txt
+++ b/toolchain/dependencies/CMakeLists.txt
@@ -36,6 +36,7 @@ if (MFC_FFTW)
                 URL        "http://www.fftw.org/fftw-3.3.10.tar.gz"
                 CMAKE_ARGS -DBUILD_TESTS=OFF
                            -DBUILD_SHARED_LIBS=OFF
+                           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
                            "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
             )
         else()


### PR DESCRIPTION
## Description

Set minimum policy version to 3.5 to fix FFTW compilation with CMake 4.0+.

See https://github.com/FFTW/fftw3/issues/381

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Note

It still fails the tests where it needs to build the master branch. The log shows that FFTW in the PR branch is correctly built. 
