### PR TITLE
Make surface tension compatible with the 5-eqn model and immersed boundaries

### DIFF
--- a/.github/workflows/frontier/submit.sh
+++ b/.github/workflows/frontier/submit.sh
@@ -21,7 +21,7 @@ sbatch <<EOT
 #SBATCH -A CFD154                  # charge account
 #SBATCH -N 1                       # Number of nodes required
 #SBATCH -n 8                       # Number of cores required
-#SBATCH -t 01:00:00                # Duration of the job (Ex: 15 mins)
+#SBATCH -t 01:30:00                # Duration of the job (Ex: 15 mins)
 #SBATCH -o$job_slug.out            # Combined output and error messages file
 #SBATCH -q debug                   # Use debug QOS - only one job per user allowed in queue!
 #SBATCH -W                         # Do not exit until the submitted job terminates.

--- a/src/common/m_checker_common.fpp
+++ b/src/common/m_checker_common.fpp
@@ -316,8 +316,8 @@ contains
         @:PROHIBIT(.not. f_is_default(sigma) .and. .not. surface_tension, &
             "sigma is set but surface_tension is not enabled")
 
-        @:PROHIBIT(surface_tension .and. model_eqns /= 3, &
-            "The surface tension model requires model_eqns=3")
+        @:PROHIBIT(surface_tension .and. (model_eqns /= 3 .and. model_eqns /=2), &
+            "The surface tension model requires model_eqns=3 or model_eqns=2")
 
         @:PROHIBIT(surface_tension .and. num_fluids /= 2, &
             "The surface tension model requires num_fluids=2")

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -296,7 +296,7 @@ module m_global_parameters
     !! conditions data to march the solution in the physical computational domain
     !! to the next time-step.
 
-    !$acc declare create(sys_size, buff_size, E_idx, gamma_idx, pi_inf_idx, alf_idx, n_idx, stress_idx, b_size, tensor_size, xi_idx, species_idx, B_idx)
+    !$acc declare create(sys_size, buff_size, E_idx, gamma_idx, pi_inf_idx, alf_idx, n_idx, stress_idx, b_size, tensor_size, xi_idx, species_idx, B_idx, c_idx)
 
     integer :: shear_num !! Number of shear stress components
     integer, dimension(3) :: shear_indices !<
@@ -1212,7 +1212,7 @@ contains
         chemxb = species_idx%beg
         chemxe = species_idx%end
 
-        !$acc update device(momxb, momxe, advxb, advxe, contxb, contxe, bubxb, bubxe, intxb, intxe, sys_size, buff_size, E_idx, alf_idx, n_idx, adv_n, adap_dt, pi_fac, strxb, strxe, chemxb, chemxe)
+        !$acc update device(momxb, momxe, advxb, advxe, contxb, contxe, bubxb, bubxe, intxb, intxe, sys_size, buff_size, E_idx, alf_idx, n_idx, adv_n, adap_dt, pi_fac, strxb, strxe, chemxb, chemxe, c_idx)
         !$acc update device(b_size, xibeg, xiend, tensor_size)
 
         !$acc update device(species_idx)

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -135,6 +135,7 @@ contains
 
         real(wp) :: pres_IP, coeff
         real(wp), dimension(3) :: vel_IP, vel_norm_IP
+        real(wp) :: c_IP
         real(wp), dimension(num_fluids) :: alpha_rho_IP, alpha_IP
         real(wp), dimension(nb) :: r_IP, v_IP, pb_IP, mv_IP
         real(wp), dimension(nb*nmom) :: nmom_IP
