### PR TITLE
Fix Homebrew install crash from namelist parser

### DIFF
--- a/toolchain/mfc/params/namelist_parser.py
+++ b/toolchain/mfc/params/namelist_parser.py
@@ -4,11 +4,103 @@ Parse Fortran namelist definitions to extract valid parameters for each target.
 This module reads the Fortran source files and extracts the parameter names
 from each target's namelist definition. This ensures the Python toolchain
 stays in sync with what the Fortran code actually accepts.
+
+When Fortran sources are unavailable (e.g. Homebrew installs), a built-in
+fallback parameter set is used instead.
 """
 
 import re
 from pathlib import Path
 from typing import Dict, Set
+
+
+# Fallback parameters for when Fortran source files are not available.
+# Generated from the namelist definitions in src/*/m_start_up.fpp.
+# To regenerate: python3 toolchain/mfc/params/namelist_parser.py
+_FALLBACK_PARAMS = {
+    'pre_process': {
+        'Bx0', 'Ca', 'R0ref', 'Re_inv', 'Web',
+        'a_x', 'a_y', 'a_z', 'adv_n', 'bc_x',
+        'bc_y', 'bc_z', 'bub_pp', 'bubbles_euler', 'bubbles_lagrange',
+        'case_dir', 'cfl_adap_dt', 'cfl_const_dt', 'cont_damage', 'cyl_coord',
+        'dist_type', 'down_sample', 'elliptic_smoothing', 'elliptic_smoothing_iters', 'fft_wrt',
+        'file_per_process', 'fluid_pp', 'fluid_rho', 'hyper_cleaning', 'hyperelasticity',
+        'hypoelasticity', 'ib', 'igr', 'igr_order', 'loops_x',
+        'loops_y', 'loops_z', 'm', 'mhd', 'mixlayer_perturb',
+        'mixlayer_perturb_k0', 'mixlayer_perturb_nk', 'mixlayer_vel_coef', 'mixlayer_vel_profile', 'model_eqns',
+        'mpp_lim', 'muscl_order', 'n', 'n_start', 'n_start_old',
+        'nb', 'num_bc_patches', 'num_fluids', 'num_ibs', 'num_patches',
+        'old_grid', 'old_ic', 'p', 'palpha_eps', 'parallel_io',
+        'patch_bc', 'patch_ib', 'patch_icpp', 'perturb_flow', 'perturb_flow_fluid',
+        'perturb_flow_mag', 'perturb_sph', 'perturb_sph_fluid', 'pi_fac', 'poly_sigma',
+        'polydisperse', 'polytropic', 'pre_stress', 'precision', 'pref',
+        'ptgalpha_eps', 'qbmm', 'recon_type', 'relativity', 'relax',
+        'relax_model', 'rhoRV', 'rhoref', 'sigR', 'sigV',
+        'sigma', 'simplex_params', 'simplex_perturb', 'stretch_x', 'stretch_y',
+        'stretch_z', 'surface_tension', 't_step_old', 't_step_start', 'thermal',
+        'viscous', 'weno_order', 'x_a', 'x_b', 'x_domain',
+        'y_a', 'y_b', 'y_domain', 'z_a', 'z_b',
+        'z_domain',
+    },
+    'simulation': {
+        'Bx0', 'Ca', 'R0ref', 'Re_inv', 'Web',
+        'acoustic', 'acoustic_source', 'adap_dt', 'adap_dt_max_iters', 'adap_dt_tol',
+        'adv_n', 'alf_factor', 'alpha_bar', 'alt_soundspeed', 'avg_state',
+        'bc_x', 'bc_y', 'bc_z', 'bf_x', 'bf_y',
+        'bf_z', 'bub_pp', 'bubble_model', 'bubbles_euler', 'bubbles_lagrange',
+        'case_dir', 'cfl_adap_dt', 'cfl_const_dt', 'cfl_target', 'chem_params',
+        'cont_damage', 'cont_damage_s', 'cyl_coord', 'down_sample', 'dt',
+        'fd_order', 'fft_wrt', 'file_per_process', 'fluid_pp', 'g_x',
+        'g_y', 'g_z', 'hyper_cleaning', 'hyper_cleaning_speed', 'hyper_cleaning_tau',
+        'hyperelasticity', 'hypoelasticity', 'ib', 'ic_beta', 'ic_eps',
+        'igr', 'igr_iter_solver', 'igr_order', 'igr_pres_lim', 'int_comp',
+        'integral', 'integral_wrt', 'k_x', 'k_y', 'k_z',
+        'lag_params', 'low_Mach', 'm', 'mapped_weno', 'mhd',
+        'mixture_err', 'model_eqns', 'mp_weno', 'mpp_lim', 'muscl_lim',
+        'muscl_order', 'n', 'n_start', 'nb', 'null_weights',
+        'num_bc_patches', 'num_fluids', 'num_ibs', 'num_igr_iters', 'num_igr_warm_start_iters',
+        'num_integrals', 'num_probes', 'num_source', 'nv_uvm_igr_temps_on_gpu', 'nv_uvm_out_of_core',
+        'nv_uvm_pref_gpu', 'p', 'p_x', 'p_y', 'p_z',
+        'palpha_eps', 'parallel_io', 'patch_ib', 'pi_fac', 'poly_sigma',
+        'polydisperse', 'polytropic', 'precision', 'pref', 'prim_vars_wrt',
+        'probe', 'probe_wrt', 'ptgalpha_eps', 'qbmm', 'rdma_mpi',
+        'recon_type', 'relativity', 'relax', 'relax_model', 'rhoref',
+        'riemann_solver', 'run_time_info', 'sigma', 'surface_tension', 't_save',
+        't_step_old', 't_step_print', 't_step_save', 't_step_start', 't_step_stop',
+        't_stop', 'tau_star', 'teno', 'teno_CT', 'thermal',
+        'time_stepper', 'viscous', 'w_x', 'w_y', 'w_z',
+        'wave_speeds', 'weno_Re_flux', 'weno_avg', 'weno_eps', 'weno_order',
+        'wenoz', 'wenoz_q', 'x_a', 'x_b', 'x_domain',
+        'y_a', 'y_b', 'y_domain', 'z_a', 'z_b',
+        'z_domain',
+    },
+    'post_process': {
+        'Bx0', 'Ca', 'E_wrt', 'G', 'R0ref',
+        'Re_inv', 'Web', 'adv_n', 'alpha_rho_e_wrt', 'alpha_rho_wrt',
+        'alpha_wrt', 'alt_soundspeed', 'avg_state', 'bc_x', 'bc_y',
+        'bc_z', 'bub_pp', 'bubbles_euler', 'bubbles_lagrange', 'c_wrt',
+        'case_dir', 'cf_wrt', 'cfl_adap_dt', 'cfl_const_dt', 'cfl_target',
+        'chem_wrt_T', 'chem_wrt_Y', 'cons_vars_wrt', 'cont_damage', 'cyl_coord',
+        'down_sample', 'fd_order', 'fft_wrt', 'file_per_process', 'fluid_pp',
+        'flux_lim', 'flux_wrt', 'format', 'gamma_wrt', 'heat_ratio_wrt',
+        'hyper_cleaning', 'hyperelasticity', 'hypoelasticity', 'ib', 'igr',
+        'igr_order', 'lag_betaC_wrt', 'lag_betaT_wrt', 'lag_db_wrt', 'lag_dphidt_wrt',
+        'lag_header', 'lag_id_wrt', 'lag_mg_wrt', 'lag_mv_wrt', 'lag_pos_prev_wrt',
+        'lag_pos_wrt', 'lag_pres_wrt', 'lag_r0_wrt', 'lag_rad_wrt', 'lag_rmax_wrt',
+        'lag_rmin_wrt', 'lag_rvel_wrt', 'lag_txt_wrt', 'lag_vel_wrt', 'liutex_wrt',
+        'm', 'mhd', 'mixture_err', 'model_eqns', 'mom_wrt',
+        'mpp_lim', 'muscl_order', 'n', 'n_start', 'nb',
+        'num_bc_patches', 'num_fluids', 'num_ibs', 'omega_wrt', 'output_partial_domain',
+        'p', 'parallel_io', 'pi_inf_wrt', 'poly_sigma', 'polydisperse',
+        'polytropic', 'precision', 'pref', 'pres_inf_wrt', 'pres_wrt',
+        'prim_vars_wrt', 'qbmm', 'qm_wrt', 'recon_type', 'relativity',
+        'relax', 'relax_model', 'rho_wrt', 'rhoref', 'schlieren_alpha',
+        'schlieren_wrt', 'sigR', 'sigma', 'sim_data', 'surface_tension',
+        't_save', 't_step_save', 't_step_start', 't_step_stop', 't_stop',
+        'thermal', 'vel_wrt', 'weno_order', 'x_output', 'y_output',
+        'z_output',
+    },
+}
 
 
 def parse_namelist_from_file(filepath: Path) -> Set[str]:
@@ -65,7 +157,8 @@ def parse_all_namelists(mfc_root: Path) -> Dict[str, Set[str]]:
         mfc_root: Path to MFC root directory
 
     Returns:
-        Dict mapping target name to set of valid parameter names
+        Dict mapping target name to set of valid parameter names.
+        Falls back to built-in parameter sets when sources are unavailable.
     """
     targets = {
         'pre_process': mfc_root / 'src' / 'pre_process' / 'm_start_up.fpp',
@@ -76,7 +169,9 @@ def parse_all_namelists(mfc_root: Path) -> Dict[str, Set[str]]:
     result = {}
     for target_name, filepath in targets.items():
         if not filepath.exists():
-            raise FileNotFoundError(f"Fortran source not found: {filepath}")
+            # Source files not available (e.g. Homebrew install).
+            # Use built-in fallback parameters.
+            return dict(_FALLBACK_PARAMS)
         result[target_name] = parse_namelist_from_file(filepath)
 
     return result

--- a/toolchain/mfc/run/case_dicts.py
+++ b/toolchain/mfc/run/case_dicts.py
@@ -66,7 +66,6 @@ def _is_param_valid_for_target(param_name: str, target_name: str) -> bool:
 
     Uses the Fortran namelist definitions as the source of truth.
     Handles indexed params like "patch_icpp(1)%geometry" by checking base name.
-
     Args:
         param_name: The parameter name (may include indices)
         target_name: One of 'pre_process', 'simulation', 'post_process'


### PR DESCRIPTION
## **User description**
## Summary
- The namelist parser (added post-v5.2.0) reads `src/*/m_start_up.fpp` at runtime to determine valid parameters per target. Homebrew installs don't include these Fortran source files, causing a `FileNotFoundError` crash when running any case.
- When sources are unavailable, fall back to a built-in copy of the parsed parameter sets (generated from the same Fortran namelists). This maintains correct per-target filtering while working without the source tree.
- Verified via Homebrew CI: all 3 macOS targets (14, 15, 26) pass build + Sod shock tube test: https://github.com/MFlowCode/homebrew-mfc/actions/runs/22085224543

## Test plan
- [x] Homebrew CI passes on macos-14, macos-15, macos-26
- [x] Fallback params match live Fortran parse (verified locally)
- [x] Dev mode (with sources) still filters correctly (`bogus_param` rejected)
- [x] `run_time_info` correctly excluded from `pre_process` in fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Avoid crash when Fortran sources are missing by using built-in namelist parameters

### What Changed
- If the Fortran namelist source files are absent (e.g. Homebrew installs), the parser no longer raises FileNotFoundError and instead uses a built-in set of valid parameters for pre_process, simulation, and post_process
- Parameter validation continues to be per-target using those fallback sets, so invalid parameters are still rejected even without the source tree
- No change to behavior when source files are present — live parsing is still used

### Impact
`✅ No runtime crash on Homebrew installs`
`✅ Correct per-target parameter validation without source files`
`✅ Homebrew CI succeeds for macOS targets`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system robustness with automatic fallback parameter handling. When required source files are unavailable, the system now gracefully switches to built-in default parameters instead of failing, ensuring processes can continue execution with sensible baseline configurations.

* **Documentation**
  * Minor code documentation and formatting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->