### PR TITLE
MPI FFTW 

### DIFF
--- a/src/common/m_mpi_common.fpp
+++ b/src/common/m_mpi_common.fpp
@@ -1164,6 +1164,113 @@ contains
 
             if (p > 0) then
 
+#ifdef MFC_POST_PROCESS
+                if(fft_wrt .and. (.not. file_per_process)) then 
+
+                    ! Initial estimate of optimal processor topology
+                    num_procs_x = 1
+                    num_procs_y = 1
+                    num_procs_z = num_procs
+                    ierr = -1
+
+                    ! Benchmarking the quality of this initial guess
+                    tmp_num_procs_y = num_procs_y
+                    tmp_num_procs_z = num_procs_z
+                    fct_min = 10._wp*abs((n + 1)/tmp_num_procs_y &
+                                         - (p + 1)/tmp_num_procs_z)
+
+                    ! Optimization of the initial processor topology
+                    do i = 1, num_procs
+
+                        if (mod(num_procs, i) == 0 &
+                            .and. &
+                            (n + 1)/i >= num_stcls_min*recon_order) then
+
+                            tmp_num_procs_y = i
+                            tmp_num_procs_z = num_procs/i
+
+                            if (fct_min >= abs((n + 1)/tmp_num_procs_y &
+                                               - (p + 1)/tmp_num_procs_z) &
+                                .and. &
+                                (p + 1)/tmp_num_procs_z &
+                                >= &
+                                num_stcls_min*recon_order) then
+
+                                num_procs_y = i
+                                num_procs_z = num_procs/i
+                                fct_min = abs((n + 1)/tmp_num_procs_y &
+                                              - (p + 1)/tmp_num_procs_z)
+                                ierr = 0
+
+                            end if
+
+                        end if
+
+                    end do
+
+                else
+                    ! Initial estimate of optimal processor topology
+                    num_procs_x = 1
+                    num_procs_y = 1
+                    num_procs_z = num_procs
+                    ierr = -1
+
+                    ! Benchmarking the quality of this initial guess
+                    tmp_num_procs_x = num_procs_x
+                    tmp_num_procs_y = num_procs_y
+                    tmp_num_procs_z = num_procs_z
+                    fct_min = 10._wp*abs((m + 1)/tmp_num_procs_x &
+                                         - (n + 1)/tmp_num_procs_y) &
+                              + 10._wp*abs((n + 1)/tmp_num_procs_y &
+                                           - (p + 1)/tmp_num_procs_z)
+
+                    ! Optimization of the initial processor topology
+                    do i = 1, num_procs
+
+                        if (mod(num_procs, i) == 0 &
+                            .and. &
+                            (m + 1)/i >= num_stcls_min*recon_order) then
+
+                            do j = 1, num_procs/i
+
+                                if (mod(num_procs/i, j) == 0 &
+                                    .and. &
+                                    (n + 1)/j >= num_stcls_min*recon_order) then
+
+                                    tmp_num_procs_x = i
+                                    tmp_num_procs_y = j
+                                    tmp_num_procs_z = num_procs/(i*j)
+
+                                    if (fct_min >= abs((m + 1)/tmp_num_procs_x &
+                                                       - (n + 1)/tmp_num_procs_y) &
+                                        + abs((n + 1)/tmp_num_procs_y &
+                                              - (p + 1)/tmp_num_procs_z) &
+                                        .and. &
+                                        (p + 1)/tmp_num_procs_z &
+                                        >= &
+                                        num_stcls_min*recon_order) &
+                                        then
+
+                                        num_procs_x = i
+                                        num_procs_y = j
+                                        num_procs_z = num_procs/(i*j)
+                                        fct_min = abs((m + 1)/tmp_num_procs_x &
+                                                      - (n + 1)/tmp_num_procs_y) &
+                                                  + abs((n + 1)/tmp_num_procs_y &
+                                                        - (p + 1)/tmp_num_procs_z)
+                                        ierr = 0
+
+                                    end if
+
+                                end if
+
+                            end do
+
+                        end if
+
+                    end do
+                end if    
+#else
                 if (cyl_coord .and. p > 0) then
                     ! Implement pencil processor blocking if using cylindrical coordinates so
                     ! that all cells in azimuthal direction are stored on a single processor.