@@ -170,19 +171,19 @@ contains
             !Interpolate primitive variables at image point associated w/ GP
             if (bubbles_euler .and. .not. qbmm) then
                 call s_interpolate_image_point(q_prim_vf, gp, &
-                                               alpha_rho_IP, alpha_IP, pres_IP, vel_IP, &
+                                               alpha_rho_IP, alpha_IP, pres_IP, vel_IP, c_IP, &
                                                r_IP, v_IP, pb_IP, mv_IP)
             else if (qbmm .and. polytropic) then
                 call s_interpolate_image_point(q_prim_vf, gp, &
-                                               alpha_rho_IP, alpha_IP, pres_IP, vel_IP, &
+                                               alpha_rho_IP, alpha_IP, pres_IP, vel_IP, c_IP, &
                                                r_IP, v_IP, pb_IP, mv_IP, nmom_IP)
             else if (qbmm .and. .not. polytropic) then
                 call s_interpolate_image_point(q_prim_vf, gp, &
-                                               alpha_rho_IP, alpha_IP, pres_IP, vel_IP, &
+                                               alpha_rho_IP, alpha_IP, pres_IP, vel_IP, c_IP, &
                                                r_IP, v_IP, pb_IP, mv_IP, nmom_IP, pb, mv, presb_IP, massv_IP)
             else
                 call s_interpolate_image_point(q_prim_vf, gp, &
-                                               alpha_rho_IP, alpha_IP, pres_IP, vel_IP)
+                                               alpha_rho_IP, alpha_IP, pres_IP, vel_IP, c_IP)
             end if
 
             dyn_pres = 0._wp
@@ -193,6 +194,10 @@ contains
                 q_prim_vf(q)%sf(j, k, l) = alpha_rho_IP(q)
                 q_prim_vf(advxb + q - 1)%sf(j, k, l) = alpha_IP(q)
             end do
+
+            if (surface_tension) then
+                q_prim_vf(c_idx)%sf(j,k,l) = c_IP
+            end if
 
             if (model_eqns /= 4) then
                 ! If in simulation, use acc mixture subroutines
@@ -233,6 +238,11 @@ contains
                 q_cons_vf(q)%sf(j, k, l) = alpha_rho_IP(q)
                 q_cons_vf(advxb + q - 1)%sf(j, k, l) = alpha_IP(q)
             end do
+
+            ! Set color function
+            if (surface_tension) then
+                q_cons_vf(c_idx)%sf(j,k,l) = c_IP
+            end if
 
             ! Set Energy
             if (bubbles_euler) then
@@ -308,6 +318,10 @@ contains
                 q_prim_vf(q)%sf(j, k, l) = alpha_rho_IP(q)
                 q_prim_vf(advxb + q - 1)%sf(j, k, l) = alpha_IP(q)
             end do
+
+            if (surface_tension) then
+                q_prim_vf(c_idx)%sf(j,k,l) = c_IP
+            end if
 
             call s_convert_species_to_mixture_variables_acc(rho, gamma, pi_inf, qv_K, alpha_IP, &
                                                             alpha_rho_IP, Re_K, j, k, l)
@@ -725,16 +739,18 @@ contains
 
     !> Function that uses the interpolation coefficients and the current state
     !! at the cell centers in order to estimate the state at the image point
-    subroutine s_interpolate_image_point(q_prim_vf, gp, alpha_rho_IP, alpha_IP, pres_IP, vel_IP, r_IP, v_IP, pb_IP, mv_IP, nmom_IP, pb, mv, presb_IP, massv_IP)
+    subroutine s_interpolate_image_point(q_prim_vf, gp, alpha_rho_IP, alpha_IP, pres_IP, vel_IP, c_IP, r_IP, v_IP, pb_IP, mv_IP, nmom_IP, pb, mv, presb_IP, massv_IP)
         !$acc routine seq
         type(scalar_field), &
             dimension(sys_size), &
             intent(IN) :: q_prim_vf !< Primitive Variables
+
         real(wp), optional, dimension(idwbuff(1)%beg:, idwbuff(2)%beg:, idwbuff(3)%beg:, 1:, 1:), intent(INOUT) :: pb, mv
 
         type(ghost_point), intent(IN) :: gp
         real(wp), intent(INOUT) :: pres_IP
         real(wp), dimension(3), intent(INOUT) :: vel_IP
+        real(wp), intent(INOUT) :: c_IP
         real(wp), dimension(num_fluids), intent(INOUT) :: alpha_IP, alpha_rho_IP
         real(wp), optional, dimension(:), intent(INOUT) :: r_IP, v_IP, pb_IP, mv_IP
         real(wp), optional, dimension(:), intent(INOUT) :: nmom_IP
