### PR TITLE
Removement of Duplicate Weno Interpolation of Velocity Field

### DIFF
--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -762,34 +762,75 @@ contains
                 call nvtxStartRange("RHS-WENO")
 
                 if (.not. surface_tension) then
-                    ! Reconstruct densitiess
-                    iv%beg = 1; iv%end = sys_size
-                    call s_reconstruct_cell_boundary_values( &
-                        q_prim_qp%vf(1:sys_size), &
-                        qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
-                        qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
-                        id)
+                    if (all(Re_size == 0)) then
+                        ! Reconstruct densitiess
+                        iv%beg = 1; iv%end = sys_size
+                        call s_reconstruct_cell_boundary_values( &
+                            q_prim_qp%vf(1:sys_size), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
+                    else
+                        iv%beg = 1; iv%end = contxe
+                        call s_reconstruct_cell_boundary_values( &
+                            q_prim_qp%vf(iv%beg:iv%end), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
+
+                        iv%beg = E_idx; iv%end = sys_size
+                        call s_reconstruct_cell_boundary_values( &
+                            q_prim_qp%vf(iv%beg:iv%end), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
+                    end if
+
                 else
-                    iv%beg = 1; iv%end = E_idx - 1
-                    call s_reconstruct_cell_boundary_values( &
-                        q_prim_qp%vf(iv%beg:iv%end), &
-                        qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
-                        qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
-                        id)
+                    if (all(Re_size == 0)) then
+                        iv%beg = 1; iv%end = E_idx - 1
+                        call s_reconstruct_cell_boundary_values( &
+                            q_prim_qp%vf(iv%beg:iv%end), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
 
-                    iv%beg = E_idx; iv%end = E_idx
-                    call s_reconstruct_cell_boundary_values_first_order( &
-                        q_prim_qp%vf(E_idx), &
-                        qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
-                        qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
-                        id)
+                        iv%beg = E_idx; iv%end = E_idx
+                        call s_reconstruct_cell_boundary_values_first_order( &
+                            q_prim_qp%vf(E_idx), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
 
-                    iv%beg = E_idx + 1; iv%end = sys_size
-                    call s_reconstruct_cell_boundary_values( &
-                        q_prim_qp%vf(iv%beg:iv%end), &
-                        qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
-                        qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
-                        id)
+                        iv%beg = E_idx + 1; iv%end = sys_size
+                        call s_reconstruct_cell_boundary_values( &
+                            q_prim_qp%vf(iv%beg:iv%end), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
+                    else
+                        iv%beg = 1; iv%end = contxe
+                        call s_reconstruct_cell_boundary_values( &
+                            q_prim_qp%vf(iv%beg:iv%end), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
+
+                        iv%beg = E_idx; iv%end = E_idx
+                        call s_reconstruct_cell_boundary_values_first_order( &
+                            q_prim_qp%vf(E_idx), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
+
+                        iv%beg = E_idx + 1; iv%end = sys_size
+                        call s_reconstruct_cell_boundary_values( &
+                            q_prim_qp%vf(iv%beg:iv%end), &
+                            qL_rsx_vf, qL_rsy_vf, qL_rsz_vf, &
+                            qR_rsx_vf, qR_rsy_vf, qR_rsz_vf, &
+                            id)
+                    end if
+
                 end if
 
                 ! Reconstruct viscous derivatives for viscosity


### PR DESCRIPTION
### **User description**
## Description

Please include a summary of the changes and the related issue(s) if they exist.
Please also include relevant motivation and context.

Fixes #(issue) [optional]

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If viscosity is enabled then in the rhs module (m_rhs.fpp) the s_get_viscous subroutine is called (line 709). Inside s_get_viscous (in the m_viscous.fpp module) the s_reconstruct_cell_boundary_values_visc (line 557) is called, and this subroutine implements weno interpolation for the velocities. Afterwards in the m_rhs module the Weno reconstruction is being implemented for i=1,sys_size. This was removed now and the weno interpolation is implemented only one time for the velocity field. This bug somehow introduced in the past for example in MFC 4.0, it did not exist https://github.com/MFlowCode/MFC/blob/v4.0.0/src/simulation_code/m_rhs.f90 (line 1137)

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

* What computers and compilers did you use to test this:
My Laptop

## Checklist

- [ ] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [x] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran a Rocprof Systems profile using `./mfc.sh run XXXX --gpu -t simulation --rsys --hip-trace`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature


___

### **PR Type**
Bug fix


___

### **Description**
- Eliminate duplicate WENO interpolation for velocity fields when viscosity is enabled

- Add conditional logic to skip velocity reconstruction when already done in viscous module

- Restructure reconstruction calls based on Reynolds number configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Viscous Flow Check"] --> B["Reynolds Number Check"]
  B --> C["Skip Velocity WENO"]
  B --> D["Perform Full WENO"]
  C --> E["Reconstruct Non-Velocity Fields Only"]
  D --> F["Reconstruct All Fields"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>m_rhs.fpp</strong><dd><code>Conditional WENO reconstruction to eliminate velocity duplication</code></dd></summary>
<hr>

src/simulation/m_rhs.fpp

<ul><li>Add conditional checks for Reynolds number (<code>Re_size</code>) to prevent <br>duplicate WENO reconstruction<br> <li> Split reconstruction logic into velocity and non-velocity components<br> <li> Restructure both surface tension and non-surface tension code paths<br> <li> Maintain separate reconstruction calls for continuity, energy, and <br>other field variables</ul>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/1005/files#diff-fe8ed9906ee74f3d3f0dbc702d75863fc90286a345cc7067acc6e6cfe80b6d52">+68/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

