### PR TITLE
ci: clean stale .out files after checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,6 +234,9 @@ jobs:
           # submit-slurm-job.sh can detect and cancel stale SLURM jobs on retry.
           clean: false
 
+      - name: Clean stale output files
+        run:  rm -f *.out
+
       - name: Build (login node)
         if:   matrix.cluster != 'phoenix'
         timeout-minutes: 60
@@ -316,6 +319,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
+
+      - name: Clean stale output files
+        run:  rm -f *.out
 
       - name: Pre-Build (SLURM)
         if:   matrix.cluster == 'phoenix'


### PR DESCRIPTION
## Summary
- Delete stale `.out` files after checkout in both the test suite and case-optimization jobs
- Prevents the `Print Logs` step (`if: always()`) from showing output from a **previous** workflow run when the current run fails early
- Leaves `.slurm_job_id` files intact so `submit-slurm-job.sh` can still detect and cancel stale SLURM jobs

## Context
When a multi-step CI job (like case-optimization) fails at the prebuild step, the "Run Case-Optimization Tests" step is skipped. But the `Print Logs` step runs unconditionally and cats whatever `.out` files exist — which may be from a previous successful run, making it look like the current run succeeded.

## Test plan
- [ ] Verify case-optimization job shows no output in Print Logs when prebuild fails
- [ ] Verify normal successful runs still show correct logs
- [ ] Verify stale SLURM job cancellation still works (`.slurm_job_id` files preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)