### PR TITLE
Update CMakeLists.txt to link new header files for NVTX v3 for CUDA 1…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,10 +524,21 @@ function(MFC_SETUP_TARGET)
             target_compile_options(${a_target} PRIVATE "SHELL:-h noacc" "SHELL:-x acc")
         endif()
 
-        if (CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" OR CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
-            find_package(CUDAToolkit REQUIRED)
-            target_link_libraries(${a_target} PRIVATE CUDA::nvToolsExt)
+        if (CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" OR
+            CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
+
+            # Ask specifically for the header-only NVTX v3 interface
+            find_package(CUDAToolkit REQUIRED COMPONENTS nvtx3)
+
+            if (TARGET CUDA::nvToolsExt) # CUDA <= 12.8
+                target_link_libraries(${a_target} PRIVATE CUDA::nvToolsExt)
+            else() # CUDA >= 12.9
+                target_link_libraries(${a_target} PRIVATE CUDA::nvtx3)
+            endif()
+            target_link_options(${a_target} PRIVATE "-cudalib=nvtx")
+
         endif()
+        
     endforeach()
 
     install(TARGETS ${ARGS_TARGET} RUNTIME DESTINATION bin)


### PR DESCRIPTION
### **User description**
…2.9+

## Description

Adding a switch in CMakeLists.txt to locate and link the appropriate NVTX headers for CUDA 12.9+, while maintaining the previous compatibility with <= CUDA 12.8. 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

Builds with both nvhpc 25.3 and 25.5 (CUDA 12.8 and 12.9) with `--debug` and `--gpu` flags enabled.
Solve 1x randomly chosen 2D example problem per build.

**Test Configuration**:
- Personal Laptop (Older Dell P5540 w/ Quadro P2000, Rocky Linux 8.10 - 4.18.0-553.el8_10.x86_64)
- nvhpc 25.3 and nvhpc 25.5

## Checklist

- [x] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [ ] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [ x] I cannot think of a way to condense this code and reduce any introduced additional line count


___

### **PR Type**
Bug fix


___

### **Description**
- Update CMakeLists.txt to support NVTX v3 for CUDA 12.9+

- Add conditional linking for different CUDA versions

- Maintain backward compatibility with CUDA <= 12.8

- Include nvtx3 component and cudalib linker option


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CUDA Toolkit Detection"] --> B["Check CUDA Version"]
  B --> C["CUDA <= 12.8"]
  B --> D["CUDA >= 12.9"]
  C --> E["Link CUDA::nvToolsExt"]
  D --> F["Link CUDA::nvtx3"]
  E --> G["Add cudalib=nvtx option"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Update NVTX linking for CUDA version compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<ul><li>Add conditional NVTX linking based on CUDA version<br> <li> Request nvtx3 component in CUDAToolkit package<br> <li> Add cudalib=nvtx linker option for all cases<br> <li> Maintain compatibility with older CUDA versions</ul>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/949/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+14/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