@@ -1275,7 +1382,7 @@ contains
                     end do
 
                 end if
-
+#endif
                 ! Verifying that a valid decomposition of the computational
                 ! domain has been established. If not, the simulation exits.
                 if (proc_rank == 0 .and. ierr == -1) then

--- a/src/post_process/m_checker.fpp
+++ b/src/post_process/m_checker.fpp
@@ -32,6 +32,7 @@ contains
         call s_check_inputs_flux_limiter
         call s_check_inputs_volume_fraction
         call s_check_inputs_vorticity
+        call s_check_inputs_fft
         call s_check_inputs_qm
         call s_check_inputs_liutex
         call s_check_inputs_schlieren
@@ -110,6 +111,13 @@ contains
         @:PROHIBIT(p == 0 .and. (omega_wrt(1) .or. omega_wrt(2)))
         @:PROHIBIT(any(omega_wrt) .and. fd_order == dflt_int, "fd_order must be set for omega_wrt")
     end subroutine s_check_inputs_vorticity
+
+     !> Checks constraints on fft_wrt
+    impure subroutine s_check_inputs_fft
+        @:PROHIBIT(fft_wrt .and. (.not. file_per_process), "Turn off file_per_process with fft_wrt")
+        @:PROHIBIT(fft_wrt .and. (n == 0 .or. p == 0), "FFT WRT only in 3D")
+        @:PROHIBIT(fft_wrt .and. (MOD(m+1,2) == 1 .or. MOD(n+1,2) == 1 .or. MOD(p+1,2) == 1), "FFT WRT requires local dimensions divisible by 2")
+    end subroutine s_check_inputs_fft
 
     !> Checks constraints on Q-criterion parameters
     impure subroutine s_check_inputs_qm

--- a/src/post_process/m_checker.fpp
+++ b/src/post_process/m_checker.fpp
@@ -114,7 +114,7 @@ contains
 
      !> Checks constraints on fft_wrt
     impure subroutine s_check_inputs_fft
-        @:PROHIBIT(fft_wrt .and. (.not. file_per_process), "Turn off file_per_process with fft_wrt")
+        @:PROHIBIT(fft_wrt .and. file_per_process, "Turn off file_per_process with fft_wrt")
         @:PROHIBIT(fft_wrt .and. (n == 0 .or. p == 0), "FFT WRT only in 3D")
         @:PROHIBIT(fft_wrt .and. (MOD(m+1,2) == 1 .or. MOD(n+1,2) == 1 .or. MOD(p+1,2) == 1), "FFT WRT requires local dimensions divisible by 2")
     end subroutine s_check_inputs_fft

--- a/src/post_process/m_global_parameters.fpp
+++ b/src/post_process/m_global_parameters.fpp
@@ -241,6 +241,7 @@ module m_global_parameters
     integer :: flux_lim
     logical, dimension(3) :: flux_wrt
     logical :: E_wrt
+    logical :: fft_wrt
     logical :: pres_wrt
     logical, dimension(num_fluids_max) :: alpha_wrt
     logical :: gamma_wrt
@@ -422,6 +423,7 @@ contains
         parallel_io = .false.
         file_per_process = .false.
         E_wrt = .false.
+        fft_wrt = .false.
         pres_wrt = .false.
         alpha_wrt = .false.
         gamma_wrt = .false.

--- a/src/post_process/m_mpi_proxy.fpp
+++ b/src/post_process/m_mpi_proxy.fpp
@@ -105,7 +105,7 @@ contains
             & 'adv_n', 'ib', 'cfl_adap_dt', 'cfl_const_dt', 'cfl_dt',          &
             & 'surface_tension', 'hyperelasticity', 'bubbles_lagrange',        &
             & 'output_partial_domain', 'relativity', 'cont_damage', 'bc_io',   &
