### PR TITLE
Fix fluid_rho broadcast using MPI_LOGICAL instead of mpi_p

### DIFF
--- a/src/pre_process/m_mpi_proxy.fpp
+++ b/src/pre_process/m_mpi_proxy.fpp
@@ -58,7 +58,7 @@ contains
             & 'igr', 'down_sample', 'simplex_perturb','fft_wrt', 'hyper_cleaning' ]
             call MPI_BCAST(${VAR}$, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
         #:endfor
-        call MPI_BCAST(fluid_rho(1), num_fluids_max, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
+        call MPI_BCAST(fluid_rho(1), num_fluids_max, mpi_p, 0, MPI_COMM_WORLD, ierr)
 
         #:for VAR in [ 'x_domain%beg', 'x_domain%end', 'y_domain%beg',         &
             & 'y_domain%end', 'z_domain%beg', 'z_domain%end', 'a_x', 'a_y',    &


### PR DESCRIPTION
## Summary

**Severity:** CRITICAL — silently corrupts reference densities on non-root ranks.

**File:** `src/pre_process/m_mpi_proxy.fpp`, line 61

`fluid_rho` is a `real(wp)` array but is broadcast using `MPI_LOGICAL` instead of `mpi_p`. MPI doesn't type-check its arguments, so the bytes are reinterpreted as logicals on the receiving ranks, silently producing wrong density values.

### Before
```fortran
call MPI_BCAST(fluid_rho(1), num_fluids_max, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierr)
!                                             ^^^^^^^^^^^ should be mpi_p
```

### After
```fortran
call MPI_BCAST(fluid_rho(1), num_fluids_max, mpi_p, 0, MPI_COMM_WORLD, ierr)
```

### Why this went undetected
On most systems, `MPI_LOGICAL` and a real happen to be the same size (4 or 8 bytes), so the call doesn't segfault. It just reinterprets the bits, producing subtly wrong values that are hard to trace back to a broadcast type mismatch.

## Test plan
- [ ] Run multi-rank simulation and verify fluid_rho is identical across all ranks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1197