### PR TITLE
Switch to L40S for benchmarking

### DIFF
--- a/.github/workflows/phoenix/submit-bench.sh
+++ b/.github/workflows/phoenix/submit-bench.sh
@@ -20,7 +20,7 @@ sbatch_cpu_opts="\
 "
 
 sbatch_gpu_opts="\
-#SBATCH -CV100
+#SBATCH -CL40S
 #SBATCH --ntasks-per-node=4       # Number of cores per node required
 #SBATCH -G2\
 "


### PR DESCRIPTION
This changes the benchmarking CI from V100 to L40S on Phoenix. Should make benchmarking faster (less queue time and V100 are being deprecated).