### PR TITLE
Fix Intel CI env corruption and remove Python 3.14 pinning

### DIFF
--- a/.github/workflows/lint-toolchain.yml
+++ b/.github/workflows/lint-toolchain.yml
@@ -14,11 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: MFC Python setup
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.14'
-
     - name: Initialize MFC
       run: ./mfc.sh init
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,13 +123,13 @@ jobs:
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get update
           sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-mpi intel-oneapi-mpi-devel
+          # Export only new/changed env vars from setvars.sh.
+          # `printenv >> $GITHUB_ENV` dumps all vars including shell internals
+          # with special characters that corrupt GITHUB_ENV parsing.
+          printenv | sort > /tmp/env_before
           source /opt/intel/oneapi/setvars.sh
-          printenv >> $GITHUB_ENV
-
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.14'
+          printenv | sort > /tmp/env_after
+          diff /tmp/env_before /tmp/env_after | grep '^>' | sed 's/^> //' >> $GITHUB_ENV
 
       - name: Get system info for cache key
         id: sys-info


### PR DESCRIPTION
## Summary
- Replace `printenv >> $GITHUB_ENV` with a before/after diff that exports only vars added/changed by Intel `setvars.sh`. The old approach dumped all env vars including shell internals with special characters, causing `"Invalid format 'sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB'"` errors in GitHub Actions.
- Remove explicit Python 3.14 setup from `test.yml` and `lint-toolchain.yml` (runners already have a suitable Python).

## Test plan
- [ ] Ubuntu Intel debug job passes (previously failing with env corruption)
- [ ] Ubuntu Intel no-debug job passes
- [ ] Lint toolchain job passes without explicit Python 3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)