### PR TITLE
ci: don't cancel push-to-master CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PRs: group by branch (new push cancels old). Push to master: unique per SHA (never cancelled).
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   lint-gate:
@@ -162,11 +163,12 @@ jobs:
             # (which can take 20-240 minutes). Only test_coverage_cache.json.gz
             # is changed, so rebase conflicts are essentially impossible.
             git fetch origin master
-            git rebase origin/master
+            git rebase origin/master || { git rebase --abort; echo "Rebase conflict — cache will be regenerated on the next trigger."; exit 0; }
             # Push using admin token to bypass branch protection rulesets.
             # The default GITHUB_TOKEN lacks the Repository Admin role needed
-            # to push directly to master.
-            git push https://x-access-token:${CACHE_PUSH_TOKEN}@github.com/MFlowCode/MFC.git HEAD:refs/heads/master
+            # to push directly to master. Use credential helper to avoid
+            # leaking the token in git error messages.
+            git -c "http.https://github.com/.extraheader=Authorization: basic $(echo -n "x-access-token:${CACHE_PUSH_TOKEN}" | base64)" push origin HEAD:refs/heads/master
           fi
 
   github:


### PR DESCRIPTION
## Summary

Push-to-master CI runs share a concurrency group with `cancel-in-progress: true`. Every PR merge cancels the previous master run, so self-hosted tests and `rebuild-cache` never complete on active days.

Fix: give each push a unique concurrency group (by SHA) so master runs don't cancel each other. PRs still cancel old runs on the same branch.

```yaml
# Before:
group: ${{ github.workflow }}-${{ github.ref }}
cancel-in-progress: true

# After:
group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
cancel-in-progress: ${{ github.event_name != 'push' }}
```

## Test plan

- [ ] Multiple master pushes run concurrently without cancelling each other
- [ ] PR pushes still cancel previous runs on the same branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)