### PR TITLE
ci: remove cases.py, definitions.py, and case_validator.py from ALWAYS_RUN_ALL for smarter pruning

### DIFF
--- a/toolchain/mfc/test/coverage.py
+++ b/toolchain/mfc/test/coverage.py
@@ -37,7 +37,13 @@ COVERAGE_CACHE_PATH = Path(common.MFC_ROOT_DIR) / "toolchain/mfc/test/test_cover
 
 # Changes to these files trigger the full test suite.
 # CPU coverage cannot tell us about GPU directive changes (macro files), and
-# toolchain files define or change the set of tests themselves.
+# toolchain files that affect .inp generation or test execution must run all.
+#
+# NOT included (safe to prune):
+#   - cases.py: adding a test doesn't invalidate existing coverage; new tests
+#     are conservatively included (not in cache -> always runs).
+#   - definitions.py: adding a parameter doesn't affect tests that don't use it;
+#     the PR's .fpp changes trigger the relevant tests via coverage overlap.
 ALWAYS_RUN_ALL = frozenset(
     [
         "CMakeLists.txt",
@@ -48,9 +54,7 @@ ALWAYS_RUN_ALL = frozenset(
         "src/common/include/macros.fpp",
         "src/common/include/case.fpp",
         "toolchain/mfc/test/case.py",
-        "toolchain/mfc/test/cases.py",
         "toolchain/mfc/test/coverage.py",
-        "toolchain/mfc/params/definitions.py",
         "toolchain/mfc/run/input.py",
         "toolchain/mfc/case_validator.py",
     ]

--- a/toolchain/mfc/test/test_coverage_unit.py
+++ b/toolchain/mfc/test/test_coverage_unit.py
@@ -223,14 +223,16 @@ class TestShouldRunAllTests(unittest.TestCase):
     def test_macros_fpp_triggers_all(self):
         assert should_run_all_tests({"src/common/include/macros.fpp"}) is True
 
-    def test_cases_py_triggers_all(self):
-        assert should_run_all_tests({"toolchain/mfc/test/cases.py"}) is True
+    def test_cases_py_does_not_trigger_all(self):
+        """cases.py removed from ALWAYS_RUN_ALL: new tests are conservatively included."""
+        assert should_run_all_tests({"toolchain/mfc/test/cases.py"}) is False
 
     def test_case_py_triggers_all(self):
         assert should_run_all_tests({"toolchain/mfc/test/case.py"}) is True
 
-    def test_definitions_py_triggers_all(self):
-        assert should_run_all_tests({"toolchain/mfc/params/definitions.py"}) is True
+    def test_definitions_py_does_not_trigger_all(self):
+        """definitions.py removed from ALWAYS_RUN_ALL: new params are covered by .fpp changes."""
+        assert should_run_all_tests({"toolchain/mfc/params/definitions.py"}) is False
 
     def test_input_py_triggers_all(self):
         assert should_run_all_tests({"toolchain/mfc/run/input.py"}) is True
@@ -448,10 +450,10 @@ class TestDesignCornerCases(unittest.TestCase):
 
     def test_non_fpp_always_run_all_detected(self):
         """
-        End-to-end: diff lists only cases.py (non-.fpp) ->
+        End-to-end: diff lists only case.py (non-.fpp, in ALWAYS_RUN_ALL) ->
         _parse_diff_files includes it -> should_run_all_tests fires.
         """
-        files = _parse_diff_files("toolchain/mfc/test/cases.py\n")
+        files = _parse_diff_files("toolchain/mfc/test/case.py\n")
         assert should_run_all_tests(files) is True
 
     def test_niche_feature_pruning(self):


### PR DESCRIPTION
## Summary

Most physics PRs change `cases.py` (adding tests) and `definitions.py` (adding parameters). With both in `ALWAYS_RUN_ALL`, these PRs always run the full test suite, defeating the coverage-based pruning.

Neither file needs to trigger full runs:
- **`cases.py`**: adding a test doesn't invalidate existing coverage data. New tests aren't in the cache → conservatively included (always run).
- **`definitions.py`**: adding a parameter doesn't affect tests that don't use it. The PR's `.fpp` changes trigger the relevant tests via coverage overlap.

Files that remain in `ALWAYS_RUN_ALL` (changes here affect all test outputs):
- `CMakeLists.txt`, GPU macro `.fpp` files, `case.fpp`
- `case.py`, `input.py`, `case_validator.py`, `coverage.py`
- `toolchain/cmake/`

## Test plan

- [ ] PR changing `cases.py` + `.fpp` files: pruning kicks in (not full suite)
- [ ] New tests not in cache are still included conservatively

🤖 Generated with [Claude Code](https://claude.com/claude-code)