### PR TITLE
fix: guard QBMM boundary extrapolation with present(pb_in)

### DIFF
--- a/src/common/m_boundary_common.fpp
+++ b/src/common/m_boundary_common.fpp
@@ -116,7 +116,7 @@ contains
                         call s_dirichlet(q_prim_vf, 1, -1, k, l)
                     end select
 
-                    if (qbmm .and. (.not. polytropic) .and. &
+                    if (qbmm .and. (.not. polytropic) .and. present(pb_in) .and. present(mv_in) .and. &
                         (bc_type(1, 1)%sf(0, k, l) <= BC_GHOST_EXTRAP)) then
                         call s_qbmm_extrapolation(1, -1, k, l, pb_in, mv_in)
                     end if
@@ -146,7 +146,7 @@ contains
                         call s_dirichlet(q_prim_vf, 1, 1, k, l)
                     end select
 
-                    if (qbmm .and. (.not. polytropic) .and. &
+                    if (qbmm .and. (.not. polytropic) .and. present(pb_in) .and. present(mv_in) .and. &
                         (bc_type(1, 2)%sf(0, k, l) <= BC_GHOST_EXTRAP)) then
                         call s_qbmm_extrapolation(1, 1, k, l, pb_in, mv_in)
                     end if
@@ -184,7 +184,7 @@ contains
                             call s_dirichlet(q_prim_vf, 2, -1, k, l)
                         end select
 
-                        if (qbmm .and. (.not. polytropic) .and. &
+                        if (qbmm .and. (.not. polytropic) .and. present(pb_in) .and. present(mv_in) .and. &
                             (bc_type(2, 1)%sf(k, 0, l) <= BC_GHOST_EXTRAP) .and. &
                             (bc_type(2, 1)%sf(k, 0, l) /= BC_AXIS)) then
                             call s_qbmm_extrapolation(2, -1, k, l, pb_in, mv_in)
@@ -215,7 +215,7 @@ contains
                             call s_dirichlet(q_prim_vf, 2, 1, k, l)
                         end select
 
-                        if (qbmm .and. (.not. polytropic) .and. &
+                        if (qbmm .and. (.not. polytropic) .and. present(pb_in) .and. present(mv_in) .and. &
                             (bc_type(2, 2)%sf(k, 0, l) <= BC_GHOST_EXTRAP)) then
                             call s_qbmm_extrapolation(2, 1, k, l, pb_in, mv_in)
                         end if
@@ -253,7 +253,7 @@ contains
                             call s_dirichlet(q_prim_vf, 3, -1, k, l)
                         end select
 
-                        if (qbmm .and. (.not. polytropic) .and. &
+                        if (qbmm .and. (.not. polytropic) .and. present(pb_in) .and. present(mv_in) .and. &
                             (bc_type(3, 1)%sf(k, l, 0) <= BC_GHOST_EXTRAP)) then
                             call s_qbmm_extrapolation(3, -1, k, l, pb_in, mv_in)
                         end if
@@ -283,7 +283,7 @@ contains
                             call s_dirichlet(q_prim_vf, 3, 1, k, l)
                         end select
 
-                        if (qbmm .and. (.not. polytropic) .and. &
+                        if (qbmm .and. (.not. polytropic) .and. present(pb_in) .and. present(mv_in) .and. &
                             (bc_type(3, 2)%sf(k, l, 0) <= BC_GHOST_EXTRAP)) then
                             call s_qbmm_extrapolation(3, 1, k, l, pb_in, mv_in)
                         end if


### PR DESCRIPTION
## Summary

- Post_process calls `s_populate_variables_buffers` without the optional `pb_in`/`mv_in` arguments, but the QBMM guard (`qbmm .and. .not. polytropic`) could still evaluate to true, causing access to an absent optional argument — undefined behavior in Fortran.
- Add `present(pb_in)` to all 6 call sites of `s_qbmm_extrapolation` in `m_boundary_common.fpp`.
- Caught by gfortran `-fcheck=bounds` in the macOS debug CI build.

## Test plan

- [x] Compiles with gfortran
- [x] `./mfc.sh precheck` passes
- [ ] CI macOS debug build passes (currently fails on master for QBMM + post_process)