### PR TITLE
Add AI review trigger commands to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,12 +31,10 @@ See the [developer guide](https://mflowcode.github.io/documentation/contributing
 
 </details>
 
-<details>
-<summary><strong>AI code reviews</strong></summary>
+## AI code reviews
 
 Reviews are not triggered automatically. To request a review, comment on the PR:
 - `@coderabbitai review` — incremental review (new changes only)
 - `@coderabbitai full review` — full review from scratch
 - `/review` — Qodo review
-
-</details>
+- `/improve` — Qodo code suggestions


### PR DESCRIPTION
## Summary
- AI code reviews (CodeRabbit, Qodo) are no longer triggered automatically on every push
- Adds a visible section to the PR template with commands to manually request reviews

## Test plan
- [ ] Verify new PR descriptions include the AI review section
- [ ] Confirm `@coderabbitai review` and `/review` / `/improve` commands work from PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request template with AI code review guidelines and command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->