### PR TITLE
Widen scaling plot card and add link to performance page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -89,12 +89,17 @@
                 .then(sims => renderSims(sims));
 
             document.getElementById("ft-scaling").innerHTML = scalings.map(s => `
-                <a href="documentation/expectedPerformance.html" class="flex md:w-2/6 mx-auto flex-col text-white rounded bg-slate-900 rounded-b-lg hover:ring-2 hover:ring-amber-400 transition-shadow no-underline">
+                <div class="flex md:w-1/2 mx-auto flex-col text-white rounded bg-slate-900 rounded-b-lg">
                     <div class="flex-1 grid bg-white pb-2">
                         <img class="place-self-center" src="${s.image}" alt="${s.label}">
                     </div>
-                    <div class="flex-1 p-2 font-semibold text-center">${s.label}</div>
-                </a>
+                    <div class="flex flex-row items-center">
+                        <div class="flex-1 p-2 font-semibold text-center">${s.label}</div>
+                        <a class="w-10 text-center text-xl hover:text-amber-400 transition-colors" href="documentation/expectedPerformance.html">
+                            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                        </a>
+                    </div>
+                </div>
             `).join("");
 
             document.getElementById("copyright-year").textContent = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- Widen the weak scaling plot card from 33% to 50% width on desktop for better readability
- Replace full-card clickable link with a proper link icon bar at the bottom, matching the simulation gallery card style

## Test plan
- [x] Docs build locally
- [x] Scaling card renders at correct width
- [x] Link icon navigates to expectedPerformance.html
- [x] All precheck tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)