### PR TITLE
Fix homebrew-release workflow for retags and fork URLs

### DIFF
--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -109,13 +109,14 @@ jobs:
 
           echo "Updating formula to v${VERSION}..."
 
-          # Update URL
-          sed -i "s|url \"https://github.com/MFlowCode/MFC/archive/refs/tags/v[^\"]*\.tar\.gz\"|url \"https://github.com/MFlowCode/MFC/archive/refs/tags/v${VERSION}.tar.gz\"|" "$FORMULA"
+          # Update URL (match any GitHub archive URL, not just MFlowCode/MFC,
+          # in case the formula temporarily points at a fork during testing)
+          sed -i "s|url \"https://github.com/[^\"]*/archive/[^\"]*\.tar\.gz\"|url \"https://github.com/MFlowCode/MFC/archive/refs/tags/v${VERSION}.tar.gz\"|" "$FORMULA"
 
           # Update SHA256 (the one right after url, not bottle SHAs)
           # This uses awk to only update the first sha256 after the url line
           awk -v newsha="$SHA256" '
-            /^  url "https:\/\/github.com\/MFlowCode\/MFC/ { found_url=1 }
+            /^  url "https:\/\/github.com\// { found_url=1 }
             found_url && /^  sha256 "/ && !updated {
               sub(/sha256 "[^"]*"/, "sha256 \"" newsha "\"")
               updated=1
@@ -157,13 +158,16 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git add Formula/mfc.rb
-          git commit -m "Update MFC to v${VERSION}"
 
-          echo "Pushing to homebrew-mfc..."
-          git push origin main
-
-          echo "Successfully pushed formula update!"
-          echo "The bottle.yml workflow in homebrew-mfc will now build bottles automatically."
+          if git diff --cached --quiet; then
+            echo "::notice::Formula already up to date for v${VERSION} — nothing to push."
+          else
+            git commit -m "Update MFC to v${VERSION}"
+            echo "Pushing to homebrew-mfc..."
+            git push origin main
+            echo "Successfully pushed formula update!"
+            echo "The bottle.yml workflow in homebrew-mfc will now build bottles automatically."
+          fi
 
       - name: Dry run summary
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}


### PR DESCRIPTION
## **User description**
## Summary
- Broaden URL matching patterns in the `homebrew-release.yml` workflow to handle any GitHub archive URL, not just `MFlowCode/MFC`. This fixes failures when the formula temporarily points at a fork during testing.
- Skip the commit/push step gracefully when the formula is already up to date (e.g. retag scenario), instead of failing.
- Triggered by the failure at https://github.com/MFlowCode/MFC/actions/runs/22085562970

## Test plan
- [x] Verified the sed/awk patterns match both `MFlowCode/MFC` and fork URLs
- [x] The `git diff --cached --quiet` check correctly detects no-op updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix homebrew-release workflow for retags and fork URLs**

### What Changed
- Formula URL updates now match any GitHub archive URL, so releases succeed even when the formula temporarily points at a fork during testing
- The SHA update logic targets the checksum immediately following the URL line (works regardless of which repo was previously referenced)
- If the formula file has no changes (e.g., a retag), the workflow skips committing and pushing and emits a notice instead of failing

### Impact
`✅ Fewer failed release runs when formulas point to forks`
`✅ No-op retags no longer cause failed pushes`
`✅ More reliable formula updates during release workflows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened release automation with improved handling of edge cases and varied release scenarios.
  * Enhanced flexibility in processing release configurations to support a wider range of source patterns.
  * Optimized workflow efficiency through conditional logic that gracefully skips processing when no changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->