### PR TITLE
fix ibm benchmark on frontier + amd

### DIFF
--- a/src/simulation/m_compute_levelset.fpp
+++ b/src/simulation/m_compute_levelset.fpp
@@ -33,6 +33,10 @@ contains
 
         integer :: i, patch_id, patch_geometry
 
+        if (num_gps < 1) then
+            return
+        end if
+
         $:GPU_UPDATE(device='[gps(1:num_gps)]')
 
         !  3D Patch Geometries


### PR DESCRIPTION
## **User description**
## Description

Simple bug fix that was introduced in a recent PR; AMD compilers don't like update device when the array bounds are 1:0. 

Fixes #(issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other: _describe_

## Testing

How did you test your changes?

## Checklist

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed

See the [developer guide](https://mflowcode.github.io/documentation/contributing.html) for full coding standards.

<details>
<summary><strong>GPU changes</strong> (expand if you modified <code>src/simulation/</code>)</summary>

- [ ] GPU results match CPU results
- [ ] Tested on NVIDIA GPU or AMD GPU

</details>


___

## **CodeAnt-AI Description**
Prevent GPU update when there are zero ghost points to avoid AMD failure

### What Changed
- The subroutine returns immediately when the ghost-point count is less than 1, so no GPU update or kernel launch is attempted for empty arrays
- Removes the condition that caused AMD compilers or runtimes to reject an update with an array slice of bounds 1:0
- All other behavior for non-empty ghost-point arrays is unchanged

### Impact
`✅ Runs IBM benchmark on Frontier without AMD compile/runtime error`
`✅ Fewer GPU launch failures when arrays are empty`
`✅ Stable execution when no ghost points are present`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance by preventing unnecessary processing when no items require computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->