### PR TITLE
Refactor time_stepper

### DIFF
--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -1149,14 +1149,8 @@ contains
         mytime = mytime + dt
 
         ! Total-variation-diminishing (TVD) Runge-Kutta (RK) time-steppers
-        if (time_stepper == 1) then
-            call s_1st_order_tvd_rk(t_step, time_avg)
-        elseif (time_stepper == 2) then
-            call s_2nd_order_tvd_rk(t_step, time_avg)
-        elseif (time_stepper == 3 .and. (.not. adap_dt)) then
-            call s_3rd_order_tvd_rk(t_step, time_avg)
-        elseif (time_stepper == 3 .and. adap_dt) then
-            call s_strang_splitting(t_step, time_avg)
+        if (any(time_stepper == (/1, 2, 3/))) then
+            call s_tvd_rk(t_step, time_avg, time_stepper)
         end if
 
         if (relax) call s_infinite_relaxation_k(q_cons_ts(1)%vf)

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -442,36 +442,36 @@ contains
         end do
 
         if (any(time_stepper == (/1, 2, 3/))) then
-          ! Time stepper index
-          if (time_stepper == 1) then
-            stor = 1
-          else
-            stor = 2
-          end if
+            ! Time stepper index
+            if (time_stepper == 1) then
+                stor = 1
+            else
+                stor = 2
+            end if
 
-          @:ALLOCATE (rk_coef(time_stepper, 3))
-          if (time_stepper == 1) then
-            rk_coef(1, 1) = 1._wp
-            rk_coef(1, 2) = 0._wp
-            rk_coef(1, 3) = 1._wp
-          else if (time_stepper == 2) then
-            rk_coef(1, 1) = 1._wp
-            rk_coef(1, 2) = 0._wp
-            rk_coef(1, 3) = 1._wp
-            rk_coef(2, 1) = 0.5_wp
-            rk_coef(2, 2) = 0.5_wp
-            rk_coef(2, 3) = 0.5_wp
-          else if (time_stepper == 3) then
-            rk_coef(1, 1) = 1._wp
-            rk_coef(1, 2) = 0._wp
-            rk_coef(1, 3) = 1._wp
-            rk_coef(2, 1) = 1._wp/4._wp
-            rk_coef(2, 2) = 3._wp/4._wp
-            rk_coef(2, 3) = 1._wp/4._wp
-            rk_coef(3, 1) = 2._wp/3._wp
-            rk_coef(3, 2) = 1._wp/3._wp
-            rk_coef(3, 3) = 2._wp/3._wp
-          end if
+            @:ALLOCATE (rk_coef(time_stepper, 3))
+            if (time_stepper == 1) then
+                rk_coef(1, 1) = 1._wp
+                rk_coef(1, 2) = 0._wp
+                rk_coef(1, 3) = 1._wp
+            else if (time_stepper == 2) then
+                rk_coef(1, 1) = 1._wp
+                rk_coef(1, 2) = 0._wp
+                rk_coef(1, 3) = 1._wp
+                rk_coef(2, 1) = 0.5_wp
+                rk_coef(2, 2) = 0.5_wp
+                rk_coef(2, 3) = 0.5_wp
+            else if (time_stepper == 3) then
+                rk_coef(1, 1) = 1._wp
+                rk_coef(1, 2) = 0._wp
+                rk_coef(1, 3) = 1._wp
+                rk_coef(2, 1) = 1._wp/4._wp
+                rk_coef(2, 2) = 3._wp/4._wp
+                rk_coef(2, 3) = 1._wp/4._wp
+                rk_coef(3, 1) = 2._wp/3._wp
+                rk_coef(3, 2) = 1._wp/3._wp
+                rk_coef(3, 3) = 2._wp/3._wp
+            end if
         end if
 
     end subroutine s_initialize_time_steppers_module
@@ -491,7 +491,7 @@ contains
         call cpu_time(start)
         call nvtxStartRange("TIMESTEP")
 
