### PR TITLE
Fix Skipped Test Issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
         include:
           - os:    ubuntu
-            mpi:   mpi
+            mpi:   no-mpi
             precision: single
             debug: no-debug
             intel: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
         include:
           - os:    ubuntu
-            mpi:   no-mpi
+            mpi:   mpi
             precision: single
             debug: no-debug
             intel: false

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -37,6 +37,7 @@ def __filter(cases_) -> typing.List[TestCase]:
             # Do not "continue" because "--to" might be the same as "--from"
         if bFoundFrom and case.get_uuid() == ARG("to"):
             cases    = cases[from_i:i+1]
+            skipped_cases += [case for case in cases_ if case not in cases]
             bFoundTo = True
             break
 
@@ -51,6 +52,7 @@ def __filter(cases_) -> typing.List[TestCase]:
             checkCase.append(case.get_uuid())
             if not set(ARG("only")).issubset(set(checkCase)):
                 cases.remove(case)
+                skipped_cases.append(case)
 
     for case in cases[:]:
         if case.ppn > 1 and not ARG("mpi"):
@@ -63,9 +65,11 @@ def __filter(cases_) -> typing.List[TestCase]:
             ,'Axisymmetric', 'Transducer', 'Transducer Array', 'Cylindrical', 'HLLD', 'Example']
             if any(label in case.trace for label in skip):
                 cases.remove(case)
+                skipped_cases.append(case)
 
 
     if ARG("no_examples"):
+        skipped_cases += [case for case in cases if "Example" in case.trace]
         cases = [case for case in cases if not "Example" in case.trace]
 
     if ARG("percent") == 100:
@@ -74,7 +78,7 @@ def __filter(cases_) -> typing.List[TestCase]:
     seed(time.time())
 
     selected_cases = sample(cases, k=int(len(cases)*ARG("percent")/100.0))
-    skipped_cases = [item for item in cases if item not in selected_cases]
+    skipped_cases += [item for item in cases if item not in selected_cases]
 
     return selected_cases, skipped_cases
 

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -37,7 +37,7 @@ def __filter(cases_) -> typing.List[TestCase]:
             # Do not "continue" because "--to" might be the same as "--from"
         if bFoundFrom and case.get_uuid() == ARG("to"):
             cases    = cases[from_i:i+1]
-            skipped_cases += [case for case in cases_ if case not in cases]
+            skipped_cases = [case for case in cases_ if case not in cases]
             bFoundTo = True
             break
 
@@ -69,8 +69,9 @@ def __filter(cases_) -> typing.List[TestCase]:
 
 
     if ARG("no_examples"):
-        skipped_cases += [case for case in cases if "Example" in case.trace]
-        cases = [case for case in cases if not "Example" in case.trace]
+        example_cases = [case for case in cases if "Example" in case.trace]
+        skipped_cases += example_cases
+        cases = [case for case in cases if case not in example_cases]
 
     if ARG("percent") == 100:
         return cases, skipped_cases


### PR DESCRIPTION
### **User description**
## Description

There were several logic problem during test. The test script ignored skipped cases for some special flags, and when combining % flag with other options will only count the skipped cases filtered by % flag.

Fixes #(issue) [optional]

### Type of change

Please delete options that are not relevant.

- [ ] Fixed the logic in toolchain/mfc/test/test.py script

### Scope

- [ ] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

* What computers and compilers did you use to test this:

## Checklist

- [ ] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [ ] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [ ] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [ ] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran a Rocprof Systems profile using `./mfc.sh run XXXX --gpu -t simulation --rsys --hip-trace`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed skipped test case tracking logic in test filtering

- Corrected handling of skipped cases when using percent flag

- Added proper skipped case collection for range and filter operations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.py</strong><dd><code>Fix skipped test case tracking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

toolchain/mfc/test/test.py

<li>Added skipped case tracking for <code>--from</code>/<code>--to</code> range filtering<br> <li> Fixed skipped case collection in <code>--only</code> filter logic<br> <li> Added skipped case tracking for <code>--single</code> flag filtering<br> <li> Fixed skipped case accumulation when using <code>--percent</code> flag


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/904/files#diff-f6e8934e27b5173e5e507afd442b7e24ef61cf90dcb204dcc76f3eb9437b63ac">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>