### PR TITLE
Fix s_write_intf_data_file using wrong loop index for distance check

### DIFF
--- a/src/post_process/m_data_output.fpp
+++ b/src/post_process/m_data_output.fpp
@@ -1546,19 +1546,16 @@ contains
                         counter = counter + 1
                         x_d1(counter) = x_cc(j)
                         y_d1(counter) = y_cc(k)
-                        euc_d = sqrt((x_cc(j) - x_d1(i))**2 + (y_cc(k) - y_d1(i))**2)
-                        tgp = sqrt(dx(j)**2 + dy(k)**2)
                     else
-                        euc_d = sqrt((x_cc(j) - x_d1(i))**2 + (y_cc(k) - y_d1(i))**2)
                         tgp = sqrt(dx(j)**2 + dy(k)**2)
                         do i = 1, counter
+                            euc_d = sqrt((x_cc(j) - x_d1(i))**2 + (y_cc(k) - y_d1(i))**2)
                             if (euc_d < tgp) then
-                                cycle
-                            elseif (euc_d > tgp .and. i == counter) then
+                                exit
+                            elseif (i == counter) then
                                 counter = counter + 1
                                 x_d1(counter) = x_cc(j)
                                 y_d1(counter) = y_cc(k)
-
                             end if
                         end do
                     end if


### PR DESCRIPTION
## Summary

**Severity:** HIGH — interface contour extraction uses stale loop index, produces wrong point distances.

**File:** `src/post_process/m_data_output.fpp`, lines 1549-1563

In `s_write_intf_data_file`, the Euclidean distance `euc_d` between a candidate interface point and existing stored points is computed using `x_d1(i)` and `y_d1(i)`, where `i` is stale from a previous outer loop (value = `m+1` after the maxalpha search loop). This references out-of-bounds or wrong data. Additionally, `euc_d` is computed once outside the inner loop, so the distance check is the same for all stored points.

### Before
```fortran
! euc_d uses stale 'i' from the previous loop, not the stored-point index
euc_d = sqrt((x_cc(j) - x_d1(i))**2 + (y_cc(k) - y_d1(i))**2)
tgp = sqrt(dx(j)**2 + dy(k)**2)
do i = 1, counter        ! i is now a different loop variable
    if (euc_d < tgp) then
        cycle             ! wrong: should exit, not cycle
    elseif (euc_d > tgp .and. i == counter) then
        ! add point
```

### After
```fortran
tgp = sqrt(dx(j)**2 + dy(k)**2)
do i = 1, counter
    euc_d = sqrt((x_cc(j) - x_d1(i))**2 + (y_cc(k) - y_d1(i))**2)
    if (euc_d < tgp) then
        exit              ! too close to existing point, reject candidate
    elseif (i == counter) then
        ! add point — passed all distance checks
```

Three fixes:
1. Moved `euc_d` computation inside the loop so it checks distance to each stored point
2. Changed `cycle` to `exit` for correct early termination (reject if too close to **any** point)
3. Removed dead code in the `counter == 0` branch (distance to self)

## Test plan
- [ ] Run post-processing with interface data output
- [ ] Verify extracted contour points are properly spaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1211