### PR TITLE
Fix lint_param_docs parser bugs and deduplicate CI source lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,20 +41,14 @@ jobs:
       - name: Lint Toolchain
         run: ./mfc.sh lint
 
-      - name: Lint Source - No Raw Directives
-        run: |
-          ! grep -iR '!\$acc\|!\$omp' --exclude="parallel_macros.fpp" --exclude="acc_macros.fpp" --exclude="omp_macros.fpp" --exclude="shared_parallel_macros.fpp" --exclude="syscheck.fpp" ./src/*
-
-      - name: Lint Source - No Double Precision Intrinsics
-        run: |
-          ! grep -iR 'double_precision\|dsqrt\|dexp\|dlog\|dble\|dabs\|double\ precision\|real(8)\|real(4)\|dprod\|dmin\|dmax\|dfloat\|dreal\|dcos\|dsin\|dtan\|dsign\|dtanh\|dsinh\|dcosh\|d0' --exclude-dir=syscheck --exclude="*nvtx*" --exclude="*precision_select*" ./src/*
-
-      - name: Lint Source - No Junk Code
-        run: |
-          ! grep -iR -e '\.\.\.' -e '\-\-\-' -e '===' ./src/*
+      - name: Lint Source
+        run: python3 toolchain/mfc/lint_source.py
 
       - name: Lint Docs
         run: python3 toolchain/mfc/lint_docs.py
+
+      - name: Lint Parameter Docs
+        run: python3 toolchain/mfc/lint_param_docs.py
 
   file-changes:
     name: Detect File Changes

--- a/toolchain/mfc/lint_param_docs.py
+++ b/toolchain/mfc/lint_param_docs.py
@@ -1,7 +1,8 @@
 """Check parameter documentation completeness.
 
 Tier 1 (blocking): Parameters with DESCRIPTIONS entries must appear in case.md.
-Tier 2 (warnings): Fortran namelist / REGISTRY sync checks.
+Tier 2 (blocking): Fortran namelist params must be in REGISTRY.
+Tier 3 (blocking): Scalar REGISTRY params must have descriptions.
 """
 
 from __future__ import annotations
@@ -90,9 +91,11 @@ def _parse_namelist_params(fpp_path: Path) -> set[str]:
         stripped = line.strip()
         if stripped.startswith("!") or stripped.startswith("#:") or stripped.startswith("#"):
             continue
-        if "namelist /user_inputs/" in stripped.lower():
-            in_namelist = True
-            accum = stripped.split("/user_inputs/", 1)[1] if "/user_inputs/" in stripped else ""
+        lower = stripped.lower()
+        if "namelist /user_inputs/" in lower:
+            idx = lower.index("/user_inputs/") + len("/user_inputs/")
+            accum += " " + stripped[idx:]
+            in_namelist = accum.rstrip().endswith("&")
             continue
         if in_namelist:
             if stripped.startswith("&"):


### PR DESCRIPTION
## Summary

Follow-up to #1327. Fixes bugs found by Claude CI review and deduplicates CI workflow.

## Fixes

- **Docstring**: Updated to reflect all 3 tiers are blocking (was incorrectly saying Tier 2 is "warnings")
- **Case-sensitivity bug**: `_parse_namelist_params` used `stripped.lower()` for detection but `stripped.split("/user_inputs/")` for extraction — fails on uppercase Fortran. Now uses index-based slicing from the lowercase match.
- **Single-line namelist bug**: Parser read one line past a single-line namelist declaration. Now checks for continuation `&` immediately.
- **Multiple namelist blocks**: Uses `+=` for accumulator so subsequent `namelist /user_inputs/` blocks are captured.
- **CI DRY violation**: Replaced 3 hardcoded `grep` steps in `test.yml` with single `python3 toolchain/mfc/lint_source.py` call. Added missing `lint_param_docs.py` step. CI now matches precheck exactly.

## Test plan

- [x] `python3 toolchain/mfc/lint_param_docs.py` exits 0
- [x] `./mfc.sh precheck -j 8` passes all 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)