### PR TITLE
Fix docs CI: run linkcheck before publish step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,12 @@ jobs:
         echo "url-count = ${{ steps.sitemap.outputs.url-count }}"
         echo "excluded-count = ${{ steps.sitemap.outputs.excluded-count }}"
 
+    - name: Linkcheck - Lychee
+      uses: lycheeverse/lychee-action@v2
+      with:
+        args: -c .lychee.toml build/install/docs/mfc/
+        fail: true
+
     - name: Publish Documentation
       if:   github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' &&  (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' )
       run:  |
@@ -82,12 +88,6 @@ jobs:
         git -C ../www add -A
         git -C ../www commit -m "Docs @ ${GITHUB_SHA::7}" || true
         git -C ../www push
-
-    - name: Linkcheck - Lychee
-      uses: lycheeverse/lychee-action@v2
-      with:
-        args: -c .lychee.toml build/install/docs/mfc/
-        fail: true
 
 # DOC_PUSH_URL should be of the format:
 # --> https://<username>:<token>@github.com/<username>/<repository>


### PR DESCRIPTION
## **User description**
## Summary
- Swap Lychee linkcheck and Publish steps in `docs.yml` so linkcheck runs while `build/install/docs/mfc/` still has files

The Publish step uses `mv` (not `cp`) to move built docs into the deploy repo, leaving the build directory empty. On `schedule` and `workflow_dispatch` events (where Publish is active), Lychee then finds zero files and fails with `failIfEmpty`.

This was the root cause of https://github.com/MFlowCode/MFC/actions/runs/22202143038/job/64217490447

## Test plan
- [ ] Trigger a `workflow_dispatch` run of the Documentation workflow and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Run linkcheck before publishing docs to prevent false failures**

### What Changed
- The documentation link checker now runs before the Publish step so it sees the built site files
- Scheduled and manual documentation workflow runs no longer fail when the Publish step moves files out of the build directory
- Publish behavior and deployment to the docs repo remain unchanged

### Impact
`✅ Fewer documentation CI failures on scheduled/manual runs`
`✅ Clearer linkcheck results that reflect actual built docs`
`✅ More reliable scheduled docs publishes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the documentation build workflow by reordering validation steps to occur earlier in the process, ensuring documentation quality checks are performed before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->