### PR TITLE
Fix OBJ reader using j as both triangle counter and vertex index

### DIFF
--- a/src/common/m_model.fpp
+++ b/src/common/m_model.fpp
@@ -226,7 +226,7 @@ contains
         character(LEN=*), intent(in) :: filepath
         type(t_model), intent(out) :: model
 
-        integer :: i, j, k, l, iunit, iostat, nVertices
+        integer :: i, j, k, l, iv3, iunit, iostat, nVertices
 
         real(wp), dimension(1:3), allocatable :: vertices(:, :)
 
@@ -275,10 +275,10 @@ contains
                 read (line(3:), *) vertices(i, :)
                 i = i + 1
             case ("f ")
-                read (line(3:), *) k, l, j
+                read (line(3:), *) k, l, iv3
                 model%trs(j)%v(1, :) = vertices(k, :)
                 model%trs(j)%v(2, :) = vertices(l, :)
-                model%trs(j)%v(3, :) = vertices(j, :)
+                model%trs(j)%v(3, :) = vertices(iv3, :)
                 j = j + 1
             case default
                 print *, "Error: unknown line type in OBJ file ", filepath


### PR DESCRIPTION
## Summary

**Severity:** CRITICAL — triangle assignments go to wrong indices; potential OOB crash.

**File:** `src/common/m_model.fpp`, lines 278-282

In the OBJ reader, `j` serves double duty as both the sequential triangle counter (initialized to 1 on line 264) and the third vertex index read from the face line. When `read(line(3:), *) k, l, j` executes, `j` is overwritten with the vertex index from the file, then immediately used as the triangle index in `model%trs(j)`.

### Before
```fortran
j = 1  ! triangle counter
...
case ("f ")
    read (line(3:), *) k, l, j         ! j overwritten with vertex index
    model%trs(j)%v(1, :) = vertices(k, :)  ! j is now a vertex index, not triangle counter
    model%trs(j)%v(2, :) = vertices(l, :)
    model%trs(j)%v(3, :) = vertices(j, :)  ! also wrong: self-referential
    j = j + 1                           ! incrementing from wrong base
```

### After
```fortran
integer :: i, j, k, l, iv3, ...   ! new variable iv3
...
case ("f ")
    read (line(3:), *) k, l, iv3       ! third vertex index in separate var
    model%trs(j)%v(1, :) = vertices(k, :)  ! j is the triangle counter
    model%trs(j)%v(2, :) = vertices(l, :)
    model%trs(j)%v(3, :) = vertices(iv3, :)
    j = j + 1
```

### Why this went undetected
Only triggers when loading OBJ STL models, a specialized feature with limited test coverage.

## Test plan
- [ ] Load an OBJ model file and verify triangle geometry matches the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1199