### PR TITLE
`verrou` into Workflow

### DIFF
--- a/.github/workflows/verrou.yml
+++ b/.github/workflows/verrou.yml
@@ -1,0 +1,31 @@
+name: Floating-Point Compliance
+
+on: [pull_request, push]
+
+jobs:
+  self:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone PR
+        uses: actions/checkout@v4
+
+      - name: valgrind Setup
+        run: |
+          # get recent release of valgrind from GitHub API
+          VALGRIND_VERSION=$(curl -s https://api.github.com/repos/LouisBrunner/valgrind/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+          # download and extract it
+          wget https://github.com/LouisBrunner/valgrind/releases/download/${VALGRIND_VERSION}/valgrind-${VALGRIND_VERSION}.tar.bz2
+          tar -xjf valgrind-${VALGRIND_VERSION}.tar.bz2
+          cd valgrind-${VALGRIND_VERSION}
+          ./autogen.sh
+          ./configure --enable-only64bit --prefix=/usr/local
+          make
+          sudo make install
+          source /usr/local/env.sh
+
+      - name: Run tests
+        run: valgrind --tool=verrou ./mfc.sh test -a --dry-run
+
+      - name: Check floating point compliance
+        run: |
+          echo "Checking floating point compliance..."


### PR DESCRIPTION
## Description
Concerning (#650),
Intended as standalone floating-point error checker.

Debugging info,
The current Valgrind setup ought to be sufficient, so debugging locally (nektos/act extension) or on the CI are all viable.

To-dos,
- [ ] Proper Valgrind commands to generate the most amount of errors.
- [ ] Save and process all reports such that non-empty error summaries are displayed.

Ref [verrou docs](https://edf-hpc.github.io/verrou/vr-manual.html)