### PR TITLE
ci: remove case_validator.py from ALWAYS_RUN_ALL

### DIFF
--- a/toolchain/mfc/test/coverage.py
+++ b/toolchain/mfc/test/coverage.py
@@ -44,6 +44,8 @@ COVERAGE_CACHE_PATH = Path(common.MFC_ROOT_DIR) / "toolchain/mfc/test/test_cover
 #     are conservatively included (not in cache -> always runs).
 #   - definitions.py: adding a parameter doesn't affect tests that don't use it;
 #     the PR's .fpp changes trigger the relevant tests via coverage overlap.
+#   - case_validator.py: validation only affects user-facing error messages for
+#     invalid configs, not test outputs (tests use valid configs).
 ALWAYS_RUN_ALL = frozenset(
     [
         "CMakeLists.txt",
@@ -56,7 +58,6 @@ ALWAYS_RUN_ALL = frozenset(
         "toolchain/mfc/test/case.py",
         "toolchain/mfc/test/coverage.py",
         "toolchain/mfc/run/input.py",
-        "toolchain/mfc/case_validator.py",
     ]
 )
 

--- a/toolchain/mfc/test/test_coverage_unit.py
+++ b/toolchain/mfc/test/test_coverage_unit.py
@@ -237,8 +237,9 @@ class TestShouldRunAllTests(unittest.TestCase):
     def test_input_py_triggers_all(self):
         assert should_run_all_tests({"toolchain/mfc/run/input.py"}) is True
 
-    def test_case_validator_triggers_all(self):
-        assert should_run_all_tests({"toolchain/mfc/case_validator.py"}) is True
+    def test_case_validator_does_not_trigger_all(self):
+        """case_validator.py removed: validation only affects error messages, not test outputs."""
+        assert should_run_all_tests({"toolchain/mfc/case_validator.py"}) is False
 
     def test_cmakelists_triggers_all(self):
         assert should_run_all_tests({"CMakeLists.txt"}) is True


### PR DESCRIPTION
## Summary

Follow-up to #1328. Removes `case_validator.py` from `ALWAYS_RUN_ALL` — validation only affects user-facing error messages for invalid configs, not test outputs (tests use valid configs).

This unblocks pruning for PRs like #1303 (MTHINC) and #1298 (Herschel-Bulkley) that change `case_validator.py` alongside simulation `.fpp` files.

## Test plan

- [ ] PR #1303 (MTHINC): should see pruned test count instead of full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)