### PR TITLE
ci: use admin token for cache push to bypass branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,8 @@ jobs:
 
       - name: Commit Cache to Master
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
+        env:
+          CACHE_PUSH_TOKEN: ${{ secrets.CACHE_PUSH_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -161,7 +163,10 @@ jobs:
             # is changed, so rebase conflicts are essentially impossible.
             git fetch origin master
             git rebase origin/master
-            git push origin HEAD:refs/heads/master
+            # Push using admin token to bypass branch protection rulesets.
+            # The default GITHUB_TOKEN lacks the Repository Admin role needed
+            # to push directly to master.
+            git push https://x-access-token:${CACHE_PUSH_TOKEN}@github.com/MFlowCode/MFC.git HEAD:refs/heads/master
           fi
 
   github:


### PR DESCRIPTION
## Summary

- The `rebuild-cache` job's push to master is blocked by GitHub repository rulesets (`GH013`). The default `GITHUB_TOKEN` doesn't have the Repository Admin role needed to bypass branch protection.
- Fix: use `CACHE_PUSH_TOKEN` secret (admin-scoped) for the push step only.

Follows up on #1320.

## Test plan

- [ ] `rebuild-cache` job pushes cache to master successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)