### PR TITLE
Broken Link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Click <kbd> <> Code</kbd> (green button at top right) → <kbd>Codespaces</kbd> 
 > ****Note:**** Codespaces is a free service with a monthly quota of compute time and storage usage.
 > It is recommended for testing commands, troubleshooting, and running simple case files without installing dependencies or building MFC on your device.
 > Don't conduct any critical work here!
-> To learn more, please see [how Docker & Containers work](https://mflowcode.github.io/documentation/docker.html).
+> To learn more, please see [how Docker & Containers work](https://mflowcode.github.io/documentation/md_docker.html).
 
 You can navigate [to this webpage](https://mflowcode.github.io/documentation/md_getting-started.html) to get you get started using MFC on your local machine, cluster, or supercomputer!
 It's rather straightforward.


### PR DESCRIPTION
### **User description**
## Description
**Minor Fix:** corrected a link in the repo readme which directed initially to `docker.html` (non-existent) instead of `md_docker.html`.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed broken documentation link in README

- Changed `docker.html` to `md_docker.html`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md"] -- "update link" --> B["docker.html → md_docker.html"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix broken Docker documentation link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Corrected documentation link from non-existent <code>docker.html</code> to correct <br><code>md_docker.html</code><br> <li> Link now properly directs to Docker & Containers documentation page</ul>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/1021/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