@@ -757,6 +773,8 @@ contains
         alpha_IP = 0._wp
         pres_IP = 0._wp
         vel_IP = 0._wp
+
+        if (surface_tension) c_IP = 0._wp
 
         if (bubbles_euler) then
             r_IP = 0._wp
@@ -800,6 +818,10 @@ contains
                         alpha_IP(l) = alpha_IP(l) + coeff* &
                                       q_prim_vf(advxb + l - 1)%sf(i, j, k)
                     end do
+
+                    if (surface_tension) then
+                        c_IP = c_IP + coeff * q_prim_vf(c_idx)%sf(i,j,k)
+                    end if
 
                     if (bubbles_euler .and. .not. qbmm) then
                         !$acc loop seq

--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -196,7 +196,7 @@ contains
             end do
 
             if (surface_tension) then
-                q_prim_vf(c_idx)%sf(j,k,l) = c_IP
+                q_prim_vf(c_idx)%sf(j, k, l) = c_IP
             end if
 
             if (model_eqns /= 4) then
@@ -241,7 +241,7 @@ contains
 
             ! Set color function
             if (surface_tension) then
-                q_cons_vf(c_idx)%sf(j,k,l) = c_IP
+                q_cons_vf(c_idx)%sf(j, k, l) = c_IP
             end if
 
             ! Set Energy
@@ -320,7 +320,7 @@ contains
             end do
 
             if (surface_tension) then
-                q_prim_vf(c_idx)%sf(j,k,l) = c_IP
+                q_prim_vf(c_idx)%sf(j, k, l) = c_IP
             end if
 
             call s_convert_species_to_mixture_variables_acc(rho, gamma, pi_inf, qv_K, alpha_IP, &
@@ -820,7 +820,7 @@ contains
                     end do
 
                     if (surface_tension) then
-                        c_IP = c_IP + coeff * q_prim_vf(c_idx)%sf(i,j,k)
+                        c_IP = c_IP + coeff*q_prim_vf(c_idx)%sf(i, j, k)
                     end if
 
                     if (bubbles_euler .and. .not. qbmm) then

--- a/src/simulation/m_riemann_solvers.fpp
+++ b/src/simulation/m_riemann_solvers.fpp
@@ -1650,7 +1650,7 @@ contains
                                     end do
                                 end if
 
-                                ! SURFACE TENSION FLUX. need to check
+                                ! COLOR FUNCTION FLUX
                                 if (surface_tension) then
                                     flux_rs${XYZ}$_vf(j, k, l, c_idx) = &
                                         (xi_M*qL_prim_rs${XYZ}$_vf(j, k, l, c_idx) + &
@@ -2830,6 +2830,15 @@ contains
                                                 dir_flg(idxi)* &
                                                 s_P*(xi_R - 1._wp))
                                 end do
+
+                                ! COLOR FUNCTION FLUX
+                                if (surface_tension) then
+                                    flux_rs${XYZ}$_vf(j, k, l, c_idx) = &
+                                        xi_M*qL_prim_rs${XYZ}$_vf(j, k, l, c_idx) &
+                                        *(vel_L(idx1) + s_M*(xi_L - 1._wp)) &
+                                        + xi_P*qR_prim_rs${XYZ}$_vf(j + 1, k, l, c_idx) &
+                                        *(vel_R(idx1) + s_P*(xi_R - 1._wp))
+                                end if
 
                                 ! REFERENCE MAP FLUX.
                                 if (hyperelasticity) then


### PR DESCRIPTION
## Description

This PR makes the resolved phase surface tension model compatible with the 5-equation model and immersed boundaries.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

Recovering a circle on an immersed boundary:
https://github.com/user-attachments/assets/2b5d5618-10e6-4e89-83bd-f1ffe1fecf9c

Recovering a sphere in 3D:
https://github.com/user-attachments/assets/d23164c3-205b-4998-aca1-6b1f1195ce6d

Laplace pressure jump:
https://github.com/user-attachments/assets/d63d03cf-fffa-4c30-9e44-0343d67279a7

## Checklist

- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count


