### PR TITLE
lint: add pylint directive check and remove dead directives

### DIFF
--- a/toolchain/mfc/lint_source.py
+++ b/toolchain/mfc/lint_source.py
@@ -312,6 +312,33 @@ def check_junk_comments(repo_root: Path) -> list[str]:
     return errors
 
 
+def check_pylint_directives(repo_root: Path) -> list[str]:
+    """Flag ``# pylint:`` directives in Python files.
+
+    MFC uses ruff for linting; leftover pylint directives are dead code.
+    """
+    errors: list[str] = []
+    pylint_re = re.compile(r"#\s*pylint\s*:", re.IGNORECASE)
+    self_path = Path(__file__).resolve()
+
+    for subdir in ["examples", "benchmarks", "toolchain"]:
+        d = repo_root / subdir
+        if not d.exists():
+            continue
+        for py in sorted(d.rglob("*.py")):
+            if py.resolve() == self_path:
+                continue
+            lines = py.read_text(encoding="utf-8").splitlines()
+            rel = py.relative_to(repo_root)
+
+            for i, line in enumerate(lines):
+                match = pylint_re.search(line)
+                if match:
+                    errors.append(f"  {rel}:{i + 1} pylint directive. Fix: remove (use ruff noqa comments if needed)")
+
+    return errors
+
+
 def main():
     repo_root = Path(__file__).resolve().parents[2]
 
@@ -324,6 +351,7 @@ def main():
     all_errors.extend(check_fypp_list_duplicates(repo_root))
     all_errors.extend(check_duplicate_lines(repo_root))
     all_errors.extend(check_hardcoded_byte_size(repo_root))
+    all_errors.extend(check_pylint_directives(repo_root))
 
     if all_errors:
         print("Source lint failed:")

--- a/toolchain/mfc/test/coverage.py
+++ b/toolchain/mfc/test/coverage.py
@@ -206,7 +206,7 @@ def _compute_gcov_prefix_strip(root_dir: str) -> str:
     return str(len(Path(real_root).parts) - 1)  # -1 excludes root '/'
 
 
-def _collect_single_test_coverage(  # pylint: disable=too-many-locals
+def _collect_single_test_coverage(
     uuid: str,
     test_gcda: str,
     root_dir: str,
@@ -286,7 +286,7 @@ def _collect_single_test_coverage(  # pylint: disable=too-many-locals
     return uuid, sorted(coverage)
 
 
-def _run_single_test_direct(test_info: dict, gcda_dir: str, strip: str) -> tuple:  # pylint: disable=too-many-locals
+def _run_single_test_direct(test_info: dict, gcda_dir: str, strip: str) -> tuple:
     """
     Run a single test by invoking Fortran executables directly.
 
@@ -352,7 +352,7 @@ def _run_single_test_direct(test_info: dict, gcda_dir: str, strip: str) -> tuple
     return uuid, test_gcda, failures
 
 
-def _prepare_test(case) -> dict:  # pylint: disable=too-many-locals
+def _prepare_test(case) -> dict:
     """
     Prepare a test for direct execution: create directory, generate .inp
     files, and resolve binary paths.  All Python/toolchain overhead happens
@@ -445,7 +445,7 @@ def _prepare_test(case) -> dict:  # pylint: disable=too-many-locals
     }
 
 
-def build_coverage_cache(  # pylint: disable=too-many-locals,too-many-statements
+def build_coverage_cache(
     root_dir: str,
     cases: list,
     n_jobs: Optional[int] = None,
@@ -490,7 +490,7 @@ def build_coverage_cache(  # pylint: disable=too-many-locals,too-many-statements
     for i, case in enumerate(cases):
         try:
             test_infos.append(_prepare_test(case))
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             cons.print(f"  [yellow]Warning: skipping {case.get_uuid()} — prep failed: {exc}[/yellow]")
         if (i + 1) % 100 == 0 or (i + 1) == len(cases):
             cons.print(f"  [{i + 1:3d}/{len(cases):3d}] prepared")
@@ -507,7 +507,7 @@ def build_coverage_cache(  # pylint: disable=too-many-locals,too-many-statements
             for i, future in enumerate(as_completed(futures)):
                 try:
                     uuid, test_gcda, failures = future.result()
-                except Exception as exc:  # pylint: disable=broad-except
+                except Exception as exc:
                     info = futures[future]
                     cons.print(f"  [yellow]Warning: {info['uuid']} failed to run: {exc}[/yellow]")
                     continue
@@ -560,7 +560,7 @@ def build_coverage_cache(  # pylint: disable=too-many-locals,too-many-statements
             for future in as_completed(futures):
                 try:
                     uuid, coverage = future.result()
-                except Exception as exc:  # pylint: disable=broad-except
+                except Exception as exc:
                     uuid = futures[future]
                     cons.print(f"  [yellow]Warning: {uuid} coverage failed: {exc}[/yellow]")
                     # Do NOT store entry — absent entries are conservatively

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -113,7 +113,7 @@ def __filter(cases_) -> typing.Tuple[typing.List[TestCase], typing.List[TestCase
 
     # --only-changes: filter based on file-level gcov coverage
     if ARG("only_changes"):
-        from .coverage import (  # pylint: disable=import-outside-toplevel
+        from .coverage import (
             filter_tests_by_coverage,
             get_changed_files,
             load_coverage_cache,
@@ -234,7 +234,7 @@ def test():
         return
 
     if ARG("build_coverage_cache"):
-        from .coverage import build_coverage_cache  # pylint: disable=import-outside-toplevel
+        from .coverage import build_coverage_cache
 
         all_cases = [b.to_case() for b in cases]
 

--- a/toolchain/mfc/test/test_coverage_unit.py
+++ b/toolchain/mfc/test/test_coverage_unit.py
@@ -7,7 +7,6 @@ Run with:
 These tests are fully offline (no build, no git, no gcov binary required).
 They use mocks and in-memory data structures to verify logic.
 """
-# pylint: disable=protected-access,exec-used,too-few-public-methods,wrong-import-position
 
 import gzip
 import hashlib


### PR DESCRIPTION
## Summary
- Add `check_pylint_directives()` to `lint_source.py` that flags any `# pylint:` directives in Python files under `examples/`, `benchmarks/`, and `toolchain/`
- Remove all 10 existing pylint directive comments across `coverage.py`, `test.py`, and `test_coverage_unit.py`
- MFC uses ruff for linting, so these directives were dead code

## Test plan
- [x] `./mfc.sh precheck -j 8` passes (new check integrated into existing lint pipeline)
- [x] Verify no remaining `# pylint:` directives in scanned directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)