### PR TITLE
Fix broken example 0D_bubblecollapse_adap

### DIFF
--- a/docs/documentation/case.md
+++ b/docs/documentation/case.md
@@ -379,6 +379,8 @@ Details of implementation of viscosity in MFC can be found in [Coralic (2015)](r
 | `mixture_err`          | Logical | Mixture properties correction |
 | `time_stepper`         | Integer | Runge--Kutta order [1-3] |
 | `adap_dt`              | Logical | Strang splitting scheme with adaptive time stepping |
+| `adap_dt_tol`          | Real    | Tolerance for adaptive time stepping in Strang splitting scheme|
+| `adap_dt_max_iters`    | Integer | Max iteration for adaptive time stepping in Strang splitting scheme |
 | `weno_order`	         | Integer | WENO order [1,3,5] |
 | `weno_eps`	         | Real    | WENO perturbation (avoid division by zero) |
 | `mapped_weno`	         | Logical | WENO-M (WENO with mapping of nonlinear weights) |
@@ -453,7 +455,7 @@ The effect and use of the source term are assessed by [Schmidmayer et al., 2019]
 - `time_stepper` specifies the order of the Runge-Kutta (RK) time integration scheme that is used for temporal integration in simulation, from the 1st to 5th order by corresponding integer.
 Note that `time_stepper = 3` specifies the total variation diminishing (TVD), third order RK scheme ([Gottlieb and Shu, 1998](references.md)).
 
-- `adap_dt` activates the Strang operator splitting scheme which splits flux and source terms in time marching, and an adaptive time stepping strategy is implemented for the source term. It requires ``bubbles_euler = 'T'``, ``polytropic = 'T'``, ``adv_n = 'T'`` and `time_stepper = 3`. Additionally, it can be used with ``bubbles_lagrange = 'T'`` and `time_stepper = 3`
+- `adap_dt` activates the Strang operator splitting scheme which splits flux and source terms in time marching, and an adaptive time stepping strategy is implemented for the source term. It requires ``bubbles_euler = 'T'``, ``polytropic = 'T'``, ``adv_n = 'T'`` and `time_stepper = 3`. Additionally, it can be used with ``bubbles_lagrange = 'T'`` and `time_stepper = 3`. `adap_dt_tol` and `adap_dt_max_iters` are 1e-4 and 100, respectively, by default.
 
 - `weno_order` specifies the order of WENO scheme that is used for spatial reconstruction of variables by an integer of 1, 3, 5, and 7, that correspond to the 1st, 3rd, 5th, and 7th order, respectively.
 

--- a/examples/0D_bubblecollapse_adap/case.py
+++ b/examples/0D_bubblecollapse_adap/case.py
@@ -118,6 +118,7 @@ print(
             "adv_n": "T",
             # adap_dt
             "adap_dt": "T",
+            "adap_dt_max_iters": 200,
             # Gas compression model
             "polytropic": "T",
             "thermal": 1,

--- a/src/common/m_constants.fpp
+++ b/src/common/m_constants.fpp
@@ -55,7 +55,7 @@ module m_constants
 
     ! Strang Splitting constants
     real(wp), parameter :: dflt_adap_dt_tol = 1.e-4_wp !< Default tolerance for adaptive step size
-    integer, parameter :: adap_dt_max_iters = 100 !< Maximum number of iterations
+
     ! Constants of the algorithm described by Heirer, E. Hairer S.P.Nørsett G. Wanner, Solving Ordinary Differential Equations I, Chapter II.4
     ! to choose the initial time step size for the adaptive time stepping routine
     real(wp), parameter :: threshold_first_guess = 1.e-5_wp

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -409,7 +409,8 @@ module m_global_parameters
     logical :: adv_n        !< Solve the number density equation and compute alpha from number density
     logical :: adap_dt      !< Adaptive step size control
     real(wp) :: adap_dt_tol !< Tolerance to control adaptive step size
-    $:GPU_DECLARE(create='[adv_n,adap_dt,adap_dt_tol]')
+    integer :: adap_dt_max_iters !< Maximum number of iterations
+    $:GPU_DECLARE(create='[adv_n,adap_dt,adap_dt_tol,adap_dt_max_iters]')
 
     integer :: bubble_model !< Gilmore or Keller--Miksis bubble model
     integer :: thermal      !< Thermal behavior. 1 = adiabatic, 2 = isotherm, 3 = transfer
@@ -676,6 +677,7 @@ contains
         adv_n = .false.
         adap_dt = .false.
         adap_dt_tol = dflt_real
+        adap_dt_max_iters = 100
 
         pi_fac = 1._wp
 
@@ -1254,7 +1256,7 @@ contains
         $:GPU_UPDATE(device='[momxb,momxe,advxb,advxe,contxb,contxe, &
             & bubxb,bubxe,intxb,intxe,sys_size,buff_size,E_idx, &
             & alf_idx,n_idx,adv_n,adap_dt,pi_fac,strxb,strxe, &
-            & chemxb,chemxe,c_idx]')
+            & chemxb,chemxe,c_idx,adap_dt_tol,adap_dt_max_iters]')
         $:GPU_UPDATE(device='[b_size,xibeg,xiend,tensor_size]')
 
         $:GPU_UPDATE(device='[species_idx]')

--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -99,7 +99,8 @@ contains
             & 'bc_y%beg', 'bc_y%end', 'bc_z%beg', 'bc_z%end',  'fd_order',     &
             & 'num_probes', 'num_integrals', 'bubble_model', 'thermal',        &
             & 'R0_type', 'num_source', 'relax_model', 'num_ibs', 'n_start',    &
-            & 'num_bc_patches', 'num_igr_iters', 'num_igr_warm_start_iters']
+            & 'num_bc_patches', 'num_igr_iters', 'num_igr_warm_start_iters',   &
+            & 'adap_dt_max_iters' ]
             call MPI_BCAST(${VAR}$, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
         #:endfor
 

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -173,7 +173,7 @@ contains
             relax, relax_model, &
             palpha_eps, ptgalpha_eps, &
             R0_type, file_per_process, sigma, &
-            pi_fac, adv_n, adap_dt, adap_dt_tol, &
+            pi_fac, adv_n, adap_dt, adap_dt_tol, adap_dt_max_iters, &
             bf_x, bf_y, bf_z, &
             k_x, k_y, k_z, w_x, w_y, w_z, p_x, p_y, p_z, &
             g_x, g_y, g_z, n_start, t_save, t_stop, &
@@ -1415,7 +1415,7 @@ contains
         $:GPU_UPDATE(device='[nb,R0ref,Ca,Web,Re_inv,weight,R0,V0, &
             & bubbles_euler,polytropic,polydisperse,qbmm,R0_type, &
             & ptil,bubble_model,thermal,poly_sigma,adv_n,adap_dt, &
-            & adap_dt_tol,n_idx,pi_fac,low_Mach]')
+            & adap_dt_tol,adap_dt_max_iters,n_idx,pi_fac,low_Mach]')
         $:GPU_UPDATE(device='[R_n,R_v,phi_vn,phi_nv,Pe_c,Tw,pv,M_n, &
             & M_v,k_n,k_v,pb0,mass_n0,mass_v0,Pe_T,Re_trans_T, &
             & Re_trans_c,Im_trans_T,Im_trans_c,omegaN,mul0,ss, &

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -285,6 +285,7 @@ SIMULATION.update({
     'pi_fac': ParamType.REAL,
     'adap_dt': ParamType.LOG,
     'adap_dt_tol': ParamType.REAL,
+    'adap_dt_max_iters': ParamType.INT,
     'ib': ParamType.LOG,
     'num_ibs': ParamType.INT,
     'n_start': ParamType.INT,


### PR DESCRIPTION
## Description

I noticed that the example `0D_bubblecollapse_adap` is broken. The reason was that when Lagrange bubble model is updated, the maximum iteration for adaptive time stepping was fixed to 100, while this case requires more than 100 as it involves violent collapse of bubbles. Therefore, I moved `adap_dt_max_iters` from `m_constant` to user input parameter. 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Scope

- [x] This PR comprises a set of related changes with a common goal

## How Has This Been Tested?

The figure shows the comparison between `adap_dt_max_iters = 100` and `adap_dt_max_iters = 200`.  For `adap_dt_max_iters = 100`, the rebound cannot be captured. 
<img width="1667" height="1250" alt="results" src="https://github.com/user-attachments/assets/aa3c25a5-a27a-42d4-b227-b88c53a4c9cf" />

**Test Configuration**:

* What computers and compilers did you use to test this: MacBook M4 Pro

## Checklist

- [x] I have added comments for the new code
- [x] I added Doxygen docstrings to the new code
- [x] I have made corresponding changes to the documentation (`docs/`)
