### PR TITLE
fix(runners): fix registration token API, shuffle rebalance, consolidate dirs

### DIFF
--- a/misc/runners/common/rebalance-runners.sh
+++ b/misc/runners/common/rebalance-runners.sh
@@ -106,6 +106,16 @@ done
 # Add offline runners to be placed
 for i in "${offline[@]}"; do to_place+=("offline $i"); done
 
+# Shuffle to_place so sequential runner numbers spread across nodes
+# (avoids overloading one node when jobs arrive in number order)
+shuffled=()
+while [ ${#to_place[@]} -gt 0 ]; do
+    rand=$(( RANDOM % ${#to_place[@]} ))
+    shuffled+=("${to_place[$rand]}")
+    to_place=("${to_place[@]:0:$rand}" "${to_place[@]:$((rand+1))}")
+done
+to_place=("${shuffled[@]}")
+
 # Assign to underloaded nodes
 moves=()
 for entry in "${to_place[@]}"; do

--- a/misc/runners/common/runner-lib.sh
+++ b/misc/runners/common/runner-lib.sh
@@ -21,7 +21,7 @@ gh_list_runners() {
 
 # Get a registration token for new runners.
 gh_registration_token() {
-    gh api "orgs/$ORG/actions/runners/registration-token" --jq .token
+    gh api "orgs/$ORG/actions/runners/registration-token" -X POST --jq .token
 }
 
 # Get the latest runner binary version.

--- a/misc/runners/phoenix/config.sh
+++ b/misc/runners/phoenix/config.sh
@@ -15,7 +15,6 @@ SSH_OPTS="-o ConnectTimeout=5"
 
 # Parent directories containing actions-runner-*/ installations on shared storage.
 RUNNER_PARENT_DIRS=(
-    /storage/scratch1/6/sbryngelson3/mfc-runners
     /storage/project/r-sbryngelson3-0/sbryngelson3/mfc-runners-2
 )
 


### PR DESCRIPTION
## Summary
- Add `-X POST` to `gh_registration_token()` — required by GitHub API, was causing 404 on runner creation
- Shuffle runner placement order during rebalance so sequential runner numbers spread across nodes (avoids overloading one node when jobs arrive in number order)
- Remove scratch dir from Phoenix `RUNNER_PARENT_DIRS` (all runners consolidated to project storage)

## Test plan
- [x] Verified `create-runner` works with the `-X POST` fix (created phoenix 1-4)
- [x] Verified `rebalance-runners` dry run produces randomized order
- [x] Verified all 10 runners healthy after rebalance (`check-runners`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)