### PR TITLE
Trigger CI on draft-to-ready PR conversion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add `ready_for_review` to `pull_request` activity types in `test.yml`
- Without this, converting a draft PR to ready-for-review does not re-trigger CI (including self-hosted jobs), requiring an empty commit or force-push as a workaround
- GitHub Actions `pull_request` defaults to `[opened, synchronize, reopened]` — this adds `ready_for_review` to that list

## Change
One line in `.github/workflows/test.yml`:
```yaml
pull_request:
+   types: [opened, synchronize, reopened, ready_for_review]
```

## Test plan
- [x] Create a draft PR, then convert to ready — verify self-hosted jobs trigger
- [x] Verify normal push-triggered CI still works as before