### PR TITLE
Fix f_check_interpolation_2D/3D returning only last edge's result

### DIFF
--- a/src/common/m_model.fpp
+++ b/src/common/m_model.fpp
@@ -746,11 +746,9 @@ contains
         do j = 1, boundary_edge_count
             l1 = sqrt((boundary_v(j, 2, 1) - boundary_v(j, 1, 1))**2 + &
                       (boundary_v(j, 2, 2) - boundary_v(j, 1, 2))**2)
-
-            if ((l1 > cell_width)) then
+            if (l1 > cell_width) then
                 interpolate = .true.
-            else
-                interpolate = .false.
+                return
             end if
         end do
 
@@ -794,8 +792,7 @@ contains
                 (edge_l(2) > cell_width) .or. &
                 (edge_l(3) > cell_width)) then
                 interpolate = .true.
-            else
-                interpolate = .false.
+                return
             end if
         end do
 


### PR DESCRIPTION
## **User description**
## Summary
- Fix `f_check_interpolation_2D` and `f_check_interpolation_3D` in `m_model.fpp` which only returned the interpolation decision from the **last** edge/triangle in the loop, silently discarding earlier `true` results.

## Bug Details
Both subroutines loop over edges (2D) or triangles (3D), checking if any edge length exceeds the cell width. However, the `interpolate` flag was unconditionally overwritten on every iteration:

```fortran
if (l1 > cell_width) then
    interpolate = .true.
else
    interpolate = .false.   ! ← clobbers previous .true.
end if
```

If edge 5 of 10 needs interpolation but the last edge doesn't, the function returns `.false.`, causing the caller to skip interpolation when it's needed. This can produce incorrect levelset fields for OBJ models where mesh resolution varies across the surface.

## Fix
Return early on the first edge that exceeds the cell width. Since `interpolate` is initialized to `.false.` before the loop, only the `true` case needs handling.

## Test plan
- [ ] Existing OBJ model tests pass
- [ ] 3D immersed boundary cases with non-uniform triangle meshes produce correct levelsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix interpolation checks to correctly detect when any boundary edge/triangle needs interpolation

### What Changed
- The 2D and 3D interpolation-check routines now stop and report "interpolate needed" as soon as any edge or triangle side is longer than the cell width, instead of using the last edge's result.
- Calls that previously could skip interpolation when an earlier edge required it will now trigger interpolation as intended.
- Observable behavior: OBJ and other imported meshes with non-uniform edge lengths produce correct levelset interpolation decisions.

### Impact
`✅ Fewer skipped interpolations for OBJ and imported meshes`
`✅ Correct levelset shapes for non-uniform meshes`
`✅ Fewer rendering/artifact errors at mesh boundaries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

Fixes #1219