### PR TITLE
Remove duplicate R3bar accumulation line that doubles bubble perturbation

### DIFF
--- a/src/pre_process/m_assign_variables.fpp
+++ b/src/pre_process/m_assign_variables.fpp
@@ -233,7 +233,6 @@ contains
         if (qbmm) then
             do i = 1, nb
                 R3bar = R3bar + weight(i)*0.5_wp*(q_prim_vf(bubxb + 1 + (i - 1)*nmom)%sf(j, k, l))**3._wp
-                R3bar = R3bar + weight(i)*0.5_wp*(q_prim_vf(bubxb + 1 + (i - 1)*nmom)%sf(j, k, l))**3._wp
             end do
         else
             do i = 1, nb


### PR DESCRIPTION
## Summary

**Severity:** HIGH — doubles bubble perturbation for QBMM cases.

**File:** `src/pre_process/m_assign_variables.fpp`, lines 235-236

Character-for-character identical duplicate line in the QBMM branch of the R3bar accumulation loop. This doubles the computed value of R3bar.

### Before
```fortran
if (qbmm) then
    do i = 1, nb
        R3bar = R3bar + weight(i)*0.5_wp*(q_prim_vf(...))**3._wp
        R3bar = R3bar + weight(i)*0.5_wp*(q_prim_vf(...))**3._wp   ! duplicate
    end do
```

### After
```fortran
if (qbmm) then
    do i = 1, nb
        R3bar = R3bar + weight(i)*0.5_wp*(q_prim_vf(...))**3._wp
    end do
```

### Why this went undetected
QBMM is a specialized bubble dynamics feature. The doubled R3bar produces a systematically wrong (but not obviously broken) bubble volume fraction initialization.

## Test plan
- [ ] Run QBMM bubble test case
- [ ] Verify R3bar matches expected bubble radius statistics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1203