### PR TITLE
Exclude OLCF Summit URL from link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -28,4 +28,5 @@ exclude = [
     "https://cpe\\.ext\\.hpe\\.com",                   # HPE Cray docs have broken SSL cert
     "https://sc22\\.supercomputing\\.org",              # Returns 415 to automated requests
     "https://strawberryperl\\.com",                    # Frequently times out
+    "https://www\\.olcf\\.ornl\\.gov/summit",            # Returns 503 to automated requests
 ]


### PR DESCRIPTION
## Summary

- Exclude `https://www.olcf.ornl.gov/summit` from Lychee link checks

The OLCF site returns 503 to automated requests and sends a 1-hour rate limit backoff, causing the docs CI to fail.

## Test plan

- [ ] Docs CI passes with this change