### PR TITLE
Fix s_create_directory called with /* wildcard creating junk directory

### DIFF
--- a/src/pre_process/m_start_up.fpp
+++ b/src/pre_process/m_start_up.fpp
@@ -355,7 +355,7 @@ contains
         ! the time-step directory that will contain the new grid and initial
         ! condition data are also generated.
         if (old_ic .neqv. .true.) then
-            call s_delete_directory(trim(proc_rank_dir)//'/*')
+            call s_delete_directory(trim(proc_rank_dir))
             call s_create_directory(trim(proc_rank_dir)//'/0')
         end if
 


### PR DESCRIPTION
## **User description**
## Summary
- Fix `s_read_serial_ic_data_files` in `m_start_up.fpp` calling `s_create_directory` with a `/*` suffix, which creates a literal directory named `*` instead of cleaning the output directory.

## Bug Details
The code at line 508 calls:
```fortran
call s_create_directory(trim(proc_rank_dir)//'/*')
```

The comment above says "cleaned out to make room for new pre-process data", but `s_create_directory` runs `mkdir -p "path/*"`, which creates a directory literally named `*` inside `proc_rank_dir`. The intent was to remove old files to make room for new data.

The old data files happen to get overwritten by subsequent writes, so this doesn't cause crashes, but it leaves a junk `*` directory behind and doesn't actually clean old files that may no longer be relevant.

## Fix
Replace the `s_create_directory(path/*)` call with `s_delete_directory(path)` to actually remove the old directory contents. The subsequent `s_create_directory(path/0)` uses `mkdir -p` so it recreates both the parent and the `/0` subdirectory.

## Test plan
- [ ] Serial pre-process restart (old_ic) cases still work
- [ ] No `*` directory created in process rank directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix creation of a literal '*' directory when preparing per-rank pre-process folders

### What Changed
- Removed the call that created a path ending with '/*' and replaced it with a call that deletes the existing rank directory before recreating the time-step subfolder
- The code now removes previous pre-process files instead of creating a literal '*' directory and then recreates the '/0' subdirectory for new data

### Impact
`✅ No leftover '*' directories in per-rank folders`
`✅ Old pre-process files are removed before new data is written`
`✅ More predictable serial pre-process restart behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved directory cleanup during initialization process to ensure consistent system state before starting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1220