### PR TITLE
changed output file to run_time.inf (3) (#504)

### DIFF
--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -149,18 +149,18 @@ contains
         ! Generating table header for the stability criteria to be outputted
         if (cfl_dt) then
             if (viscous) then
-                write (1, '(A)') '     Time-steps        dt     = Time         ICFL '// &
+                write (3, '(A)') '     Time-steps        dt     = Time         ICFL '// &
                     'Max      VCFL Max        Rc Min       ='
             else
-                write (1, '(A)') '            Time-steps                dt       Time '// &
+                write (3, '(A)') '            Time-steps                dt       Time '// &
                     '               ICFL Max              '
             end if
         else
             if (viscous) then
-                write (1, '(A)') '     Time-steps        Time         ICFL '// &
+                write (3, '(A)') '     Time-steps        Time         ICFL '// &
                     'Max      VCFL Max        Rc Min        '
             else
-                write (1, '(A)') '            Time-steps                Time '// &
+                write (3, '(A)') '            Time-steps                Time '// &
                     '               ICFL Max              '
             end if
         end if
@@ -351,12 +351,12 @@ contains
         ! Outputting global stability criteria extrema at current time-step
         if (proc_rank == 0) then
             if (viscous) then
-                write (1, '(6X,I8,F10.6,6X,6X,F10.6,6X,F9.6,6X,F9.6,6X,F10.6)') &
+                write (3, '(6X,I8,F10.6,6X,6X,F10.6,6X,F9.6,6X,F9.6,6X,F10.6)') &
                     t_step, dt, t_step*dt, icfl_max_glb, &
                     vcfl_max_glb, &
                     Rc_min_glb
             else
-                write (1, '(13X,I8,14X,F10.6,14X,F10.6,13X,F9.6)') &
+                write (3, '(13X,I8,14X,F10.6,14X,F10.6,13X,F9.6)') &
                     t_step, dt, t_step*dt, icfl_max_glb
             end if
 


### PR DESCRIPTION
## Description
dumps all data into run_time.inf instead of the default file (fort.1)

``` bash 
/MFC-mo2/tests/4E0FBE72$ ls
D        golden-metadata.txt  post_process.inp   restart_data    syscheck.inp
MFC.sh   golden.txt           pre_process.inp    run_time.inf
case.py  indices.dat          pre_time_data.dat  simulation.inp
```

example of run_time.inf content: 
```txt
Description: Stability information at each time-step of the simulation. This
             data is composed of the inviscid Courant–Friedrichs–Lewy (ICFL)
             number, the viscous CFL (VCFL) number, the capillary CFL (CCFL)
             number and the cell Reynolds (Rc) number. Please note that only
             those stability conditions pertinent to the physics included in
             the current computation are displayed.
Date: 06/11/25


            Time-steps                Time                ICFL Max              
                    0                0.000500                0.000000              0.327482
                    1                0.000500                0.000500              0.357676
                    2                0.000500                0.001000              0.379429
                    3                0.000500                0.001500              0.390992
                    4                0.000500                0.002000              0.396743
                    5                0.000500                0.002500              0.398029
                    6                0.000500                0.003000              0.397962
                    7                0.000500                0.003500              0.409929
                    8                0.000500                0.004000              0.416906
                    9                0.000500                0.004500              0.418559
                   10                0.000500                0.005000              0.417314
                   11                0.000500                0.005500              0.423738
                   12                0.000500                0.006000              0.425645
                   13                0.000500                0.006500              0.423960
                   14                0.000500                0.007000              0.427397
                   15                0.000500                0.007500              0.426164
                   16                0.000500                0.008000              0.426784
                   17                0.000500                0.008500              0.427558
                   18                0.000500                0.009000              0.425918
                   19                0.000500                0.009500              0.428402
                   20                0.000500                0.010000              0.427583
                   21                0.000500                0.010500              0.428566
                   22                0.000500                0.011000              0.429166
                   23                0.000500                0.011500              0.427539
                   24                0.000500                0.012000              0.429855
                   25                0.000500                0.012500              0.429434
                   26                0.000500                0.013000              0.428507
                   27                0.000500                0.013500              0.430199
                   28                0.000500                0.014000              0.429318
                   29                0.000500                0.014500              0.429413
                   30                0.000500                0.015000              0.430053
                   31                0.000500                0.015500              0.429033
                   32                0.000500                0.016000              0.429606
                   33                0.000500                0.016500              0.429719
                   34                0.000500                0.017000              0.428677
                   35                0.000500                0.017500              0.429477
                   36                0.000500                0.018000              0.429322
                   37                0.000500                0.018500              0.428305
                   38                0.000500                0.019000              0.429179
                   39                0.000500                0.019500              0.428892
                   40                0.000500                0.020000              0.428078
                   41                0.000500                0.020500              0.428775
                   42                0.000500                0.021000              0.428444
                   43                0.000500                0.021500              0.427882
                   44                0.000500                0.022000              0.428315
                   45                0.000500                0.022500              0.427990
                   46                0.000500                0.023000              0.427539
                   47                0.000500                0.023500              0.427822
                   48                0.000500                0.024000              0.427539
                   49                0.000500                0.024500              0.436169
    

ICFL Max:  0.436169

Run-time: 1s
```
