### PR TITLE
Fix simplex noise using mod(i,255) instead of iand(i,255)

### DIFF
--- a/src/pre_process/m_simplex_noise.fpp
+++ b/src/pre_process/m_simplex_noise.fpp
@@ -205,8 +205,8 @@ contains
         x2 = x0 - 1._wp + 2._wp*G2
         y2 = y0 - 1._wp + 2._wp*G2
 
-        ii = mod(i, 255)
-        jj = mod(j, 255)
+        ii = iand(i, 255)
+        jj = iand(j, 255)
 
         gi0 = mod(p_vec(ii + p_vec(jj)), 10) + 1
         gi1 = mod(p_vec(ii + i1 + p_vec(jj + j1)), 10) + 1


### PR DESCRIPTION
## **User description**
## Summary
- Fix 2D simplex noise in `m_simplex_noise.fpp` using `mod(i, 255)` which produces range 0-254, skipping index 255 of the permutation table.

## Bug Details
The simplex noise implementation hashes grid coordinates into the permutation table using:

```fortran
ii = mod(i, 255)    ! range 0..254
jj = mod(j, 255)    ! range 0..254
```

The permutation table `p_vec` has 256 entries (indices 0-255). Using `mod(i, 255)` gives range 0-254, so `p_vec(255)` is never accessed. This introduces a subtle bias in the noise distribution — one permutation entry is systematically excluded, slightly reducing the randomness of the noise pattern.

The standard simplex noise algorithm uses `mod(i, 256)` or equivalently `iand(i, 255)` (bitwise AND with 255) to wrap indices to the full 0-255 range.

## Fix
Replace `mod(i, 255)` with `iand(i, 255)` which gives the correct 0-255 range and is also faster (bitwise operation vs division).

## Test plan
- [ ] Simplex noise perturbation cases still produce valid noise fields
- [ ] All 256 permutation table entries are now reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix incorrect index wrapping in 2D simplex noise so all permutation entries are used

### What Changed
- Index wrapping for the simplex noise permutation now covers the full 0–255 range, so the previously skipped permutation entry is reachable
- Noise outputs no longer exclude one permutation value, removing a subtle bias in generated noise patterns
- Index wrapping uses a bitwise operation which is marginally faster than the previous modulus approach

### Impact
`✅ Correct simplex noise distribution`
`✅ Full permutation table coverage (0–255)`
`✅ Slightly faster noise generation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

Fixes #1223