### PR TITLE
Fix bc_x%ve3 never MPI-broadcast (duplicate ve2 instead)

### DIFF
--- a/src/simulation/m_mpi_proxy.fpp
+++ b/src/simulation/m_mpi_proxy.fpp
@@ -145,7 +145,7 @@ contains
 
         #:for VAR in [ 'dt','weno_eps','teno_CT','pref','rhoref','R0ref','Web','Ca', 'sigma', &
             & 'Re_inv', 'poly_sigma', 'palpha_eps', 'ptgalpha_eps', 'pi_fac',    &
-            & 'bc_x%vb1','bc_x%vb2','bc_x%vb3','bc_x%ve1','bc_x%ve2','bc_x%ve2', &
+            & 'bc_x%vb1','bc_x%vb2','bc_x%vb3','bc_x%ve1','bc_x%ve2','bc_x%ve3', &
             & 'bc_y%vb1','bc_y%vb2','bc_y%vb3','bc_y%ve1','bc_y%ve2','bc_y%ve3', &
             & 'bc_z%vb1','bc_z%vb2','bc_z%vb3','bc_z%ve1','bc_z%ve2','bc_z%ve3', &
             & 'bc_x%pres_in','bc_x%pres_out','bc_y%pres_in','bc_y%pres_out', 'bc_z%pres_in','bc_z%pres_out', &


### PR DESCRIPTION
## Summary

**Severity:** CRITICAL — non-root ranks get uninitialized `bc_x%ve3`.

**File:** `src/simulation/m_mpi_proxy.fpp`, line 148

The MPI broadcast list for x-boundary velocity-end parameters has `bc_x%ve2` duplicated where `bc_x%ve3` should be. The `bc_y` and `bc_z` rows are correct.

### Before
```fortran
& 'bc_x%vb1','bc_x%vb2','bc_x%vb3','bc_x%ve1','bc_x%ve2','bc_x%ve2', &
!                                                          ^^^^^^^^^ should be ve3
& 'bc_y%vb1','bc_y%vb2','bc_y%vb3','bc_y%ve1','bc_y%ve2','bc_y%ve3', &
& 'bc_z%vb1','bc_z%vb2','bc_z%vb3','bc_z%ve1','bc_z%ve2','bc_z%ve3', &
```

### After
```fortran
& 'bc_x%vb1','bc_x%vb2','bc_x%vb3','bc_x%ve1','bc_x%ve2','bc_x%ve3', &
```

### Why this went undetected
Only manifests in multi-rank 3D runs with x-direction velocity boundary conditions that use the `ve3` component — a narrow intersection of conditions.

## Test plan
- [ ] Run multi-rank 3D simulation with x-boundary velocity BCs that set ve3
- [ ] Verify bc_x%ve3 is identical on root and non-root ranks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error in the MPI broadcast configuration where a boundary condition variable was incorrectly duplicated. The correction ensures all necessary boundary variables are properly synchronized during parallel simulation execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1196