-        ! Adaptive dt: initial stage 
+        ! Adaptive dt: initial stage
         if (adap_dt) call s_adaptive_dt_bubble(1)
 
         do s = 1, nstage
@@ -523,13 +523,13 @@ contains
                     do k = 0, n
                         do j = 0, m
                             if (s == 1 .and. time_stepper /= 1) then
-                              q_cons_ts(stor)%vf(i)%sf(j, k, l) = &
-                                  q_cons_ts(1)%vf(i)%sf(j, k, l)
+                                q_cons_ts(stor)%vf(i)%sf(j, k, l) = &
+                                    q_cons_ts(1)%vf(i)%sf(j, k, l)
                             end if
                             q_cons_ts(1)%vf(i)%sf(j, k, l) = &
                                 rk_coef(s, 1)*q_cons_ts(1)%vf(i)%sf(j, k, l) &
-                              + rk_coef(s, 2)*q_cons_ts(stor)%vf(i)%sf(j, k, l) &
-                              + rk_coef(s, 3)*dt*rhs_vf(i)%sf(j, k, l)
+                                + rk_coef(s, 2)*q_cons_ts(stor)%vf(i)%sf(j, k, l) &
+                                + rk_coef(s, 3)*dt*rhs_vf(i)%sf(j, k, l)
                         end do
                     end do
                 end do
@@ -544,17 +544,17 @@ contains
                             do j = 0, m
                                 do q = 1, nnode
                                     if (s == 1 .and. time_stepper /= 1) then
-                                      pb_ts(stor)%sf(j, k, l, q, i) = &
-                                        pb_ts(1)%sf(j, k, l, q, i)
-                                      mv_ts(stor)%sf(j, k, l, q, i) = &
-                                        mv_ts(1)%sf(j, k, l, q, i)
+                                        pb_ts(stor)%sf(j, k, l, q, i) = &
+                                            pb_ts(1)%sf(j, k, l, q, i)
+                                        mv_ts(stor)%sf(j, k, l, q, i) = &
+                                            mv_ts(1)%sf(j, k, l, q, i)
                                     end if
                                     pb_ts(1)%sf(j, k, l, q, i) = &
-                                          rk_coef(s, 1)*pb_ts(1)%sf(j, k, l, q, i) &
+                                        rk_coef(s, 1)*pb_ts(1)%sf(j, k, l, q, i) &
                                         + rk_coef(s, 2)*pb_ts(stor)%sf(j, k, l, q, i) &
                                         + rk_coef(s, 3)*dt*rhs_pb(j, k, l, q, i)
                                     mv_ts(1)%sf(j, k, l, q, i) = &
-                                          rk_coef(s, 1)*mv_ts(1)%sf(j, k, l, q, i) &
+                                        rk_coef(s, 1)*mv_ts(1)%sf(j, k, l, q, i) &
                                         + rk_coef(s, 2)*mv_ts(stor)%sf(j, k, l, q, i) &
                                         + rk_coef(s, 3)*dt*rhs_mv(j, k, l, q, i)
                                 end do
@@ -583,7 +583,7 @@ contains
             end if
         end do
 
-        ! Adaptive dt: final stage 
+        ! Adaptive dt: final stage
         if (adap_dt) call s_adaptive_dt_bubble(3)
 
         call nvtxEndRange


### PR DESCRIPTION
## Description

This PR refactors time_stepper routines by integrating s_1st_order_tvd_rk, s_2nd_order_tvd_rk, s_3rd_order_tvd_rk, s_strang_splitting into a single subroutine s_tvd_rk. 

### Type of change

- [ ] Something else

### Scope

- [x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

* What computers and compilers did you use to test this:

## Checklist

- [ ] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [x] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [x] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [x] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ ] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran a Rocprof Systems profile using `./mfc.sh run XXXX --gpu -t simulation --rsys --hip-trace`, and have attached the output file and plain text results to this PR.
- [ ] Ran my code using various numbers of different GPUs (1, 2, and 8, for example) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature
