### PR TITLE
Fix y-velocity perturbation using already-modified x-velocity

### DIFF
--- a/src/pre_process/m_perturbation.fpp
+++ b/src/pre_process/m_perturbation.fpp
@@ -83,8 +83,8 @@ contains
                     perturb_alpha = q_prim_vf(E_idx + perturb_flow_fluid)%sf(i, j, k)
                     call random_number(rand_real)
                     rand_real = rand_real*perturb_flow_mag
-                    q_prim_vf(mom_idx%beg)%sf(i, j, k) = (1._wp + rand_real)*q_prim_vf(mom_idx%beg)%sf(i, j, k)
                     q_prim_vf(mom_idx%end)%sf(i, j, k) = rand_real*q_prim_vf(mom_idx%beg)%sf(i, j, k)
+                    q_prim_vf(mom_idx%beg)%sf(i, j, k) = (1._wp + rand_real)*q_prim_vf(mom_idx%beg)%sf(i, j, k)
                     if (bubbles_euler) then
                         q_prim_vf(alf_idx)%sf(i, j, k) = (1._wp + rand_real)*q_prim_vf(alf_idx)%sf(i, j, k)
                     end if


### PR DESCRIPTION
## **User description**
## Summary
- Fix `s_perturb_surrounding_flow` in `m_perturbation.fpp` where the y-velocity perturbation reads the x-velocity after it has already been modified, producing an unintended coupled perturbation.

## Bug Details
The perturbation code modifies x-velocity in place, then uses the modified value for the y-perturbation:

```fortran
q_prim_vf(mom_idx%beg)%sf(i,j,k) = (1 + r) * vx    ! line 86: vx overwritten with (1+r)*vx
q_prim_vf(mom_idx%end)%sf(i,j,k) = r * vx_modified   ! line 87: reads (1+r)*vx instead of vx
```

The y-velocity ends up as `r * (1+r) * vx_original` instead of the intended `r * vx_original`. This introduces an unintended `(1+r)` scaling factor in the y-perturbation, coupling it to the x-perturbation magnitude.

## Fix
Swap the order of the two assignments so the y-velocity is computed from the original x-velocity before x-velocity is modified:

```fortran
q_prim_vf(mom_idx%end)%sf(i,j,k) = r * vx            ! y-vel from original x-vel
q_prim_vf(mom_idx%beg)%sf(i,j,k) = (1 + r) * vx      ! then modify x-vel
```

## Test plan
- [ ] Flow perturbation cases produce physically consistent velocity fields
- [ ] y-velocity perturbation magnitude matches x-velocity perturbation magnitude (same `rand_real` scaling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix y-velocity perturbation order so y uses original x-velocity

### What Changed
- The y-velocity perturbation now uses the original x-velocity value before x is modified, preventing an extra (1+r) scaling on y
- The x-velocity perturbation is applied afterwards as (1 + r) * x, preserving the intended independent scalings
- Surrounding-flow perturbations for volume fraction keep the same random scaling behavior

### Impact
`✅ Correct y-velocity scaling`
`✅ Consistent surrounding flow perturbations`
`✅ Fewer unintended coupled velocity errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

Fixes #1222