### PR TITLE
Fix integral zmin/zmax never initialized (copy-paste of ymin/ymax)

### DIFF
--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -814,8 +814,8 @@ contains
             integral(i)%xmax = dflt_real
             integral(i)%ymin = dflt_real
             integral(i)%ymax = dflt_real
-            integral(i)%ymin = dflt_real
-            integral(i)%ymax = dflt_real
+            integral(i)%zmin = dflt_real
+            integral(i)%zmax = dflt_real
         end do
 
         ! GRCBC flags


### PR DESCRIPTION
## Summary

**Severity:** CRITICAL — 3D volume integrals use garbage z-bounds.

**File:** `src/simulation/m_global_parameters.fpp`, lines 817-818

The initialization loop for volume integral bounds repeats `ymin`/`ymax` on the lines that should set `zmin`/`zmax`, a copy-paste error from the y-bounds initialization just above.

### Before
```fortran
integral(i)%xmin = dflt_real
integral(i)%xmax = dflt_real
integral(i)%ymin = dflt_real
integral(i)%ymax = dflt_real
integral(i)%ymin = dflt_real   ! should be zmin
integral(i)%ymax = dflt_real   ! should be zmax
```

### After
```fortran
integral(i)%xmin = dflt_real
integral(i)%xmax = dflt_real
integral(i)%ymin = dflt_real
integral(i)%ymax = dflt_real
integral(i)%zmin = dflt_real
integral(i)%zmax = dflt_real
```

### Why this went undetected
Only affects 3D simulations that use volume integral diagnostics. The y-bounds are initialized twice (harmlessly), masking the fact that z-bounds are never set.

## Test plan
- [ ] Run 3D simulation with volume integral output and verify z-bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1198