### PR TITLE
fix: handle stale runner processes with deleted binaries

### DIFF
--- a/misc/runners/common/runner-lib.sh
+++ b/misc/runners/common/runner-lib.sh
@@ -65,6 +65,7 @@ find_pids() {
     ssh $SSH_OPTS "$1" '
         for p in $(ps aux | grep Runner.Listener | grep -v grep | awk "{print \$2}"); do
             exe=$(readlink -f /proc/$p/exe 2>/dev/null || true)
+            exe=${exe% (deleted)}
             [ "$exe" = "'"$2"'/bin/Runner.Listener" ] && echo "$p"
         done
     ' 2>/dev/null | grep -E '^[0-9]+$' | tr '\n' ' ' || true


### PR DESCRIPTION
## Summary
- `find_pids` now strips the ` (deleted)` suffix that Linux appends to `/proc/PID/exe` when a runner binary is replaced on disk
- Without this, runners with stale binaries are invisible to `find_node` and `restart-all`, appearing offline even though the process is alive
- Fixes the case where `restart-all` reports runners as OFFLINE and skips them instead of restarting them

## Test plan
- [ ] Verify `restart-all` detects and restarts runners whose binaries have been updated on disk
- [ ] Verify `find_node` correctly locates runners with deleted binaries
- [ ] Verify `stop_runner` correctly kills stale processes before starting fresh ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)