### PR TITLE
Looks like the LD library path is bad

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -96,4 +96,5 @@ h-all HPC_OMPI_DIR="/apps/mpi/cuda/12.8.1/nvhpc/25.3/openmpi/5.0.7"
 h-all HPC_OMPI_BIN="/apps/mpi/cuda/12.8.1/nvhpc/25.3/openmpi/5.0.7/bin"
 h-all OMPI_MCA_pml=ob1 OMPI_MCA_coll_hcoll_enable=0
 h-gpu PATH="/apps/mpi/cuda/12.8.1/nvhpc/25.3/openmpi/5.0.7/bin:${PATH}"
+h-all LD_LIBRARY_PATH=/apps/compilers/cuda/12.8.1/lib64:$LD_LIBRARY_PATH
 h-gpu MFC_CUDA_CC=100 NVHPC_CUDA_HOME="/apps/compilers/cuda/12.8.1"


### PR DESCRIPTION
### **User description**
## Description

Fixes an issue when calling MPI with multiple ranks on hipervator


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes LD_LIBRARY_PATH configuration for MPI multi-rank execution

- Adds CUDA library path to environment on HiperGator cluster

- Ensures proper library resolution for OpenMPI with NVHPC


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MPI Multi-rank Job"] -->|Missing CUDA libs| B["Library Resolution Fails"]
  C["Add LD_LIBRARY_PATH"] -->|CUDA 12.8.1 lib64| D["Proper Library Loading"]
  B -->|Fix Applied| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modules</strong><dd><code>Add CUDA library path to environment configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

toolchain/modules

<ul><li>Added <code>LD_LIBRARY_PATH</code> environment variable configuration for <br>HiperGator cluster<br> <li> Points to CUDA 12.8.1 lib64 directory with proper path prepending<br> <li> Applied globally to all HiperGator nodes (h-all) to ensure consistent <br>library resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/1031/files#diff-b555f8528e854fd29294a897c09ff6381e933fb57801d31378cbfa8b2fe59908">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

