### PR TITLE
Fix GPU example, compiler matrix, and AMD flang in CLAUDE.md docs

### DIFF
--- a/.claude/rules/common-pitfalls.md
+++ b/.claude/rules/common-pitfalls.md
@@ -36,10 +36,10 @@
 - Boundary condition symmetry requirements must be maintained
 
 ## Compiler-Specific Issues
-- Code must compile on gfortran, nvfortran, Cray ftn, and Intel ifx
+- CI-gated compilers (must always pass): gfortran, nvfortran, Cray ftn, and Intel ifx
+- AMD flang is additionally supported for `--gpu mp` builds but not in the CI matrix
 - Each compiler has different strictness levels and warning behavior
 - Fypp macros must expand correctly for both GPU and CPU builds
-- GPU builds only work with nvfortran, Cray ftn, and AMD flang
 
 ## Test System
 - Tests are generated **programmatically** in `toolchain/mfc/test/cases.py`, not standalone files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,8 @@
 MFC is an exascale multi-physics CFD solver written in modern Fortran 2008+ with Fypp
 preprocessing. It has three executables (pre_process, simulation, post_process), a Python
 toolchain for building/running/testing, and supports GPU acceleration via OpenACC and
-OpenMP target offload. It must compile with gfortran, nvfortran, Cray ftn, and Intel ifx.
+OpenMP target offload. It must compile with gfortran, nvfortran, Cray ftn, and Intel ifx (CI-gated).
+AMD flang is additionally supported for OpenMP target offload GPU builds.
 
 ## Commands
 
@@ -167,4 +168,4 @@ When reviewing PRs, prioritize in this order:
 4. MPI correctness (halo exchange, buffer sizing, GPU_UPDATE calls)
 5. GPU code (GPU_* Fypp macros only, no raw pragmas)
 6. Physics consistency (pressure formula matches model_eqns)
-7. Compiler portability (all four compilers)
+7. Compiler portability (4 CI-gated compilers + AMD flang for GPU)


### PR DESCRIPTION
## **User description**
## Summary
Follow-up to #1255. Fixes accuracy issues found during review of the CLAUDE.md and `.claude/rules/` documentation:

- **Replace misleading GPU example**: The `GPU_PARALLEL` + `GPU_LOOP` block macro example showed a pattern not used anywhere in the codebase (0 occurrences). Replaced with the real `GPU_PARALLEL_LOOP` / `END_GPU_PARALLEL_LOOP` pattern (750+ occurrences across 33 files). Added warning that `GPU_LOOP` emits empty directives on Cray and AMD compilers, causing silent serial execution.
- **Fix compiler-backend matrix**: Marked Intel ifx and GNU gfortran as "Experimental" for `--gpu mp` (CMake has code paths but they're not CI-tested). Previously marked as "No" despite CMake support.
- **Resolve AMD flang inconsistency**: AMD flang was simultaneously absent from the "four required compilers" list and listed as a GPU compiler. Now consistently described as "additionally supported for GPU builds but not in the CI matrix" across all three files.

## Test plan
- [ ] Documentation-only change — no code impact
- [ ] Verify GPU macro example matches real codebase patterns
- [ ] Verify compiler matrix matches CMakeLists.txt support

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix GPU example and clarify compiler/GPU support across docs

### What Changed
- Replaced a misleading GPU_PARALLEL + GPU_LOOP example with the actual GPU_PARALLEL_LOOP / END_GPU_PARALLEL_LOOP pattern used across the codebase
- Added explicit warning that GPU_LOOP emits empty directives on Cray and AMD compilers, which can cause silent serial execution for spatial loops
- Clarified that GPU_PARALLEL is intended for scalar reductions, not for spatial loop parallelism
- Marked CI-gated compilers (gfortran, nvfortran, Cray ftn, Intel ifx) and noted AMD flang is supported for OpenMP/GPU builds but is not part of the CI matrix
- Updated compiler matrix to show GNU gfortran and Intel ifx as "Experimental" for OpenMP target offload and adjusted entries for AMD flang

### Impact
`✅ Clearer GPU loop guidance`
`✅ Fewer silent serial executions on Cray/AMD`
`✅ Clearer compiler support and CI expectations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compiler support guidance to clarify CI-gated compilers and expanded AMD flang availability for GPU builds.
  * Clarified GPU_PARALLEL macro semantics and updated guidance for scalar reductions and spatial loop patterns.
  * Refreshed compiler compatibility matrix with current OpenACC and OpenMP CPU/GPU support status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->