### PR TITLE
Fix time_real used uninitialized in Lagrangian bubble output

### DIFF
--- a/src/post_process/m_data_output.fpp
+++ b/src/post_process/m_data_output.fpp
@@ -1102,6 +1102,7 @@ contains
         call MPI_BCAST(file_time, 1, mpi_p, 0, MPI_COMM_WORLD, ierr)
         call MPI_BCAST(file_dt, 1, mpi_p, 0, MPI_COMM_WORLD, ierr)
         call MPI_BCAST(file_num_procs, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+        time_real = file_time
 
         allocate (proc_bubble_counts(file_num_procs))
 
@@ -1271,6 +1272,7 @@ contains
         call MPI_BCAST(file_time, 1, mpi_p, 0, MPI_COMM_WORLD, ierr)
         call MPI_BCAST(file_dt, 1, mpi_p, 0, MPI_COMM_WORLD, ierr)
         call MPI_BCAST(file_num_procs, 1, MPI_INTEGER, 0, MPI_COMM_WORLD, ierr)
+        time_real = file_time
 
         allocate (proc_bubble_counts(file_num_procs))
 


### PR DESCRIPTION
## Summary

**Severity:** HIGH — time column in Lagrangian bubble output contains garbage.

**File:** `src/post_process/m_data_output.fpp`, lines 1059 and 1193 (also 1219 in the Silo output variant)

`time_real` is declared as a local variable but never assigned from `file_time` (which is read from the restart file and broadcast). It is then written as the time column in the output, producing uninitialized garbage values.

### Before
```fortran
real(wp) :: time_real        ! declared, never assigned
...
call MPI_BCAST(file_time, 1, mpi_p, 0, MPI_COMM_WORLD, ierr)
...
write (29, '(E15.7)') time_real    ! garbage
```

### After
```fortran
call MPI_BCAST(file_time, 1, mpi_p, 0, MPI_COMM_WORLD, ierr)
time_real = file_time              ! assign from broadcast value
...
write (29, '(E15.7)') time_real    ! correct time
```

Fixed in both the text output subroutine and the Silo database output subroutine.

### Why this went undetected
Lagrangian bubble post-processing is a specialized feature. The other output columns (positions, velocities, radii) are correct, so users may not have noticed the time column being wrong.

## Test plan
- [ ] Run Lagrangian bubble simulation with output enabled
- [ ] Verify time column matches expected simulation time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1209