### PR TITLE
Updated Bridges2 Modules (CPU/GPU)

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -14,11 +14,9 @@ s-gpu nvhpc/22.11 cuda/nvhpc
 s-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 b     PSC Bridges2
-b-all python/3.8.6 hdf5
+b-all python/3.8.6 hdf5 anaconda3
 b-cpu allocations/1.0 gcc/10.2.0 openmpi/4.0.5-gcc10.2.0
-b-gpu nvhpc/22.9
-b-gpu cuda/11.7
-b-gpu openmpi/4.0.5-nvhpc22.9
+b-gpu nvhpc/22.9 cuda/11.7 openmpi/4.0.5-nvhpc22.9
 b-gpu MFC_CUDA_CC=70,75,80 NVHPC_CUDA_HOME=$CUDA_HOME CC=nvc CXX=nvc++ FC=nvfortran
 
 a     OLCF Ascent

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -14,10 +14,12 @@ s-gpu nvhpc/22.11 cuda/nvhpc
 s-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 b     PSC Bridges2
-b-all python/3.8.6
+b-all python/3.8.6 hdf5
 b-cpu allocations/1.0 gcc/10.2.0 openmpi/4.0.5-gcc10.2.0
-b-gpu openmpi/4.0.5-nvhpc22.9 nvhpc/22.9 cuda
-b-gpu CC=nvc CXX=nvc++ FC=nvfortran
+b-gpu nvhpc/22.9
+b-gpu cuda/11.7
+b-gpu openmpi/4.0.5-nvhpc22.9
+b-gpu MFC_CUDA_CC=70,75,80 NVHPC_CUDA_HOME=$CUDA_HOME CC=nvc CXX=nvc++ FC=nvfortran
 
 a     OLCF Ascent
 a-all python cmake/3.22.2


### PR DESCRIPTION
## Description
Concerning (#614),

Updated modules for Bridges2, tested on `--qos=cpuinteract/gpuinteract`. MFC compiles and builds neatly. To address the outdated python version issue, `anaconda3 `is loaded as it houses a very recent version. Foreseen concern would be dependency conflict with the co-existing py venv & conda env. Therefore, please keep conda as-is and do not attempt to install any dependency on it at all. To run tests, append `-- --binary mpirun`.