### PR TITLE
Make vscode a bit nicer [fewer spurious warnings or errors]

### DIFF
--- a/.fortls.json
+++ b/.fortls.json
@@ -1,0 +1,94 @@
+{
+    "source_dirs": [
+        "src/",
+        "src/common/",
+        "src/simulation/",
+        "src/pre_process/",
+        "src/post_process/"
+    ],
+    "excl_paths": [
+        "benchmarks/",
+        "examples/",
+        "tests/",
+        "misc/",
+        "src/pre_process/include/2dHardcodedIC.fpp",
+        "src/pre_process/include/3dHardcodedIC.fpp",
+        "src/pre_process/include/ExtrusionHardcodedIC.fpp"
+    ],
+    "include_dirs": [
+        "src/common/include/",
+        "src/simulation/include/",
+        "src/pre_process/include/",
+        "src/post_process/include/"
+    ],
+    "pp_suffixes": [".fpp"],
+    "pp_defs": {
+        "MFC": 1,
+        "MFC_DOUBLE_PRECISION": 1
+    },
+    "lowercase_intrinsics": true,
+    "debug_log": false,
+    "disable_diagnostics": true,
+    "use_signature_help": true,
+    "variable_hover": true,
+    "hover_signature": true,
+    "enable_code_actions": true,
+    "mod_dirs": [
+        "build/pre_process/",
+        "build/simulation/",
+        "build/post_process/",
+        "build/common/"
+    ],
+    "ext_mod_dirs": [
+        "/usr/include/",
+        "/usr/local/include/",
+        "/opt/homebrew/include/"
+    ],
+    "implicit_external_mods": [
+        "mpi",
+        "m_thermochem",
+        "hipfort",
+        "hipfort_check",
+        "hipfort_hipfft",
+        "cutensorex",
+        "silo_f9x",
+        "m_model"
+    ],
+    "disable_diagnostics_for_external_modules": true,
+    "max_line_length": 132,
+    "symbol_skip_mem": [
+        "mpi_*"
+    ],
+    "disable_var_diagnostics": true,
+    "disable_fypp": false,
+    "fypp_strict": false,
+    "error_suppression_list": [
+        "include-not-found",
+        "mod-not-found",
+        "var-masking",
+        "declared-twice",
+        "no-matching-declaration",
+        "invalid-parent",
+        "parsing-error",
+        "fypp-error",
+        "preprocessor-error",
+        "syntax-error",
+        "semantic-error",
+        "type-error",
+        "undefined-variable",
+        "line-too-long"
+    ],
+    "incremental_sync": false,
+    "debug_parser": false,
+    "skip_parse_errors": true,
+    "disable_parser": [
+        "src/post_process/m_data_output.fpp",
+        "src/pre_process/include/ExtrusionHardcodedIC.fpp",
+        "src/pre_process/m_checker.fpp",
+        "src/pre_process/include/2dHardcodedIC.fpp",
+        "src/pre_process/include/3dHardcodedIC.fpp",
+        "src/simulation/m_qbmm.fpp",
+        "src/common/m_variables_conversion.fpp",
+        "src/simulation/m_global_parameters.fpp"
+    ]
+} 

