### PR TITLE
Fix serial I/O missing beta for bubbles_lagrange in post_process

### DIFF
--- a/src/post_process/m_data_input.f90
+++ b/src/post_process/m_data_input.f90
@@ -312,6 +312,10 @@ contains
                       STATUS='old', ACTION='read')
                 read (1) q_cons_vf(i)%sf(0:m, 0:n, 0:p)
                 close (1)
+            else if (bubbles_lagrange .and. i == beta_idx) then
+                ! beta (Lagrangian void fraction) is not written by pre_process
+                ! for t_step_start; initialize to zero.
+                q_cons_vf(i)%sf(0:m, 0:n, 0:p) = 0._wp
             else
                 call s_mpi_abort('File q_cons_vf'//trim(file_num)// &
                                  '.dat is missing in '//trim(t_step_dir)// &

--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -476,6 +476,19 @@ contains
             write (2) q_cons_vf(i)%sf(0:m, 0:n, 0:p); close (2)
         end do
 
+        ! Lagrangian beta (void fraction) written as q_cons_vf(sys_size+1) to
+        ! match the parallel I/O path and allow post_process to read it.
+        if (bubbles_lagrange) then
+            write (file_path, '(A,I0,A)') trim(t_step_dir)//'/q_cons_vf', &
+                sys_size + 1, '.dat'
+
+            open (2, FILE=trim(file_path), &
+                  FORM='unformatted', &
+                  STATUS='new')
+
+            write (2) beta%sf(0:m, 0:n, 0:p); close (2)
+        end if
+
         if (qbmm .and. .not. polytropic) then
             do i = 1, nb
                 do r = 1, nnode


### PR DESCRIPTION
## Summary

With `parallel_io=F` (serial/no-MPI builds), `post_process` aborts with `q_cons_vf8.dat is missing` for any `bubbles_lagrange=T` case. This is a regression that only affects serial builds — parallel builds (`parallel_io=T`) work correctly.

**Root cause:** Two issues in the serial I/O path:

1. `s_write_serial_data_files` did not write the Lagrangian void fraction (`beta`) to `p_all/` as `q_cons_vf(sys_size+1).dat`, while `s_write_parallel_data_files` correctly does so via `alt_sys = sys_size + 1`. Meanwhile, `post_process` always includes `beta_idx` in `sys_size` when `bubbles_lagrange=T`, so it always expects this file.

2. `t_step_start` output is written by `pre_process`, which has no knowledge of Lagrangian beta. So even with fix #1, `t_step_start = 0` would still be missing the beta file.

## Changes

- **`src/simulation/m_data_output.fpp`**: write `beta` as `q_cons_vf(sys_size+1).dat` in `s_write_serial_data_files`, mirroring the parallel I/O path.
- **`src/post_process/m_data_input.f90`**: when `bubbles_lagrange=T` and `i == beta_idx` and the file is absent, initialize beta to zero instead of aborting. This handles the `t_step_start` timestep written by `pre_process`.

## Test plan

- [ ] Run a `bubbles_lagrange=T` case with `parallel_io=F` through all stages (pre_process → simulation → post_process) and confirm no abort
- [ ] Confirm existing `parallel_io=T` Lagrangian cases are unaffected
- [ ] Confirm non-Lagrangian cases are unaffected (error path still triggers for truly missing files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)