### PR TITLE
Bug fix in m_data_input.f90

### DIFF
--- a/src/post_process/m_data_input.f90
+++ b/src/post_process/m_data_input.f90
@@ -515,9 +515,8 @@ contains
                 call s_mpi_abort('File '//trim(file_loc)//' is missing. Exiting.')
             end if
         end if
-#endif
-
     end subroutine s_read_parallel_conservative_data
+#endif
 
     !>  Computation of parameters, allocation procedures, and/or
         !!      any other tasks needed to properly setup the module

--- a/src/post_process/m_data_input.f90
+++ b/src/post_process/m_data_input.f90
@@ -108,6 +108,7 @@ contains
 
     end subroutine s_read_grid_data_direction
 
+#ifdef MFC_MPI
     !> Helper subroutine to setup MPI data I/O parameters
     !!  @param data_size Local array size (output)
     !!  @param m_MOK, n_MOK, p_MOK MPI offset kinds for dimensions (output)
@@ -138,6 +139,7 @@ contains
         NVARS_MOK = int(sys_size, MPI_OFFSET_KIND)
 
     end subroutine s_setup_mpi_io_params
+#endif
 
     !> Helper subroutine to read IB data files
     !!  @param file_loc_base Base file location for IB data
@@ -148,9 +150,11 @@ contains
         character(LEN=len_trim(file_loc_base) + 20) :: file_loc
         logical :: file_exist
         integer :: ifile, ierr, data_size
+
+#ifdef MFC_MPI
         integer, dimension(MPI_STATUS_SIZE) :: status
         integer(KIND=MPI_OFFSET_KIND) :: disp
-
+#endif
         if (.not. ib) return
 
         if (parallel_io) then
@@ -426,6 +430,7 @@ contains
 
     end subroutine s_read_parallel_data_files
 
+#ifdef MFC_MPI
     !> Helper subroutine to read parallel conservative variable data
     !!  @param t_step Current time-step
     !!  @param m_MOK, n_MOK, p_MOK MPI offset kinds for dimensions
@@ -435,8 +440,6 @@ contains
         integer, intent(in) :: t_step
         integer(KIND=MPI_OFFSET_KIND), intent(inout) :: m_MOK, n_MOK, p_MOK
         integer(KIND=MPI_OFFSET_KIND), intent(inout) :: WP_MOK, MOK, str_MOK, NVARS_MOK
-
-#ifdef MFC_MPI
 
         integer :: ifile, ierr, data_size
         integer, dimension(MPI_STATUS_SIZE) :: status
@@ -512,7 +515,6 @@ contains
                 call s_mpi_abort('File '//trim(file_loc)//' is missing. Exiting.')
             end if
         end if
-
 #endif
 
     end subroutine s_read_parallel_conservative_data


### PR DESCRIPTION
### **User description**
## Description
(#902) introduced a bug where whenever `--no-mpi` was utilized, mpi-specific variables/subroutines would still be present/used in m_data_input.f90. The PR attempts to fix it by re-arranging MFC_MPI if enclosures (`#ifdef MFC_MPI .... #endif`). With the new changes, `./mfc.sh build -t post_process --no-mpi` works nicely.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed MPI preprocessor directive placement in data input module

- Resolved compilation issues when building with `--no-mpi` flag

- Reorganized `#ifdef MFC_MPI` blocks to properly isolate MPI-specific code


___

### **Changes diagram**

```mermaid
flowchart LR
  A["MPI code mixed with non-MPI"] --> B["Reorganize #ifdef blocks"]
  B --> C["MPI code properly isolated"]
  C --> D["--no-mpi builds successfully"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>m_data_input.f90</strong><dd><code>Fix MPI preprocessor directive placement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/post_process/m_data_input.f90

<li>Added <code>#ifdef MFC_MPI</code> directive before <code>s_setup_mpi_io_params</code> subroutine<br> <li> Added corresponding <code>#endif</code> after the subroutine<br> <li> Moved MPI variable declarations inside <code>#ifdef MFC_MPI</code> blocks in <br><code>s_read_ib_data_files</code><br> <li> Reorganized MPI preprocessor directives in <br><code>s_read_parallel_conservative_data</code>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/938/files#diff-feecd0a1828d0df0362debafdfbe773465c3dd6ce5222731fe9d7c30bb59203c">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>