### PR TITLE
Fix domain decomposition overwriting muscl_order

### DIFF
--- a/src/common/m_mpi_common.fpp
+++ b/src/common/m_mpi_common.fpp
@@ -1146,8 +1146,6 @@ contains
 
         if (igr) then
             recon_order = igr_order
-        else
-            recon_order = weno_order
         end if
 
         ! 3D Cartesian Processor Topology


### PR DESCRIPTION
## **User description**
## Summary
- The IGR conditional block in the domain decomposition routine had an `else` branch that unconditionally set `recon_order = weno_order`
- This overwrote the correct `muscl_order` value that was set by the `recon_type` check earlier in the function
- Fix removes the `else` branch so `recon_order` is only overridden when IGR is actually active

## Test plan
- [ ] Verify MUSCL reconstruction order is preserved through domain decomposition
- [ ] May need golden file regeneration for MUSCL-based test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Preserve MUSCL reconstruction order during domain decomposition

### What Changed
- Removed an unconditional reset to WENO in an early IGR check so the reconstruction order set by the recon_type selection (e.g., MUSCL) is no longer overwritten when IGR is inactive
- IGR still forces its own reconstruction order when active; when IGR is off, the previously chosen reconstruction (MUSCL or other) is retained
- Domain decomposition no longer causes unexpected switches to WENO in normal (non-IGR) runs

### Impact
`✅ Preserves MUSCL during domain decomposition`
`✅ Fewer unexpected reconstruction resets`
`✅ More consistent reconstruction order across processors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
