### PR TITLE
This change will fix configuration issues on HiperGator

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -83,11 +83,11 @@ san-all cmake python
 san-gpu nvhpc cuda cray-mpich
 
 h     hipergator
-h-gpu nvhpc/25.9
-h-gpu CUDA_HOME="/apps/compilers/cuda/12.8.1"
-h-all HPC_OMPI_DIR="/apps/mpi/cuda/12.8.1/nvhpc/25.3/openmpi/5.0.7"
-h-all HPC_OMPI_BIN="/apps/mpi/cuda/12.8.1/nvhpc/25.3/openmpi/5.0.7/bin"
-h-all OMPI_MCA_pml=ob1 OMPI_MCA_coll_hcoll_enable=0
-h-gpu PATH="/apps/mpi/cuda/12.8.1/nvhpc/25.3/openmpi/5.0.7/bin:${PATH}"
-h-all LD_LIBRARY_PATH=/apps/compilers/cuda/12.8.1/lib64:$LD_LIBRARY_PATH
-h-gpu MFC_CUDA_CC=100 NVHPC_CUDA_HOME="/apps/compilers/cuda/12.8.1"
+h-all python/3.12
+h-cpu gcc/14.2 openmpi/5.0.7
+h-gpu UCX_NET_DEVICES="mlx5_4:1,mlx5_7:1,mlx5_8:1,mlx5_9:1,mlx5_10:1,mlx5_13:1,mlx5_14:1,mlx5_15:1"
+h-gpu cuda/12.9.1 nvhpc/25.9 openmpi/5.0.7
+h-gpu CC=/apps/compilers/nvhpc/25.9/Linux_x86_64/25.9/comm_libs/mpi/bin/mpicc 
+h-gpu CXX=/apps/compilers/nvhpc/25.9/Linux_x86_64/25.9/comm_libs/mpi/bin/mpicxx
+h-gpu FC=/apps/compilers/nvhpc/25.9/Linux_x86_64/25.9/comm_libs/mpi/bin/mpifort
+h-gpu NVCOMPILER_COMM_LIBS_HOME=/apps/compilers/nvhpc/25.9/Linux_x86_64/25.9/comm_libs/12.9

--- a/toolchain/templates/hipergator.mako
+++ b/toolchain/templates/hipergator.mako
@@ -8,10 +8,11 @@
 #SBATCH --job-name="${name}"
 #SBATCH --output="${name}.out"
 #SBATCH --time=${walltime}
-#SBATCH --cpus-per-task=7
 % if gpu_enabled:
 #SBATCH --gpus-per-task=1
+#SBATCH --cpus-per-task=3
 #SBATCH --gpu-bind=closest
+#SBATCH --mem-per-cpu=50GB
 % endif
 % if account:
 #SBATCH --account=${account}
@@ -48,7 +49,7 @@ echo
         (set -x; ${profiler} "${target.get_install_binpath(case)}")
     % else:
         (set -x; ${profiler}    \
-            mpirun -np ${nodes*tasks_per_node}            \
+            /apps/compilers/nvhpc/25.9/Linux_x86_64/25.9/comm_libs/mpi/bin/mpirun -np ${nodes*tasks_per_node}            \
                    --bind-to none                         \
                    "${target.get_install_binpath(case)}")
     % endif


### PR DESCRIPTION
## **User description**
### **User description**
## Description

These are changes to the toolchain files (module and hipergator.mako) that establish the proper environment for run MFC on HiperGator CPUs and GPUs

### Type of change

- [X] Something else

### Scope

- [ x] This PR comprises a set of related changes with a common goal

If you cannot check the above box, please split your PR into multiple PRs that each have a common goal.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

Ran the entire test suite (-a).  Only had issue with test 6F35CD77: 3D -> Bubbles -> bubble_model=2 
Variable n°25 (1-indexed) in D/cons.13.00.000050.dat is not within tolerance:
  - Candidate:   0.00318538481841
  - Golden:      0.00318538458501
  - Error:       abs: 2.33E-10, rel: 7.33E-08
  - Tolerance:   abs: 1.00E-10, rel: 1.00E-10
Diagnostics - Maximum absolute error among FAILING variables:
 - File: D/cons.13.00.000050.dat
 - Variable n°25
 - Candidate: 0.00318538481841
 - Golden: 0.00318538458501
 - Absolute Error: 2.33E-10
 - Relative Error: 7.33E-08
Diagnostics - Maximum relative error among FAILING variables:
 - File: D/cons.13.00.000050.dat
 - Variable n°25
 - Candidate: 0.00318538481841
 - Golden: 0.00318538458501
 - Relative Error: 7.33E-08

**Test Configuration**:

Ran on two HiperGator partitions:  hpg-default and hpg-b200.

## Checklist

