### PR TITLE
Update MFC 5.0 citation to published CPC article

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,9 +9,11 @@ url: "https://github.com/MFlowCode/MFC"
 preferred-citation:
   type: article
   title: "MFC 5.0: An exascale many-physics flow solver"
-  journal: "arXiv preprint arXiv.2503.07953"
-  doi: "10.48550/arXiv.2503.07953"
-  year: 2025
+  journal: "Computer Physics Communications"
+  doi: "10.1016/j.cpc.2026.110055"
+  year: 2026
+  volume: 322
+  start: 110055
   authors:
     - given-names: Benjamin
       family-names: Wilfong
@@ -21,6 +23,8 @@ preferred-citation:
       family-names: Radhakrishnan
     - given-names: Ansh
       family-names: Gupta
+    - given-names: Daniel J.
+      family-names: Vickers
     - given-names: Diego
       family-names: Vaca-Revelo
     - given-names: Dimitrios

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ MFC conducted the largest known CFD simulation at <a href="https://arxiv.org/abs
 MFC is a 2025 Gordon Bell Prize Finalist.
 
 <p align="center">
-<a href="https://doi.org/10.48550/arXiv.2503.07953" target="_blank">
-    <img src="https://img.shields.io/badge/DOI-10.48550/arXiv.2503.07953-thistle.svg"/>
+<a href="https://doi.org/10.1016/j.cpc.2026.110055" target="_blank">
+    <img src="https://img.shields.io/badge/DOI-10.1016/j.cpc.2026.110055-thistle.svg"/>
 </a>
 <a href="https://doi.org/10.5281/zenodo.17049757" target="_blank">
     <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17049757.svg"/>
@@ -94,12 +94,14 @@ Is MFC useful for you? Consider citing it or giving a star!
 </p>
 
 ```bibtex
-@article{Wilfong_2025,
-  author = {Wilfong, Benjamin and {Le Berre}, Henry and Radhakrishnan, Anand and Gupta, Ansh and Vaca-Revelo, Diego and Adam, Dimitrios and Yu, Haocheng and Lee, Hyeoksu and Chreim, Jose Rodolfo and {Carcana Barbosa}, Mirelys and Zhang, Yanjun and Cisneros-Garibay, Esteban and Gnanaskandan, Aswin and {Rodriguez Jr.}, Mauro and Budiardja, Reuben D. and Abbott, Stephen and Colonius, Tim and Bryngelson, Spencer H.},
-  title = {{MFC 5.0: A}n exascale many-physics flow solver},
-  journal = {arXiv preprint arXiv:2503.07953},
-  year = {2025},
-  doi = {10.48550/arXiv.2503.07953}
+@article{wilfong26,
+  Author = {Benjamin Wilfong and Henry {Le Berre} and Anand Radhakrishnan and Ansh Gupta and Daniel J. Vickers and Diego Vaca-Revelo and Dimitrios Adam and Haocheng Yu and Hyeoksu Lee and Jose Rodolfo Chreim and Mirelys {Carcana Barbosa} and Yanjun Zhang and Esteban Cisneros-Garibay and Aswin Gnanaskandan and Mauro {Rodriguez Jr.} and Reuben D. Budiardja and Stephen Abbott and Tim Colonius and Spencer H. Bryngelson},
+  Title = {{MFC 5.0: A}n exascale many-physics flow solver},
+  journal = {Computer Physics Communications},
+  year = {2026},
+  volume = {322},
+  pages = {110055},
+  doi = {10.1016/j.cpc.2026.110055},
 }
 ```
 
