### PR TITLE
Fix integer(wp) non-standard kind for loop variables in bubble module

### DIFF
--- a/src/simulation/m_bubbles_EE.fpp
+++ b/src/simulation/m_bubbles_EE.fpp
@@ -74,7 +74,7 @@ contains
     subroutine s_comp_alpha_from_n(q_cons_vf)
         type(scalar_field), dimension(sys_size), intent(inout) :: q_cons_vf
         real(wp) :: nR3bar
-        integer(wp) :: i, j, k, l
+        integer :: i, j, k, l
 
         $:GPU_PARALLEL_LOOP(private='[i,j,k,l,nR3bar]', collapse=3)
         do l = 0, p


### PR DESCRIPTION
## Summary

**Severity:** HIGH — non-standard integer kind may produce wrong-sized loop variables.

**File:** `src/simulation/m_bubbles_EE.fpp`, line 77

Loop variables `i, j, k, l` are declared as `integer(wp)` where `wp` is a real kind parameter (e.g., 8 for double precision). `integer(wp)` is non-standard Fortran — it uses the real kind selector as an integer kind, which may produce wrong-sized integers on strict compilers.

### Before
```fortran
integer(wp) :: i, j, k, l    ! wp is a real kind, not an integer kind
```

### After
```fortran
integer :: i, j, k, l        ! default integer
```

### Why this went undetected
Most compilers silently accept `integer(8)` as a valid 8-byte integer kind, so this happens to work when `wp=8`. Would fail on compilers where kind 8 is not a valid integer kind.

## Test plan
- [ ] Build with strict compiler flags (`-std=f2018`)
- [ ] Run Euler-Euler bubble test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)