- [ ] I have added comments for the new code
- [ ] I added Doxygen docstrings to the new code
- [ ] I have made corresponding changes to the documentation (`docs/`)
- [ ] I have added regression tests to the test suite so that people can verify in the future that the feature is behaving as expected
- [ ] I have added example cases in `examples/` that demonstrate my new feature performing as expected.
They run to completion and demonstrate "interesting physics"
- [ ] I ran `./mfc.sh format` before committing my code
- [ ] New and existing tests pass locally with my changes, including with GPU capability enabled (both NVIDIA hardware with NVHPC compilers and AMD hardware with CRAY compilers) and disabled
- [ ] This PR does not introduce any repeated code (it follows the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
- [ ] I cannot think of a way to condense this code and reduce any introduced additional line count

### If your code changes any code source files (anything in `src/simulation`)

To make sure the code is performing as expected on GPU devices, I have:
- [ x] Checked that the code compiles using NVHPC compilers
- [ ] Checked that the code compiles using CRAY compilers
- [ ] Ran the code on either V100, A100, or H100 GPUs and ensured the new feature performed as expected (the GPU results match the CPU results)
- [ ] Ran the code on MI200+ GPUs and ensure the new features performed as expected (the GPU results match the CPU results)
- [ ] Enclosed the new feature via `nvtx` ranges so that they can be identified in profiles
- [ ] Ran a Nsight Systems profile using `./mfc.sh run XXXX --gpu -t simulation --nsys`, and have attached the output file (`.nsys-rep`) and plain text results to this PR
- [ ] Ran a Rocprof Systems profile using `./mfc.sh run XXXX --gpu -t simulation --rsys --hip-trace`, and have attached the output file and plain text results to this PR.
- [ x] Ran my code using various numbers of different GPUs (1 & 3) in parallel and made sure that the results scale similarly to what happens if you run without the new code/feature


___

### **PR Type**
Enhancement


___

### **Description**
- Update HiperGator SLURM configuration for GPU and CPU tasks

- Migrate to NVHPC 25.9 with CUDA 12.9.1 and OpenMPI 5.0.7

- Configure proper MPI paths and UCX network devices for GPU

- Adjust CPU allocation and memory settings for optimal performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SLURM Config"] -->|GPU tasks| B["3 CPUs per task"]
  A -->|Memory| C["50GB per CPU"]
  D["Module Setup"] -->|GPU| E["NVHPC 25.9 + CUDA 12.9.1"]
  D -->|CPU| F["GCC 14.2 + OpenMPI 5.0.7"]
  E -->|MPI Compilers| G["NVHPC MPI Wrappers"]
  E -->|Network| H["UCX Device Configuration"]
  I["MPI Runtime"] -->|Path| J["NVHPC 25.9 mpirun"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hipergator.mako</strong><dd><code>Update SLURM directives and MPI runtime paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

toolchain/templates/hipergator.mako

<ul><li>Moved <code>--cpus-per-task=3</code> from default to GPU-only configuration<br> <li> Added <code>--mem-per-cpu=50GB</code> memory allocation for GPU tasks<br> <li> Updated mpirun path to use NVHPC 25.9 MPI binary explicitly<br> <li> Removed hardcoded 7 CPUs per task for non-GPU jobs</ul>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/1112/files#diff-3557a59d184c38b046822ba5f5313f80a6a067af5070ce4e3332695d53413d8c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>modules</strong><dd><code>Upgrade to NVHPC 25.9 and CUDA 12.9.1 stack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

toolchain/modules

<ul><li>Replaced NVHPC 25.3 with 25.9 and CUDA 12.8.1 with 12.9.1<br> <li> Added Python 3.12 module for all HiperGator configurations<br> <li> Added GCC 14.2 and OpenMPI 5.0.7 for CPU-only builds<br> <li> Configured UCX network devices for GPU communication optimization<br> <li> Set MPI compiler wrappers to use NVHPC 25.9 MPI paths explicitly<br> <li> Updated NVCOMPILER_COMM_LIBS_HOME to point to NVHPC 25.9</ul>


</details>


  </td>
  <td><a href="https://github.com/MFlowCode/MFC/pull/1112/files#diff-b555f8528e854fd29294a897c09ff6381e933fb57801d31378cbfa8b2fe59908">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
Configure HiperGator job scripts and module defaults for NVHPC/CUDA GPU runs

### What Changed
- GPU job scripts now request 3 CPUs per task (was 7) and allocate 50GB per CPU, reducing CPU allocation while ensuring more memory per CPU for GPU tasks
- MPI launcher switched to the NVHPC/comm_libs mpirun for MPI runs, ensuring the MPI used matches the NVHPC toolchain
- Default module environment updated: Python 3.12, GCC 14.2 + OpenMPI 5.0.7 for CPU jobs; CUDA 12.9.1, NVHPC 25.9, OpenMPI 5.0.7 and NVHPC compiler wrappers for GPU jobs; UCX network devices explicitly set

### Impact
`✅ Lower CPU-per-GPU allocation for GPU jobs`
`✅ More memory reserved per CPU for GPU runs`
`✅ Consistent NVHPC/CUDA runtime and MPI launcher for GPU workflows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HiperGator toolchain with newer compiler versions (GCC 14.2, NVHPC 25.9, CUDA 12.9.1, OpenMPI 5.0.7)
  * Optimized GPU job resource allocation (cpus-per-task and memory specifications)
  * Unified MPI configuration for GPU-enabled jobs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->