### PR TITLE
Fixes for some bug in fortitude linter

### DIFF
--- a/.fortitude.toml
+++ b/.fortitude.toml
@@ -1,5 +1,4 @@
 [check]
-# Ignored Rules and justification:
 ignore = ["E001","S001","S101","C121","S091","MOD011","C001","S101","S102","C002","PORT011","C072","C003","C131","C141","C092"]
 file-extensions = ["f90","fpp","fypp"]
 output-format = "pylint"

--- a/.github/workflows/lint-source.yml
+++ b/.github/workflows/lint-source.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Lint the full source
       run: |
         source build/venv/bin/activate
-        find ./src -type f -not -name '*nvtx*' -exec fortitude check {} \;
-        find ./src -type f -not -name '*nvtx*' -exec fortitude check {} \; | wc -l | xargs -I{} sh -c '[ {} -gt 0 ] && exit 1 || exit 0'
+        find ./src -type f -not -name '*nvtx*' -exec sh -c 'fortitude check "$1" | grep -v E001' _ {} \;
+        find ./src -type f -not -name '*nvtx*' -exec sh -c 'fortitude check "$1" | grep -v E001' _ {} \; | wc -l | xargs -I{} sh -c '[ {} -gt 0 ] && exit 1 || exit 0'
 
     - name: No double precision intrinsics
       run: |


### PR DESCRIPTION
Fortitude linter doesn't ignore `E001` no matter what. Manually removing that error message.