### PR TITLE
fix: prohibit weno_Re_flux when viscous is disabled

### DIFF
--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -826,6 +826,10 @@ class CaseValidator:
             # Check Re(1) requirement
             self.prohibit(Re1 is None and viscous, f"viscous is set to true, but fluid_pp({i})%Re(1) is not specified")
 
+        # weno_Re_flux requires viscous
+        weno_Re_flux = self.get("weno_Re_flux", "F") == "T"
+        self.prohibit(weno_Re_flux and not viscous, "weno_Re_flux requires viscous to be enabled")
+
     def check_mhd_simulation(self):
         """Checks MHD constraints specific to simulation"""
         mhd = self.get("mhd", "F") == "T"


### PR DESCRIPTION
## Summary
- Adds a validation check in `case_validator.py` to error when `weno_Re_flux = T` but `viscous = F`, since `weno_Re_flux` requires viscosity to be enabled.

## Test plan
- [x] `./mfc.sh precheck -j 8` passes (all 5 checks)
- [ ] CI lint gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)