### PR TITLE
Add Python 3.13 setup step to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       - name: Setup MacOS
         if:   matrix.os == 'macos'
         run:  |


### PR DESCRIPTION
### **User description**
Fixes Cantera forced by macos loading python 3.14, revert to 3.13


___

### **PR Type**
Other


___

### **Description**
- Add Python 3.13 setup step to GitHub Actions workflow

- Fix Cantera compatibility issue with macOS Python version


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Workflow"] --> B["Python 3.13 Setup Step"] --> C["MacOS Setup Step"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.yml</strong><dd><code>Add Python 3.13 setup step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test.yml

<ul><li>Added Python 3.13 setup step using actions/setup-python@v5<br> <li> Positioned before existing MacOS setup step</ul>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/1016/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