--- a/.fortlsrc
+++ b/.fortlsrc
@@ -1,0 +1,96 @@
+{
+    "source_dirs": [
+        "src/",
+        "src/common/",
+        "src/simulation/",
+        "src/pre_process/",
+        "src/post_process/"
+    ],
+    "excl_paths": [
+        "benchmarks/",
+        "examples/",
+        "tests/",
+        "misc/",
+        "src/pre_process/include/2dHardcodedIC.fpp",
+        "src/pre_process/include/3dHardcodedIC.fpp",
+        "src/pre_process/include/ExtrusionHardcodedIC.fpp",
+        "**/m_nvtx*",
+        "**/syscheck.fpp"
+    ],
+    "include_dirs": [
+        "src/common/include/",
+        "src/simulation/include/",
+        "src/pre_process/include/",
+        "src/post_process/include/"
+    ],
+    "pp_suffixes": [".fpp"],
+    "pp_defs": {
+        "MFC": 1,
+        "MFC_DOUBLE_PRECISION": 1
+    },
+    "lowercase_intrinsics": true,
+    "debug_log": true,
+    "disable_diagnostics": false,
+    "use_signature_help": true,
+    "variable_hover": true,
+    "hover_signature": true,
+    "enable_code_actions": true,
+    "mod_dirs": [
+        "build/pre_process/",
+        "build/simulation/",
+        "build/post_process/",
+        "build/common/"
+    ],
+    "ext_mod_dirs": [
+        "/usr/include/",
+        "/usr/local/include/",
+        "/opt/homebrew/include/"
+    ],
+    "implicit_external_mods": [
+        "mpi",
+        "m_thermochem",
+        "m_variables_conversion",
+        "hipfort",
+        "hipfort_check",
+        "hipfort_hipfft",
+        "cutensorex",
+        "silo_f9x",
+        "m_model"
+    ],
+    "disable_diagnostics_for_external_modules": true,
+    "max_line_length": -1,
+    "max_comment_line_length": -1,
+    "symbol_skip_mem": [
+        "mpi_*"
+    ],
+    "disable_var_diagnostics": false,
+    "disable_fypp": false,
+    "fypp_strict": false,
+    "error_suppression_list": [
+        "include-not-found",
+        "mod-not-found",
+        "module-not-found",
+        "declared-twice",
+        "no-matching-declaration",
+        "invalid-parent",
+        "parsing-error",
+        "fypp-error",
+        "preprocessor-error",
+        "implicit-type"
+    ],
+    "incremental_sync": false,
+    "debug_parser": false,
+    "skip_parse_errors": true,
+    "disable_parser": [
+        "src/post_process/m_data_output.fpp",
+        "src/pre_process/include/ExtrusionHardcodedIC.fpp",
+        "src/pre_process/m_checker.fpp",
+        "src/pre_process/include/2dHardcodedIC.fpp",
+        "src/pre_process/include/3dHardcodedIC.fpp",
+        "src/simulation/m_qbmm.fpp",
+        "src/common/m_variables_conversion.fpp",
+        "src/simulation/m_global_parameters.fpp",
+        "**/m_nvtx*",
+        "**/syscheck.fpp"
+    ]
+} 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
-    "recommendations": [
+    "recommendations": [],
+    "unwantedRecommendations": [
         "fortran-lang.linter-gfortran"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.detectIndentation": false,
     "editor.insertSpaces":      true,
-    "editor.tabSize":           4,
+    "editor.tabSize":           2,
     "editor.rulers":            [ 80, 120 ],
     "files.exclude": {
         "**/.git":      true,
@@ -9,6 +9,7 @@
         "**/build":     true,
         "**/*.o":       true,
         "**/*.mod":     true,
+        "**/misc/**":   true
     },
 
     "cmake.configureOnOpen": false,
@@ -17,15 +18,78 @@
 
     "files.associations": {
         "*.f90": "FortranFreeForm",
-        "*.fpp": "FortranFreeForm",
+        "*.fpp": "FortranFreeForm"
     },
 
-    "fortran.preferredCase":       "lowercase",
-    "fortran.linter.includePaths": [
-        "${workspacefolder}/src/${fileDirname}",
-        "${workspacefolder}/src/${fileDirname}/include",
-        "${workspacefolder}/src/common",
-        "${workspacefolder}/src/common/include"
-    ],
-    "fortran.linter.extraArgs":    ["--free-form"],
+    // Disable the extension entirely at workspace level
+    "extensions.ignoreRecommendations": true,
+    "extensions.autoCheckUpdates": false,
+    
+    "fortran.preferredCase": "lowercase",
+    
+    // Disable built-in linter completely but enable fortls
+    "fortran.disabled": false,
+    "fortran.linter.enabled": false,
+    "fortran.linter.gfortran.enabled": false,
+    "fortran.linter.compiler": "",
+    "fortran.linter.diagnostics": false,
+    "fortran.linter.gfortran.diagnostics": false,
+    "fortran.linter.modOutput": "",
+    "fortran.linter.includePaths": [],
+    "fortran.linter.extraArgs": [],
+    "fortran.provideDiagnostics": false,
+    "fortran.provideCompletion": false,
+    "fortran.provideHover": false,
+    "fortran.provideSymbols": false,
+    "fortran.validation.enabled": false,
+    "fortran.validation.diagnostics": false,
+    "fortran.symbols": false,
+    "fortran.hover": false,
+    
+    // Enable ONLY fortls language server
+    "fortran.enableLanguageServer": true,
+    "fortran.languageServer": "fortls",
+    "fortran.fortls.disabled": false,
+    "fortran.fortls.path": "fortls",
+    
+    // Try to disable any built-in language features
+    "editor.semanticHighlighting.enabled": false,
+    "editor.suggest.showWords": false,
+    "editor.suggest.showSnippets": false,
+    
+    "[fortran]": {
+        "editor.tabSize": 2,
+        "editor.semanticHighlighting.enabled": false
+    },
+    "[fortran-free]": {
+        "editor.tabSize": 2,
+        "editor.semanticHighlighting.enabled": false
+    },
+    "[FortranFreeForm]": {
+        "editor.tabSize": 2,
+        "editor.semanticHighlighting.enabled": false
+    },
+    
+    // File exclusions - multiple layers of exclusion
+    "files.watcherExclude": {
+        "**/misc/**": true,
+        "**/benchmarks/**": true,
+        "**/examples/**": true,
+        "**/tests/**": true,
+        "**/build/**": true,
+        "**/m_nvtx*": true,
+        "**/syscheck.fpp": true
+    },
+    
+    "search.exclude": {
+        "**/misc/**": true,
+        "**/benchmarks/**": true,
+        "**/examples/**": true,
+        "**/tests/**": true,
+        "**/build/**": true
+    },
+    
+    // Keep problems panel available
+    "problems.showOn": "toggle",
+    "problems.defaultViewMode": "list"
 }


### PR DESCRIPTION
### **User description**
Modifications to the vscode setup to make the linter somewhat useful (and surpress the bazillion warnings and errorrs that were spurious)


___

### **PR Type**
Enhancement


___

### **Description**
- Configure fortls language server for Fortran development

- Disable built-in VSCode Fortran linter warnings

- Add comprehensive error suppression configuration

- Update workspace settings for better development experience


___

### **Changes diagram**

```mermaid
flowchart LR
  A["VSCode Settings"] --> B["Disable Built-in Linter"]
  A --> C["Enable fortls Server"]
  D["fortls Config"] --> E["Source Directories"]
  D --> F["Error Suppression"]
  D --> G["External Modules"]
  B --> H["Cleaner Development"]
  C --> H
  F --> H
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.fortls.json</strong><dd><code>Add fortls language server configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.fortls.json

<li>Configure fortls language server with source directories and include <br>paths<br> <li> Define preprocessor settings for MFC project<br> <li> Disable diagnostics and enable comprehensive error suppression<br> <li> Specify external modules and build directories


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/940/files#diff-6d9ac7050240abae80e8b8c9a7190f314efd77e30866f6fa48cd2ac3fa25f501">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.fortlsrc</strong><dd><code>Add alternative fortls configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.fortlsrc

<li>Similar fortls configuration with different diagnostic settings<br> <li> Enable debug logging and reduce error suppression list<br> <li> Add additional excluded paths for NVTX and syscheck files<br> <li> Configure line length limits and variable diagnostics


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/940/files#diff-37250671945b54451d530cb82c3089bdd5b0e2fb9de9dc33530f0e35c0b42fc1">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>extensions.json</strong><dd><code>Disable unwanted Fortran extension recommendations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/extensions.json

<li>Move gfortran linter from recommendations to unwanted recommendations<br> <li> Clear recommendations array to prevent automatic extension suggestions


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/940/files#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Configure VSCode workspace for fortls integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/settings.json

<li>Disable built-in Fortran linter and enable fortls language server<br> <li> Add comprehensive file exclusions for misc, benchmarks, examples, <br>tests<br> <li> Configure editor settings with 2-space tabs and semantic highlighting <br>disabled<br> <li> Set up workspace-specific Python interpreter path and file <br>associations


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/940/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357">+74/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>