### PR TITLE
Improve coverage accuracy

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,4 @@
 coverage:
-  strict_yaml_branch: default
   status:
     project:
       default:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,5 @@
 coverage:
   strict_yaml_branch: default
-  max_report_age: off
   status:
     project:
       default:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Setup Ubuntu
         run: |
             sudo apt update -y
-            sudo apt install -y tar wget make cmake gcc g++ python3 python3-dev "openmpi-*" libopenmpi-dev libblas-dev liblapack-dev
+            sudo apt install -y tar wget make cmake gcc g++ python3 \
+                python3-dev "openmpi-*" libopenmpi-dev hdf5-tools \
+                libfftw3-dev libhdf5-dev libblas-dev liblapack-dev
 
       - name: Build
         run: /bin/bash mfc.sh build -j $(nproc) --gcov

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
         add_compile_options(
             $<$<COMPILE_LANGUAGE:Fortran>:-fprofile-arcs>
             $<$<COMPILE_LANGUAGE:Fortran>:-ftest-coverage>
-            $<$<COMPILE_LANGUAGE:Fortran>:-O0>
+            $<$<COMPILE_LANGUAGE:Fortran>:-O1>
 	    )
 
         add_link_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
         add_compile_options(
             $<$<COMPILE_LANGUAGE:Fortran>:-fprofile-arcs>
             $<$<COMPILE_LANGUAGE:Fortran>:-ftest-coverage>
+            $<$<COMPILE_LANGUAGE:Fortran>:-O0>
 	    )
 
         add_link_options(
@@ -360,6 +361,8 @@ macro(HANDLE_SOURCES target useCommon)
                                  -D chemistry=False
                                  --line-numbering
                                  --no-folding
+								 --line-length=999
+		 						 --line-numbering-mode=nocontlines
                                  "${fpp}" "${f90}"
             DEPENDS  "${fpp};${${target}_incs}"
             COMMENT  "Preprocessing (Fypp) ${fpp_filename}"


### PR DESCRIPTION
### **User description**
Trying to improve coverage accuracy via a couple of simple additions.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `-O0` flag to disable optimization for coverage

- Configure Fypp preprocessor with extended line length

- Enable no-continuation-lines mode for better coverage tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CMakeLists.txt"] --> B["GNU Fortran Coverage"]
  A --> C["Fypp Preprocessor"]
  B --> D["-O0 flag added"]
  C --> E["--line-length=999"]
  C --> F["--line-numbering-mode=nocontlines"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Enhanced coverage configuration and preprocessor settings</code></dd></summary>
<hr>

CMakeLists.txt

<ul><li>Add <code>-O0</code> compiler flag for GNU Fortran coverage builds<br> <li> Configure Fypp preprocessor with extended line length (999)<br> <li> Set no-continuation-lines mode for line numbering</ul>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/979/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

