### PR TITLE
Remove debug print left in post-process production code

### DIFF
--- a/src/post_process/m_data_input.f90
+++ b/src/post_process/m_data_input.f90
@@ -312,7 +312,6 @@ contains
                       STATUS='old', ACTION='read')
                 read (1) q_cons_vf(i)%sf(0:m, 0:n, 0:p)
                 close (1)
-                print *, q_cons_vf(i)%sf(:, 0, 0)
             else
                 call s_mpi_abort('File q_cons_vf'//trim(file_num)// &
                                  '.dat is missing in '//trim(t_step_dir)// &


### PR DESCRIPTION
## Summary

**Severity:** HIGH — spams stdout with variable data during every post-process run.

**File:** `src/post_process/m_data_input.f90`, line 315

A debug `print *` statement was left in production code. It prints the entire conservative variable slice `q_cons_vf(i)%sf(:, 0, 0)` to stdout for every variable at every timestep during serial post-processing.

### Before
```fortran
read (1) q_cons_vf(i)%sf(0:m, 0:n, 0:p)
close (1)
print *, q_cons_vf(i)%sf(:, 0, 0)    ! debug print left in
```

### After
```fortran
read (1) q_cons_vf(i)%sf(0:m, 0:n, 0:p)
close (1)
```

## Test plan
- [ ] Run post-processing and verify no spurious stdout output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1205