### PR TITLE
Fixed GPU with NVHPC 25.3 - f_tri_area

### DIFF
--- a/src/pre_process/m_model.fpp
+++ b/src/pre_process/m_model.fpp
@@ -950,7 +950,7 @@ contains
                 tri(k, 2) = model%trs(i)%v(k, 2)
                 tri(k, 3) = model%trs(i)%v(k, 3)
             end do
-            tri_area = f_tri_area(tri)
+            call f_tri_area(tri, tri_area)
 
             if (tri_area > threshold_bary*cell_area_min) then
                 num_inner_vertices = Ifactor_bary_3D*ceiling(tri_area/cell_area_min)
@@ -1012,7 +1012,7 @@ contains
                 tri(k, 2) = model%trs(i)%v(k, 2)
                 tri(k, 3) = model%trs(i)%v(k, 3)
             end do
-            tri_area = f_tri_area(tri)
+            call f_tri_area(tri, tri_area)
 
             if (tri_area > threshold_bary*cell_area_min) then
                 num_inner_vertices = Ifactor_bary_3D*ceiling(tri_area/cell_area_min)
@@ -1168,6 +1168,25 @@ contains
 
     end subroutine f_normals
 
+    !> This procedure calculates the barycentric facet area
+    pure subroutine f_tri_area(tri, tri_area)
+        real(wp), dimension(1:3, 1:3), intent(in) :: tri
+        real(wp), intent(out) :: tri_area
+        t_vec3 :: AB, AC, cross
+        integer :: i !< Loop iterator
+
+        do i = 1, 3
+            AB(i) = tri(2, i) - tri(1, i)
+            AC(i) = tri(3, i) - tri(1, i)
+        end do
+
+        cross(1) = AB(2)*AC(3) - AB(3)*AC(2)
+        cross(2) = AB(3)*AC(1) - AB(1)*AC(3)
+        cross(3) = AB(1)*AC(2) - AB(2)*AC(1)
+        tri_area = 0.5_wp*sqrt(cross(1)**2 + cross(2)**2 + cross(3)**2)
+
+    end subroutine f_tri_area
+
     !> This procedure determines the levelset of interpolated 2D models.
     !! @param interpolated_boundary_v      Group of all the boundary vertices of the interpolated 2D model
     !! @param total_vertices               Total number of vertices after interpolation
@@ -1199,24 +1218,5 @@ contains
         distance = min_dist
 
     end function f_interpolated_distance
-
-    !> This procedure calculates the barycentric facet area
-    pure function f_tri_area(tri) result(tri_area)
-        real(wp), dimension(1:3, 1:3), intent(in) :: tri
-        t_vec3 :: AB, AC, cross
-        real(wp) :: tri_area
-        integer :: i !< Loop iterator
-
-        do i = 1, 3
-            AB(i) = tri(2, i) - tri(1, i)
-            AC(i) = tri(3, i) - tri(1, i)
-        end do
-
-        cross(1) = AB(2)*AC(3) - AB(3)*AC(2)
-        cross(2) = AB(3)*AC(1) - AB(1)*AC(3)
-        cross(3) = AB(1)*AC(2) - AB(2)*AC(1)
-        tri_area = 0.5_wp*sqrt(cross(1)**2 + cross(2)**2 + cross(3)**2)
-
-    end function f_tri_area
 
 end module m_model


### PR DESCRIPTION
## Description

When building with NVHPC 25.3, I was getting a FORT 2 TERMINATED by SIGNAL 11. The cause of the error was the function `f_tri_area`, It seemed to be fixed by changing it into a subroutine. 

Fixes #(issue) [optional]

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

- [x] Built Locally with NVHPC 25.3
- [x] Built on Phoenix NVHPC 24.7

**Test Configuration**:

* What computers and compilers did you use to test this:
Locally w/ Linux - NVHPC 25.3
Phoenix NVHPC 24.7

## Checklist

- [x] I ran `./mfc.sh format` before committing my code
- [x] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count