### PR TITLE
Fix IB patch vel/angular_vel/angles broadcast inside wrong loop

### DIFF
--- a/src/pre_process/m_mpi_proxy.fpp
+++ b/src/pre_process/m_mpi_proxy.fpp
@@ -76,10 +76,6 @@ contains
                 call MPI_BCAST(patch_bc(i)%${VAR}$, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
             #:endfor
 
-            #:for VAR in ['vel', 'angular_vel', 'angles']
-                call MPI_BCAST(patch_ib(i)%${VAR}$, 3, mpi_p, 0, MPI_COMM_WORLD, ierr)
-            #:endfor
-
             call MPI_BCAST(patch_bc(i)%radius, 1, mpi_p, 0, MPI_COMM_WORLD, ierr)
 
             #:for VAR in ['centroid', 'length']
@@ -121,6 +117,9 @@ contains
                 call MPI_BCAST(patch_icpp(i)%Y, size(patch_icpp(i)%Y), mpi_p, 0, MPI_COMM_WORLD, ierr)
             end if
             ! Broadcast IB variables
+            #:for VAR in ['vel', 'angular_vel', 'angles']
+                call MPI_BCAST(patch_ib(i)%${VAR}$, 3, mpi_p, 0, MPI_COMM_WORLD, ierr)
+            #:endfor
             call MPI_BCAST(patch_ib(i)%geometry, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
             call MPI_BCAST(patch_ib(i)%model_filepath, len(patch_ib(i)%model_filepath), MPI_CHARACTER, 0, MPI_COMM_WORLD, ierr)
             call MPI_BCAST(patch_ib(i)%model_threshold, 1, mpi_p, 0, MPI_COMM_WORLD, ierr)


### PR DESCRIPTION
## Summary

**Severity:** HIGH — IB patch vel/angular_vel/angles broadcast in wrong loop with wrong bounds.

**File:** `src/pre_process/m_mpi_proxy.fpp`, lines 79-81

The `patch_ib(i)%vel`, `patch_ib(i)%angular_vel`, and `patch_ib(i)%angles` broadcasts are inside the `do i = 1, num_bc_patches_max` loop, but they reference `patch_ib` which should be iterated up to `num_patches_max` (where all other `patch_ib` fields are broadcast).

### Before
```fortran
do i = 1, num_bc_patches_max        ! BC patches loop
    ! patch_bc broadcasts... (correct)
    call MPI_BCAST(patch_ib(i)%vel, ...)          ! WRONG loop!
    call MPI_BCAST(patch_ib(i)%angular_vel, ...)  ! WRONG loop!
    call MPI_BCAST(patch_ib(i)%angles, ...)       ! WRONG loop!
end do
do i = 1, num_patches_max           ! patches loop
    ! other patch_ib broadcasts... (correct loop, missing vel/angular_vel/angles)
end do
```

### After
Moved the vel/angular_vel/angles broadcasts into the `num_patches_max` loop alongside the other `patch_ib` fields.

### Why this went undetected
If `num_bc_patches_max >= num_patches_max`, all IB patches would still get broadcast (with some extra unnecessary iterations). Only fails when there are more IB patches than BC patches.

## Test plan
- [ ] Run multi-rank simulation with immersed boundaries
- [ ] Verify IB patch velocities/angles are consistent across ranks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1208