### PR TITLE
Fix grid stretching using wrong array bounds for y_cc and z_cc

### DIFF
--- a/src/pre_process/m_grid.f90
+++ b/src/pre_process/m_grid.f90
@@ -131,7 +131,7 @@ contains
             end do
 
             y_cb = y_cb*length
-            y_cc(0:m) = (y_cb(0:n) + y_cb(-1:n - 1))/2._wp
+            y_cc(0:n) = (y_cb(0:n) + y_cb(-1:n - 1))/2._wp
 
             dy = minval(y_cb(0:n) - y_cb(-1:n - 1))
 
@@ -168,7 +168,7 @@ contains
             end do
 
             z_cb = z_cb*length
-            z_cc(0:m) = (z_cb(0:p) + z_cb(-1:p - 1))/2._wp
+            z_cc(0:p) = (z_cb(0:p) + z_cb(-1:p - 1))/2._wp
 
             dz = minval(z_cb(0:p) - z_cb(-1:p - 1))
 


### PR DESCRIPTION
## Summary

**Severity:** CRITICAL — corrupts y/z cell-center coordinates when grid stretching is active.

**File:** `src/pre_process/m_grid.f90`, lines 134 and 171

After applying grid stretching, the cell-center arrays are computed with the wrong left-hand side bounds: `y_cc(0:m)` and `z_cc(0:m)` use the x-dimension size `m` instead of the y-dimension `n` and z-dimension `p`.

### Before
```fortran
! y-direction (line 134)
y_cc(0:m) = (y_cb(0:n) + y_cb(-1:n-1))/2._wp   ! m is x-size, should be n

! z-direction (line 171)
z_cc(0:m) = (z_cb(0:p) + z_cb(-1:p-1))/2._wp   ! m is x-size, should be p
```

### After
```fortran
y_cc(0:n) = (y_cb(0:n) + y_cb(-1:n-1))/2._wp
z_cc(0:p) = (z_cb(0:p) + z_cb(-1:p-1))/2._wp
```

### Why this went undetected
When `m == n == p` (equal resolution in all directions), the wrong index produces the same result. The bug only manifests with anisotropic grids **and** stretching enabled.

## Test plan
- [ ] Run 3D case with grid stretching and anisotropic resolution (m != n != p)
- [ ] Verify y_cc and z_cc cell centers match expected stretched coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1200