### PR TITLE
Fix z-boundary backward FD stencil using fields(2) instead of fields(3)

### DIFF
--- a/src/common/m_finite_differences.fpp
+++ b/src/common/m_finite_differences.fpp
@@ -50,7 +50,7 @@ contains
                         if (z == iz_s%beg) then
                             divergence = divergence + (-3._wp*fields(3)%sf(x, y, z) + 4._wp*fields(3)%sf(x, y, z + 1) - fields(3)%sf(x, y, z + 2))/(z_cc(z + 2) - z_cc(z))
                         else if (z == iz_s%end) then
-                            divergence = divergence + (+3._wp*fields(3)%sf(x, y, z) - 4._wp*fields(3)%sf(x, y, z - 1) + fields(2)%sf(x, y, z - 2))/(z_cc(z) - z_cc(z - 2))
+                            divergence = divergence + (+3._wp*fields(3)%sf(x, y, z) - 4._wp*fields(3)%sf(x, y, z - 1) + fields(3)%sf(x, y, z - 2))/(z_cc(z) - z_cc(z - 2))
                         else
                             divergence = divergence + (fields(3)%sf(x, y, z + 1) - fields(3)%sf(x, y, z - 1))/(z_cc(z + 1) - z_cc(z - 1))
                         end if


### PR DESCRIPTION
## Summary

**Severity:** CRITICAL — produces wrong results in all 3D simulations using this routine.

**File:** `src/common/m_finite_differences.fpp`, line 53

The z-direction upper-boundary backward finite difference stencil at `iz_s%end` uses `fields(2)` (the **y**-component) instead of `fields(3)` (the **z**-component) in the third term of the second-order backward difference.

### Before
```fortran
divergence = divergence + (+3._wp*fields(3)%sf(x,y,z) &
    - 4._wp*fields(3)%sf(x,y,z-1) &
    + fields(2)%sf(x,y,z-2)) / (z_cc(z) - z_cc(z-2))
!   ^^^^^^^^^ should be fields(3)
```

### After
```fortran
divergence = divergence + (+3._wp*fields(3)%sf(x,y,z) &
    - 4._wp*fields(3)%sf(x,y,z-1) &
    + fields(3)%sf(x,y,z-2)) / (z_cc(z) - z_cc(z-2))
```

### Why this went undetected
This is a copy-paste error in the x→y→z stencil chain where only the third term of the z-direction backward stencil is wrong — the first two terms correctly use `fields(3)`. The bug only activates at the exact upper z-boundary cells (`iz_s%end`) where the one-sided backward stencil is used; the interior central-difference stencil and the lower-boundary forward stencil are both correct. This makes the error localized to a thin boundary layer that is easily masked by the correct values everywhere else.

## Test plan
- [ ] Run 3D test case with non-trivial z-boundary divergence
- [ ] Verify divergence values at `iz_s%end` match the y-boundary analog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1194