### PR TITLE
ci: skip pre-commit hook on automated cache commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "Coverage cache unchanged."
           else
-            git commit -m "Regenerate gcov coverage cache [skip ci]"
+            git commit --no-verify -m "Regenerate gcov coverage cache [skip ci]"
             # Rebase onto latest master in case it advanced during the build
             # (which can take 20-240 minutes). Only test_coverage_cache.json.gz
             # is changed, so rebase conflicts are essentially impossible.


### PR DESCRIPTION
## Summary

- The `rebuild-cache` CI job's `git commit` triggers the pre-commit hook, which runs `precheck` on the entire repo. If any other merged PR introduced a spelling/lint issue, the automated cache commit fails — even though only `test_coverage_cache.json.gz` is being committed.
- Fix: add `--no-verify` to the automated `git commit` in the "Commit Cache to Master" step.

Fixes the failure in https://github.com/MFlowCode/MFC/actions/runs/23218089807/job/67484083040

## Test plan

- [ ] `rebuild-cache` job succeeds on the next push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)