### PR TITLE
Move to gfortran 15 on macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,8 @@ jobs:
         run:  |
           brew update
           brew upgrade
-          brew install coreutils python cmake fftw hdf5 gcc@14 boost open-mpi
-          echo "FC=gfortran-14" >> $GITHUB_ENV
+          brew install coreutils python cmake fftw hdf5 gcc@15 boost open-mpi
+          echo "FC=gfortran-15" >> $GITHUB_ENV
           echo "BOOST_INCLUDE=/opt/homebrew/include/" >> $GITHUB_ENV
 
       - name: Setup Ubuntu


### PR DESCRIPTION
### **User description**
MacOS runners were using gfortran 14 with an incompatible open-mpi. This PR moves us to gnu15 and fixes a build error.


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade gfortran from version 14 to 15 on macOS

- Fix compatibility issues with open-mpi

- Add missing newline at end of file


___

### **Changes diagram**

```mermaid
flowchart LR
  A["macOS CI Setup"] --> B["Install gcc@15"]
  B --> C["Set FC=gfortran-15"]
  C --> D["Compatible with open-mpi"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.yml</strong><dd><code>Upgrade gfortran version in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test.yml

<li>Update brew install command to use <code>gcc@15</code> instead of <code>gcc@14</code><br> <li> Change environment variable <code>FC</code> to <code>gfortran-15</code><br> <li> Add missing newline at end of file


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/924/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>