### PR TITLE
Fix moncon_cutoff declared as integer, truncating 1e-8 to 0

### DIFF
--- a/src/common/m_constants.fpp
+++ b/src/common/m_constants.fpp
@@ -44,7 +44,7 @@ module m_constants
     ! Interface Compression
     real(wp), parameter :: dflt_ic_eps = 1e-4_wp !< Ensure compression is only applied to surface cells in THINC
     real(wp), parameter :: dflt_ic_beta = 1.6_wp !< Sharpness parameter's default value used in THINC
-    integer, parameter :: moncon_cutoff = 1e-8_wp !< Monotonicity constraint's limiter to prevent extremas in THINC
+    real(wp), parameter :: moncon_cutoff = 1e-8_wp !< Monotonicity constraint's limiter to prevent extremas in THINC
 
     ! Chemistry
     real(wp), parameter :: dflt_T_guess = 1200._wp ! Default guess for temperature (when a previous value is not available)


### PR DESCRIPTION
## Summary

**Severity:** CRITICAL — completely disables the THINC monotonicity constraint.

**File:** `src/common/m_constants.fpp`, line 47

`moncon_cutoff` is declared as `integer` but assigned the real literal `1e-8_wp`. Fortran silently truncates this to `0`. Every comparison like `moncon > moncon_cutoff` is then always true (since `moncon_cutoff = 0`), so the THINC monotonicity constraint is never enforced.

### Before
```fortran
integer, parameter :: moncon_cutoff = 1e-8_wp  ! becomes 0
```

### After
```fortran
real(wp), parameter :: moncon_cutoff = 1e-8_wp  ! stays 1e-8
```

### Why this went undetected
Fortran truncates real-to-integer conversions at compile time with at most a warning (often suppressed). THINC still produces plausible-looking results without the monotonicity constraint — the interface compression just allows more extrema than intended, which is hard to notice visually.

## Test plan
- [ ] Run THINC interface compression test case and verify monotonicity constraint activates
- [ ] Check that interface overshoots are now suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1195