-            & 'down_sample' ]
+            & 'down_sample','fft_wrt' ]
 
             call MPI_BCAST(${VAR}$, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
         #:endfor

--- a/src/post_process/m_start_up.fpp
+++ b/src/post_process/m_start_up.fpp
@@ -242,14 +242,11 @@ contains
         real(wp), dimension(-offset_x%beg:m + offset_x%end, &
                             -offset_y%beg:n + offset_y%end, &
                             -offset_z%beg:p + offset_z%end, 3) :: liutex_axis
-        integer :: i, j, k, l,  kx, ky, kz, kf, Nf, j_glb, k_glb, l_glb
+        integer :: i, j, k, l,  kx, ky, kz, kf, j_glb, k_glb, l_glb
         real(wp) :: En_tot
         character(20) :: filename
         logical :: file_exists
         integer :: x_beg, x_end, y_beg, y_end, z_beg, z_end
-
-
-        print *, proc_rank, proc_coords(1), proc_coords(2), proc_coords(3)
 
         if (output_partial_domain) then
             call s_define_output_region
@@ -904,6 +901,8 @@ contains
             Nyloc2 = (n_glb + 1) / num_procs_z
             Nzloc = p + 1 
 
+            Nf = max(Nx, Ny, Nz)
+
             @:ALLOCATE(data_in(Nx*Nyloc*Nzloc))
             @:ALLOCATE(data_out(Nx*Nyloc*Nzloc))
 
@@ -912,7 +911,6 @@ contains
             @:ALLOCATE(data_cmplx_z(Nxloc, Nyloc2, Nz))
 
             @:ALLOCATE(En_real(Nxloc, Nyloc2, Nz))
-            Nf = max(Nx, Ny, Nz)
             @:ALLOCATE(En(Nf)) 
 
             size_n(1) = Nx

--- a/src/post_process/m_start_up.fpp
+++ b/src/post_process/m_start_up.fpp
@@ -1,3 +1,5 @@
+#:include 'macros.fpp'
+
 !>
 !! @file m_start_up.f90
 !! @brief  Contains module m_start_up
@@ -6,9 +8,13 @@
 !!              consistency of the user provided inputs. This module also allocates, initializes and
 !!              deallocates the relevant variables and sets up the time stepping,
 !!              MPI decomposition and I/O procedures
+
+
 module m_start_up
 
     ! Dependencies
+
+    use, intrinsic :: iso_c_binding
 
     use m_derived_types         !< Definitions of the derived types
 
@@ -45,7 +51,26 @@ module m_start_up
 
     use m_chemistry
 
+#ifdef MFC_MPI
+    use mpi                    !< Message passing interface (MPI) module
+#endif
+
     implicit none
+
+    include 'fftw3.f03'
+
+    type(c_ptr) :: fwd_plan_x, fwd_plan_y, fwd_plan_z
+    complex(c_double_complex), allocatable :: data_in(:), data_out(:)
+    complex(c_double_complex), allocatable :: data_cmplx(:, :, :), data_cmplx_y(:,:,:), data_cmplx_z(:, :, :)
+    real(wp), allocatable, dimension(:, :, :) :: En_real
+    real(wp), allocatable, dimension(:) :: En 
+    integer :: num_procs_x, num_procs_y, num_procs_z
+    integer :: Nx, Ny, Nz, Nxloc, Nyloc, Nyloc2, Nzloc, Nf
+    integer :: ierr
+    integer :: MPI_COMM_CART, MPI_COMM_CART12, MPI_COMM_CART13 
+    integer, dimension(3) :: cart3d_coords
+    integer, dimension(2) :: cart2d12_coords, cart2d13_coords
+    integer :: proc_rank12, proc_rank13
 
 contains
 
@@ -76,7 +101,7 @@ contains
             hypoelasticity, G, mhd, &
             chem_wrt_Y, chem_wrt_T, avg_state, &
             alpha_rho_wrt, rho_wrt, mom_wrt, vel_wrt, &
-            E_wrt, pres_wrt, alpha_wrt, gamma_wrt, &
+            E_wrt, fft_wrt, pres_wrt, alpha_wrt, gamma_wrt, &
             heat_ratio_wrt, pi_inf_wrt, pres_inf_wrt, &
             cons_vars_wrt, prim_vars_wrt, c_wrt, &
             omega_wrt, qm_wrt, liutex_wrt, schlieren_wrt, schlieren_alpha, &
@@ -217,9 +242,14 @@ contains
         real(wp), dimension(-offset_x%beg:m + offset_x%end, &
                             -offset_y%beg:n + offset_y%end, &
                             -offset_z%beg:p + offset_z%end, 3) :: liutex_axis
-        integer :: i, j, k, l
-
+        integer :: i, j, k, l,  kx, ky, kz, kf, Nf, j_glb, k_glb, l_glb
+        real(wp) :: En_tot
+        character(20) :: filename
+        logical :: file_exists
         integer :: x_beg, x_end, y_beg, y_end, z_beg, z_end
+
+
+        print *, proc_rank, proc_coords(1), proc_coords(2), proc_coords(3)
 
         if (output_partial_domain) then
             call s_define_output_region
@@ -386,6 +416,104 @@ contains
             call s_write_variable_to_formatted_database_file(varname, t_step)
 
             varname(:) = ' '
+
+        end if
+
+        !Adding Energy cascade FFT
+        if(fft_wrt) then
+
+            do l = 0, p 
+                do k = 0, n 
+                    do j = 0, m 
+                        data_cmplx(j+1,k+1,l+1) = CMPLX(q_cons_vf(mom_idx%beg)%sf(j,k,l) / q_cons_vf(1)%sf(j,k,l), 0._wp)
+                    end do 
+                end do 
+            end do
+
+            call s_mpi_FFT_fwd()
+
+            En_real = 0.5_wp*abs(data_cmplx_z)**2._wp / ((m+1)*(n+1)*(p+1))
+
+            do l = 0, p 
+                do k = 0, n 
+                    do j = 0, m 
+                        data_cmplx(j+1,k+1,l+1) = CMPLX(q_cons_vf(mom_idx%beg+1)%sf(j,k,l) / q_cons_vf(1)%sf(j,k,l), 0._wp)
+                    end do 
+                end do 
+            end do
+
+            call s_mpi_FFT_fwd()
+
+            En_real = En_real + 0.5_wp*abs(data_cmplx_z)**2._wp / ((m+1)*(n+1)*(p+1))
+
+            do l = 0, p 
+                do k = 0, n 
+                    do j = 0, m 
+                        data_cmplx(j+1,k+1,l+1) = CMPLX(q_cons_vf(mom_idx%beg+2)%sf(j,k,l) / q_cons_vf(1)%sf(j,k,l), 0._wp)
+                    end do 
+                end do 
+            end do
+
+            call s_mpi_FFT_fwd()
+
+            En_real = En_real + 0.5_wp*abs(data_cmplx_z)**2._wp / ((m+1)*(n+1)*(p+1))
+
+            do kf = 1, Nf
+                En(kf) = 0._wp
+            end do
+
+            do l = 1, Nz
+                do k = 1, Nyloc2
+                    do j = 1, Nxloc
+
+                        j_glb = j + proc_coords(2)*Nxloc
+                        k_glb = k + proc_coords(3)*Nyloc2
+                        l_glb = l 
+
+                        if(j_glb >= (m_glb+1)/ 2) then 
+                            kx = (j_glb-1) - (m_glb+1)
+                        else 
+                            kx = j_glb -1
+                        end if
+
+                        if(k_glb >= (n_glb+1)/2) then 
+                            ky = (k_glb-1) - (n_glb+1)
+                        else 
+                            ky = k_glb - 1 
+                        end if
+
+                        if(l_glb >= (p_glb+1)/2) then 
+                            kz = (l_glb-1) - (p_glb+1)
+                        else 
+                            kz = l_glb - 1 
+                        end if
+
+                        kf = NINT(SQRT(kx**2._wp + ky**2._wp + kz**2._wp)) + 1
+
+                        En(kf) = En(kf) + En_real(j, k, l)
+
+                    end do 
+                end do 
+            end do
+
+            call MPI_ALLREDUCE(MPI_IN_PLACE, En, Nf, mpi_p, MPI_SUM, MPI_COMM_WORLD,ierr)
+
+            ! do kf = 1, m +1
+            !     if(proc_rank == 0) then 
+            !         !print *, "En_tot", En(kf) , proc_rank
+            !     end if
+            !     write(filename,'(a,i0,a)') 'En_tot',proc_rank,'.dat'
+            !     inquire (FILE=filename, EXIST=file_exists)
+            !     if (file_exists) then
+            !         open (1, file=filename, position='append', status='old')
+            !         write (1, *) En(kf), proc_rank, t_step
+            !         close (1)
+            !     else
+            !         open (1, file=filename, status='new')
+            !         write (1, *) En(kf), proc_rank, t_step
+            !         close (1)
+            !     end if
+            ! end do
 
         end if
 
@@ -735,6 +863,8 @@ contains
     impure subroutine s_initialize_modules
         ! Computation of parameters, allocation procedures, and/or any other tasks
         ! needed to properly setup the modules
+        integer :: size_n(1), inembed(1), onembed(1)
+
         call s_initialize_global_parameters_module()
         if (bubbles_euler .and. nb > 1) then
             call s_simpson(weight, R0)
@@ -758,7 +888,215 @@ contains
         else
             s_read_data_files => s_read_parallel_data_files
         end if
+
+        if(fft_wrt) then 
+
+            num_procs_x = (m_glb + 1) / (m + 1)
+            num_procs_y = (n_glb + 1) / (n + 1)
+            num_procs_z = (p_glb + 1) / (p + 1)
+
+            Nx = m_glb + 1
+            Ny = n_glb + 1
+            Nz = p_glb + 1
+
+            Nxloc = (m_glb + 1) / num_procs_y
+            Nyloc = n + 1
+            Nyloc2 = (n_glb + 1) / num_procs_z
+            Nzloc = p + 1 
+
+            @:ALLOCATE(data_in(Nx*Nyloc*Nzloc))
+            @:ALLOCATE(data_out(Nx*Nyloc*Nzloc))
+
+            @:ALLOCATE(data_cmplx(Nx, Nyloc, Nzloc))
+            @:ALLOCATE(data_cmplx_y(Nxloc, Ny, Nzloc))
+            @:ALLOCATE(data_cmplx_z(Nxloc, Nyloc2, Nz))
+
+            @:ALLOCATE(En_real(Nxloc, Nyloc2, Nz))
+            Nf = max(Nx, Ny, Nz)
+            @:ALLOCATE(En(Nf)) 
+
+            size_n(1) = Nx
+            inembed(1) = Nx 
+            onembed(1) = Nx 
+
+            fwd_plan_x =  fftw_plan_many_dft(1, size_n, Nyloc*Nzloc, & 
+                                           data_in, inembed, 1, Nx, & 
+                                           data_out, onembed, 1, Nx, & 
+                                           FFTW_FORWARD, FFTW_MEASURE)
+
+            size_n(1) = Ny 
+            inembed(1) = Ny 
+            onembed(1) = Ny 
+
+            fwd_plan_y = fftw_plan_many_dft(1, size_n, Nxloc*Nzloc, & 
+                                           data_out, inembed, 1, Ny, & 
+                                           data_in, onembed, 1, Ny, & 
+                                           FFTW_FORWARD, FFTW_MEASURE)
+
+            size_n(1) = Nz 
+            inembed(1) = Nz 
+            onembed(1) = Nz   
+
+            fwd_plan_z =  fftw_plan_many_dft(1, size_n, Nxloc*Nyloc2, & 
+                                           data_in, inembed, 1, Nz, & 
+                                           data_out, onembed, 1, Nz, & 
+                                           FFTW_FORWARD, FFTW_MEASURE)   
+
+
+            call MPI_CART_CREATE(MPI_COMM_WORLD, 3, (/num_procs_x, &
+                                                          num_procs_y, num_procs_z/), &
+                                     (/.true., .true., .true./), &
+                                     .false., MPI_COMM_CART, ierr)   
+            call MPI_CART_COORDS(MPI_COMM_CART, proc_rank, 3, &
+                                     cart3d_coords, ierr)  
+
+            call MPI_Cart_SUB(MPI_COMM_CART, (/.true., .true., .false./), MPI_COMM_CART12, ierr)
+            call MPI_COMM_RANK(MPI_COMM_CART12, proc_rank12, ierr)
+            call MPI_CART_COORDS(MPI_COMM_CART12, proc_rank12, 2, cart2d12_coords, ierr)
+
+            call MPI_Cart_SUB(MPI_COMM_CART, (/.true., .false., .true./), MPI_COMM_CART13, ierr)
+            call MPI_COMM_RANK(MPI_COMM_CART13, proc_rank13, ierr)
+            call MPI_CART_COORDS(MPI_COMM_CART13, proc_rank13, 2, cart2d13_coords, ierr)
+
+        end if
     end subroutine s_initialize_modules
+
+    subroutine s_mpi_FFT_fwd
+
+    integer :: j, k, l 
+
+    do l = 1, Nzloc 
+        do k = 1, Nyloc 
+            do j = 1, Nx
+                data_in(j + (k-1)*Nx + (l-1)*Nx*Nyloc) = data_cmplx(j, k, l)
+            end do 
+        end do 
+    end do
+
+    call fftw_execute_dft(fwd_plan_x, data_in, data_out)
+
+    do l = 1, Nzloc 
+        do k = 1, Nyloc 
+            do j = 1, Nx
+                data_cmplx(j, k, l) = data_out(j + (k-1)*Nx + (l-1)*Nx*Nyloc)
+            end do 
+        end do 
+    end do
+
+    call s_mpi_transpose_x2y !!Change Pencil from data_cmplx to data_cmpx_y 
+
+    do l = 1, Nzloc 
+        do k = 1, Nxloc 
+            do j = 1, Ny
+                data_out(j + (k-1)*Ny + (l-1)*Ny*Nxloc) = data_cmplx_y(k, j, l)
+            end do 
+        end do 
+    end do
+    
+    call fftw_execute_dft(fwd_plan_y, data_out, data_in)
+
+    do l = 1, Nzloc 
+        do k = 1, Nxloc 
+            do j = 1, Ny 
+                data_cmplx_y(k, j, l) = data_in(j + (k-1)*Ny + (l-1)*Ny*Nxloc)
+            end do 
+        end do 
+    end do
+
+    call s_mpi_transpose_y2z !!Change Pencil from data_cmplx_y to data_cmpx_z
+
+    do l = 1, Nyloc2 
+        do k = 1, Nxloc 
+            do j = 1, Nz
+                data_in(j + (k-1)*Nz + (l-1)*Nz*Nxloc) = data_cmplx_z(k, l, j)
+            end do 
+        end do 
+    end do
+
+    call fftw_execute_dft(fwd_plan_z, data_in, data_out)
+
+    do l = 1, Nyloc2 
+        do k = 1, Nxloc 
+            do j = 1, Nz
+                data_cmplx_z(k, l, j) = data_out(j + (k-1)*Nz + (l-1)*Nz*Nxloc)
+            end do 
+        end do 
+    end do
+
+    end subroutine s_mpi_FFT_fwd
+
+    subroutine s_mpi_transpose_x2y
+    complex(c_double_complex), allocatable :: sendbuf(:), recvbuf(:)
+    integer :: dest_rank, src_rank
+    integer :: i, j, k, l
+
+    allocate(sendbuf(Nx*Nyloc*Nzloc))
+    allocate(recvbuf(Nx*Nyloc*Nzloc))
+
+    do dest_rank = 0, num_procs_y - 1
+        do l = 1, Nzloc 
+            do k = 1, Nyloc 
+                do j = 1, Nxloc
+                    sendbuf(j + (k-1)*Nxloc + (l-1)*Nxloc*Nyloc + dest_rank*Nxloc*Nyloc*Nzloc) = data_cmplx(j + dest_rank*Nxloc, k, l)
+                end do 
+            end do 
+        end do
+    end do
+
+    call MPI_Alltoall(sendbuf, Nxloc*Nyloc*Nzloc, MPI_DOUBLE_COMPLEX, & 
+                          recvbuf, Nxloc*Nyloc*Nzloc, MPI_DOUBLE_COMPLEX, MPI_COMM_CART12, ierr)
+
+    do src_rank = 0, num_procs_y - 1
+        do l = 1, Nzloc 
+            do k = 1, Nyloc 
+                do j = 1, Nxloc
+                    data_cmplx_y(j, k + src_rank*Nyloc, l) = recvbuf(j + (k-1)*Nxloc + (l-1)*Nxloc*Nyloc + src_rank*Nxloc*Nyloc*Nzloc) 
+                end do 
+            end do 
+        end do
+    end do
+
+    deallocate(sendbuf)
+    deallocate(recvbuf)
+
+    end subroutine s_mpi_transpose_x2y
+
+    subroutine s_mpi_transpose_y2z
+    complex(c_double_complex), allocatable :: sendbuf(:), recvbuf(:)
+    integer :: dest_rank, src_rank
+    integer :: j, k, l
+
+    allocate(sendbuf(Ny*Nxloc*Nzloc))
+    allocate(recvbuf(Ny*Nxloc*Nzloc))
+
+    do dest_rank = 0, num_procs_z - 1
+        do l = 1, Nzloc 
+            do j = 1, Nxloc
+                do k = 1, Nyloc2 
+                    sendbuf(k + (j-1)*Nyloc2 + (l-1)*(Nyloc2*Nxloc) + dest_rank*Nyloc2*Nxloc*Nzloc) = data_cmplx_y(j, k + dest_rank*Nyloc2, l)
+                end do 
+            end do 
+        end do
+    end do
+
+    call MPI_Alltoall(sendbuf, Nyloc2*Nxloc*Nzloc, MPI_DOUBLE_COMPLEX, & 
+                          recvbuf, Nyloc2*Nxloc*Nzloc, MPI_DOUBLE_COMPLEX, MPI_COMM_CART13, ierr)
+
+    do src_rank = 0, num_procs_z - 1
+        do l = 1, Nzloc 
+            do j = 1, Nxloc
+                do k = 1, Nyloc2 
+                    data_cmplx_z(j, k, l + src_rank*Nzloc) = recvbuf(k + (j-1)*Nyloc2 + (l-1)*(Nyloc2*Nxloc) + src_rank*Nyloc2*Nxloc*Nzloc) 
+                end do 
+            end do 
+        end do
+    end do
+
+    deallocate(sendbuf)
+    deallocate(recvbuf)
+
+    end subroutine s_mpi_transpose_y2z
+
 
     impure subroutine s_initialize_mpi_domain
         ! Initialization of the MPI environment

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -431,6 +431,7 @@ POST_PROCESS.update({
     'flux_lim': ParamType.INT,
     'flux_wrt': ParamType.LOG,
     'E_wrt': ParamType.LOG,
+    'fft_wrt': ParamType.LOG,
     'pres_wrt': ParamType.LOG,
     'alpha_wrt': ParamType.LOG,
     'kappa_wrt': ParamType.LOG,


### PR DESCRIPTION
## Description

Fast Fourier transform for energy cascade implemented on multiple ranks. Improves upon Conrad's implementation by using Pencil decomposition (2D) instead of Slabs (1D) in post_process. This required the use of cartesian sub-communicators. 

This is in the draft stage, as I have yet to test for correctness, but code ran successfully on 1-8 ranks. Will subsequently test for correctness on TGV problem before merging.

Fixes #(issue) [optional]

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [ x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

* What computers and compilers did you use to test this:

## Checklist

- [ ] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [ ] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [ ] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [ ] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran a Rocprof Systems profile using `./mfc.sh run XXXX --gpu -t simulation --rsys --hip-trace`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