@@ -319,12 +321,14 @@ If referencing MFC's (GPU) performance, consider citing ref. 1 and 2, which desc
 The original open-source release of MFC is ref. 3, which should be cited for provenance as appropriate.
 
 ```bibtex
-@article{Wilfong_2025,
-  author = {Wilfong, Benjamin and {Le Berre}, Henry and Radhakrishnan, Anand and Gupta, Ansh and Vaca-Revelo, Diego and Adam, Dimitrios and Yu, Haocheng and Lee, Hyeoksu and Chreim, Jose Rodolfo and {Carcana Barbosa}, Mirelys and Zhang, Yanjun and Cisneros-Garibay, Esteban and Gnanaskandan, Aswin and {Rodriguez Jr.}, Mauro and Budiardja, Reuben D. and Abbott, Stephen and Colonius, Tim and Bryngelson, Spencer H.},
-  title = {{MFC 5.0: A}n exascale many-physics flow solver},
-  journal = {arXiv preprint arXiv:2503.07953},
-  year = {2025},
-  doi = {10.48550/arXiv.2503.07953}
+@article{wilfong26,
+  Author = {Benjamin Wilfong and Henry {Le Berre} and Anand Radhakrishnan and Ansh Gupta and Daniel J. Vickers and Diego Vaca-Revelo and Dimitrios Adam and Haocheng Yu and Hyeoksu Lee and Jose Rodolfo Chreim and Mirelys {Carcana Barbosa} and Yanjun Zhang and Esteban Cisneros-Garibay and Aswin Gnanaskandan and Mauro {Rodriguez Jr.} and Reuben D. Budiardja and Stephen Abbott and Tim Colonius and Spencer H. Bryngelson},
+  Title = {{MFC 5.0: A}n exascale many-physics flow solver},
+  journal = {Computer Physics Communications},
+  year = {2026},
+  volume = {322},
+  pages = {110055},
+  doi = {10.1016/j.cpc.2026.110055},
 }
 
 @article{Radhakrishnan_2024,

--- a/docs/documentation/papers.md
+++ b/docs/documentation/papers.md
@@ -2,15 +2,17 @@
 
 # Papers
 
-MFC 5.0: An exascale many-physics flow solver. [<b>Wilfong, B., Le Berre, H., Radhakrishnan, A.,</b> Gupta, A., Vaca-Revelo, D., Adam , D., Yu, H., Lee, H., Chreim, J. R., Carcana Barbosa, M., Zhang, Y., Cisneros-Garibay, E., Gnanaskandan, A., Rodriguez Jr., M., Budiardja, R. D., Abbott, S., Colonius, T., & Bryngelson, S. H. (2025) MFC 5.0: An exascale many-physics flow solver. arXiv:2503.07953. <b>Equal contribution.</b>](https://doi.org/10.48550/arXiv.2503.07953)
+MFC 5.0: An exascale many-physics flow solver. [<b>Wilfong, B., Le Berre, H., Radhakrishnan, A.,</b> Gupta, A., Vickers, D. J., Vaca-Revelo, D., Adam, D., Yu, H., Lee, H., Chreim, J. R., Carcana Barbosa, M., Zhang, Y., Cisneros-Garibay, E., Gnanaskandan, A., Rodriguez Jr., M., Budiardja, R. D., Abbott, S., Colonius, T., & Bryngelson, S. H. (2026) MFC 5.0: An exascale many-physics flow solver. Computer Physics Communications **322**, 110055. <b>Equal contribution.</b>](https://doi.org/10.1016/j.cpc.2026.110055)
 
 ```bibtex
-@article{Wilfong_2025,
-  author = {Wilfong, Benjamin and {Le Berre}, Henry and Radhakrishnan, Anand and Gupta, Ansh and Vaca-Revelo, Diego and Adam, Dimitrios and Yu, Haocheng and Lee, Hyeoksu and Chreim, Jose Rodolfo and {Carcana Barbosa}, Mirelys and Zhang, Yanjun and Cisneros-Garibay, Esteban and Gnanaskandan, Aswin and {Rodriguez Jr.}, Mauro and Budiardja, Reuben D. and Abbott, Stephen and Colonius, Tim and Bryngelson, Spencer H.},
-  title = {{MFC 5.0: A}n exascale many-physics flow solver},
-  journal = {arXiv preprint arXiv:2503.07953},
-  year = {2025},
-  doi = {10.48550/arXiv.2503.07953}
+@article{wilfong26,
+  Author = {Benjamin Wilfong and Henry {Le Berre} and Anand Radhakrishnan and Ansh Gupta and Daniel J. Vickers and Diego Vaca-Revelo and Dimitrios Adam and Haocheng Yu and Hyeoksu Lee and Jose Rodolfo Chreim and Mirelys {Carcana Barbosa} and Yanjun Zhang and Esteban Cisneros-Garibay and Aswin Gnanaskandan and Mauro {Rodriguez Jr.} and Reuben D. Budiardja and Stephen Abbott and Tim Colonius and Spencer H. Bryngelson},
+  Title = {{MFC 5.0: A}n exascale many-physics flow solver},
+  journal = {Computer Physics Communications},
+  year = {2026},
+  volume = {322},
+  pages = {110055},
+  doi = {10.1016/j.cpc.2026.110055},
 }
 ```
 


### PR DESCRIPTION
Citations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only citation/metadata updates with no impact on runtime behavior or APIs.
> 
> **Overview**
> Updates the project’s primary citation from the arXiv preprint to the published *Computer Physics Communications* article.
> 
> This refreshes the DOI badge/link and BibTeX entries in `README.md` and `docs/documentation/papers.md`, and updates `CITATION.cff` metadata (journal/DOI/year/volume/pages and adds an author) to match the published record.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6467114a8b4d3524263a41817bcf72a2da8b1d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated citation information across all project documentation to reflect official publication of the paper in Computer Physics Communications (Volume 322, 2026), replacing previous arXiv preprint references.
- Revised publication metadata including journal, volume, pages, and DOI.
- Extended author list to include new contributor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->