### PR TITLE
New DeltaAI Module

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -70,7 +70,7 @@ o-gpu nvhpc cuda/12.3.0 cmake/3.26.3
 o-gpu CC=nvc CXX=nvc++ FC=nvfortran
 
 dai     NCSA DeltaAI
-dai-all python cmake nvhpc-openmpi3/24.3 cuda
+dai-all python cmake nvidia/25.5
 dai-all CC=nvc CXX=nvc++ FC=nvfortran
 dai-gpu MFC_CUDA_CC=89,90
 


### PR DESCRIPTION
## Description

Replaces old DeltaAI modules with new working module.

Fixes #(issue)

### Type of change

- [x] Bug fix

## Testing

I ran the `examples/3D_performance_test/` case with a 360^3 grid on 1, 2, 4, and 8 GPUs on DeltaAI. See results below:
- 1 rank: 0.4866 ns/gp/eq/rhs
- 2 rank: 0.2626 ns/gp/eq/rhs
- 4 rank: 0.1421 ns/gp/eq/rhs
- 8 rank: 0.0779 ns/gp/eq/rhs (2 Nodes)
