### PR TITLE
MPI Transfer for IBM Markers on multiple GPUs

### DIFF
--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -345,12 +345,40 @@ contains
         #:endfor
         call nvtxEndRange ! Packbuf
 
-        call nvtxStartRange("IB-MARKER-SENDRECV")
-        call MPI_SENDRECV( &
-            ib_buff_send, buffer_count, MPI_INTEGER, dst_proc, send_tag, &
-            ib_buff_recv, buffer_count, MPI_INTEGER, src_proc, recv_tag, &
-            MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
-        call nvtxEndRange ! RHS-MPI-SENDRECV-(NO)-RDMA
+        #:for rdma_mpi in [False, True]
+            if (rdma_mpi .eqv. ${'.true.' if rdma_mpi else '.false.'}$) then
+                #:if rdma_mpi
+                    #:call GPU_HOST_DATA(use_device='[ib_buff_send, ib_buff_recv]')
+                        call nvtxStartRange("IB-MARKER-SENDRECV-RDMA")
+
+                        call MPI_SENDRECV( &
+                            ib_buff_send, buffer_count, MPI_INTEGER, dst_proc, send_tag, &
+                            ib_buff_recv, buffer_count, MPI_INTEGER, src_proc, recv_tag, &
+                            MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
+
+                        call nvtxEndRange ! RHS-MPI-SENDRECV-(NO)-RDMA
+
+                    #:endcall GPU_HOST_DATA
+                    $:GPU_WAIT()
+                #:else
+                    call nvtxStartRange("IB-MARKER-DEV2HOST")
+                    $:GPU_UPDATE(host='[ib_buff_send]')
+                    call nvtxEndRange
+                    call nvtxStartRange("IB-MARKER-SENDRECV-NO-RMDA")
+
+                    call MPI_SENDRECV( &
+                        ib_buff_send, buffer_count, MPI_INTEGER, dst_proc, send_tag, &
+                        ib_buff_recv, buffer_count, MPI_INTEGER, src_proc, recv_tag, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
+
+                    call nvtxEndRange ! RHS-MPI-SENDRECV-(NO)-RDMA
+
+                    call nvtxStartRange("IB-MARKER-HOST2DEV")
+                    $:GPU_UPDATE(device='[ib_buff_recv]')
+                    call nvtxEndRange
+                #:endif
+            end if
+        #:endfor
 
         ! Unpack Received Buffer
         call nvtxStartRange("IB-MARKER-COMM-UNPACKBUF")

--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -345,18 +345,18 @@ contains
         #:endfor
         call nvtxEndRange ! Packbuf
 
+
         #:for rdma_mpi in [False, True]
             if (rdma_mpi .eqv. ${'.true.' if rdma_mpi else '.false.'}$) then
                 #:if rdma_mpi
                     #:call GPU_HOST_DATA(use_device='[ib_buff_send, ib_buff_recv]')
-                        call nvtxStartRange("IB-MARKER-SENDRECV-RDMA")
-
-                        call MPI_SENDRECV( &
-                            ib_buff_send, buffer_count, MPI_INTEGER, dst_proc, send_tag, &
-                            ib_buff_recv, buffer_count, MPI_INTEGER, src_proc, recv_tag, &
-                            MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
-
-                        call nvtxEndRange ! RHS-MPI-SENDRECV-(NO)-RDMA
+                    
+                    call nvtxStartRange("IB-MARKER-SENDRECV-RDMA")
+                    call MPI_SENDRECV( &
+                        ib_buff_send, buffer_count, MPI_INTEGER, dst_proc, send_tag, &
+                        ib_buff_recv, buffer_count, MPI_INTEGER, src_proc, recv_tag, &
+                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
+                    call nvtxEndRange 
 
                     #:endcall GPU_HOST_DATA
                     $:GPU_WAIT()
@@ -364,14 +364,13 @@ contains
                     call nvtxStartRange("IB-MARKER-DEV2HOST")
                     $:GPU_UPDATE(host='[ib_buff_send]')
                     call nvtxEndRange
+
                     call nvtxStartRange("IB-MARKER-SENDRECV-NO-RMDA")
-
                     call MPI_SENDRECV( &
-                        ib_buff_send, buffer_count, MPI_INTEGER, dst_proc, send_tag, &
-                        ib_buff_recv, buffer_count, MPI_INTEGER, src_proc, recv_tag, &
-                        MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
-
-                    call nvtxEndRange ! RHS-MPI-SENDRECV-(NO)-RDMA
+                            ib_buff_send, buffer_count, MPI_INTEGER, dst_proc, send_tag, &
+                            ib_buff_recv, buffer_count, MPI_INTEGER, src_proc, recv_tag, &
+                            MPI_COMM_WORLD, MPI_STATUS_IGNORE, ierr)
+                    call nvtxEndRange 
 
                     call nvtxStartRange("IB-MARKER-HOST2DEV")
                     $:GPU_UPDATE(device='[ib_buff_recv]')


### PR DESCRIPTION
## Description

Fix a Bug with MPI transfer of IBM Markers on multiple GPUs

Fixes #(issue) [optional]

### Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [ x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

* What computers and compilers did you use to test this:

## Checklist

- [ ] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [x] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [x] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran a Rocprof Systems profile using `./mfc.sh run XXXX --gpu -t simulation --rsys --hip-trace`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
