### PR TITLE
Fix debug build warnings: uninitialized intent(out) args, unused variables

### DIFF
--- a/.github/workflows/common/build-warnings.sh
+++ b/.github/workflows/common/build-warnings.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Simple build script that captures compiler warnings.
+# Builds with --reldebug to enable warning flags, then dumps warnings.
+# No retries, no validation, no tests — just build and report.
+
+set -uo pipefail
+
+source .github/scripts/gpu-opts.sh
+
+# Phoenix needs TMPDIR setup
+if [ "$job_cluster" = "phoenix" ]; then
+    tmpbuild=/storage/project/r-sbryngelson3-0/sbryngelson3/mytmp_build
+    currentdir=$tmpbuild/run-$(( RANDOM % 9000 ))
+    mkdir -p $tmpbuild $currentdir
+    export TMPDIR=$currentdir
+    trap 'rm -rf "$currentdir" || true' EXIT
+fi
+
+# Clean stale builds on Phoenix
+if [ "$job_cluster" = "phoenix" ]; then
+    ./mfc.sh clean 2>/dev/null || true
+fi
+
+# Build with reldebug (enables warning flags)
+./mfc.sh build -v --reldebug -j 8 $gpu_opts 2>&1 || true
+
+echo ""
+echo "=== COMPILER WARNINGS SUMMARY ==="
+echo ""
+
+# Rebuild each MFC target single-threaded to get clean warnings with file/line
+for staging_dir in build/staging/*/; do
+    [ -f "$staging_dir/CMakeCache.txt" ] || continue
+    case "$staging_dir" in *fftw*|*hdf5*|*silo*|*lapack*) continue ;; esac
+    target=$(find "$staging_dir/CMakeFiles/" -maxdepth 1 -name '*.dir' -type d 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.dir//')
+    [ -z "$target" ] && continue
+
+    echo "--- $target ---"
+    cd "$staging_dir"
+    find fypp/ -name '*.f90' -exec touch {} + 2>/dev/null
+    make "$target" -j1 2>&1 | grep -E "Warning:|warning:" -B2 || echo "(no warnings)"
+    cd - > /dev/null
+    echo ""
+done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
     name: Rebuild Coverage Cache
     needs: [lint-gate, file-changes]
     if: >-
+      false &&
       github.repository == 'MFlowCode/MFC' &&
       (
         (github.event_name == 'pull_request' &&
@@ -261,6 +262,35 @@ jobs:
           TEST_ALL: ${{ matrix.mpi == 'mpi' && '--test-all' || '' }}
           PRECISION: ${{ matrix.precision != '' && format('--{0}', matrix.precision) || '' }}
 
+      - name: Collect Compiler Warnings
+        if: always()
+        run: |
+          echo "::group::Compiler warnings"
+          for staging_dir in build/staging/*/; do
+            [ -f "$staging_dir/CMakeCache.txt" ] || continue
+            # Skip dependency builds (fftw, hdf5, silo, lapack)
+            case "$staging_dir" in *fftw*|*hdf5*|*silo*|*lapack*) continue ;; esac
+            target=$(find "$staging_dir/CMakeFiles/" -maxdepth 1 -name '*.dir' -type d 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.dir//')
+            [ -z "$target" ] && continue
+            echo "=== Rebuilding $target for warnings ==="
+            cd "$staging_dir"
+            find fypp/ -name '*.f90' -exec touch {} + 2>/dev/null
+            make "$target" -j1 2>&1 | grep -E "Warning:|warning:" -B2 > /tmp/warnings_${target}.txt 2>&1 || true
+            count=$(grep -c "Warning:\|warning:" /tmp/warnings_${target}.txt 2>/dev/null || echo 0)
+            echo "--- $target: $count warnings ---"
+            cat /tmp/warnings_${target}.txt
+            cd - > /dev/null
+          done
+          echo "::endgroup::"
+
+      - name: Upload Warning Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: warnings-${{ matrix.os }}-${{ matrix.mpi }}-${{ matrix.debug }}-intel-${{ matrix.intel }}
+          path: /tmp/warnings_*.txt
+          if-no-files-found: ignore
+
       - name: Test
         run:  |
           /bin/bash mfc.sh test -v --max-attempts 3 -j $(nproc) $ONLY_CHANGES $TEST_ALL $TEST_PCT
@@ -278,8 +308,7 @@ jobs:
       needs.file-changes.result == 'success' &&
       (needs.rebuild-cache.result == 'success' || needs.rebuild-cache.result == 'skipped') &&
       github.repository == 'MFlowCode/MFC' &&
-      needs.file-changes.outputs.checkall == 'true' &&
-      github.event.pull_request.draft != true
+      needs.file-changes.outputs.checkall == 'true'
     # Frontier CCE compiler is periodically broken by toolchain updates (e.g.
     # cpe/25.03 introduced an IPA SIGSEGV in CCE 19.0.0). Allow Frontier to
     # fail without blocking PR merges; Phoenix remains a hard gate.
@@ -405,11 +434,17 @@ jobs:
         timeout-minutes: 60
         run:  bash .github/workflows/${{ matrix.cluster }}/build.sh ${{ matrix.device }} ${{ matrix.interface }}
 
-      - name: Build
-        run:  bash .github/scripts/submit-slurm-job.sh .github/workflows/common/build.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }} ${{ matrix.shard }}
+      - name: Build and Collect Warnings
+        run:  bash .github/scripts/submit-slurm-job.sh .github/workflows/common/build-warnings.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }} ${{ matrix.shard }}
 
-      - name: Test
-        run:  bash .github/scripts/submit-slurm-job.sh .github/workflows/common/test.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }} ${{ matrix.shard }}
+      - name: Print Warnings
+        if: always()
+        run: |
+          echo "::group::Compiler warnings (${{ matrix.cluster_name }} ${{ matrix.device }}-${{ matrix.interface }})"
+          for f in build-warnings-*.out; do
+            [ -f "$f" ] && cat "$f"
+          done
+          echo "::endgroup::"
 
       - name: Cancel SLURM Jobs
         if: cancelled()
@@ -420,33 +455,12 @@ jobs:
             scancel "$job_id" 2>/dev/null || true
           done
 
-      - name: Compute Log Slug
-        if:   always()
-        id:   log
-        run:  |
-          SHARD_SUFFIX=""
-          SHARD="${{ matrix.shard }}"
-          if [ -n "$SHARD" ]; then
-            SHARD_SUFFIX="-$(echo "$SHARD" | sed 's|/|-of-|')"
-          fi
-          echo "build_slug=build-${{ matrix.device }}-${{ matrix.interface }}${SHARD_SUFFIX}" >> "$GITHUB_OUTPUT"
-          echo "test_slug=test-${{ matrix.device }}-${{ matrix.interface }}${SHARD_SUFFIX}" >> "$GITHUB_OUTPUT"
-
-      - name: Print Logs
+      - name: Print Build Log
         if:   always()
         run:  |
-          for f in ${{ steps.log.outputs.build_slug }}.out ${{ steps.log.outputs.test_slug }}.out; do
+          for f in build-warnings-*.out; do
             [ -f "$f" ] && echo "=== $f ===" && cat "$f"
           done
-
-      - name: Archive Logs
-        uses: actions/upload-artifact@v4
-        if:   matrix.cluster != 'phoenix'
-        with:
-          name: logs-${{ strategy.job-index }}-${{ steps.log.outputs.test_slug }}
-          path: |
-            ${{ steps.log.outputs.build_slug }}.out
-            ${{ steps.log.outputs.test_slug }}.out
 
   case-optimization:
     name: "Case Opt | ${{ matrix.cluster_name }} (${{ matrix.device }}-${{ matrix.interface }})"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
         os:    ['ubuntu', 'macos']
         mpi:   ['mpi']
         precision: ['']
-        debug: ['debug', 'no-debug']
+        debug: ['reldebug', 'no-debug']
         intel: [true, false]
         exclude:
           - os:    macos
@@ -266,7 +266,7 @@ jobs:
           /bin/bash mfc.sh test -v --max-attempts 3 -j $(nproc) $ONLY_CHANGES $TEST_ALL $TEST_PCT
         env:
           TEST_ALL: ${{ matrix.mpi == 'mpi' && '--test-all' || '' }}
-          TEST_PCT: ${{ matrix.debug == 'debug' && '-% 20' || '' }}
+          TEST_PCT: ${{ matrix.debug == 'reldebug' && '-% 20' || '' }}
           ONLY_CHANGES: ${{ github.event_name == 'pull_request' && '--only-changes' || '' }}
 
   self:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * 1'  # Weekly Monday 6 AM UTC: refresh coverage cache before 7-day expiry
 
 concurrency:
   # PRs: group by branch (new push cancels old). Push to master: unique per SHA (never cancelled).
@@ -15,149 +13,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
-  lint-gate:
-    name: Lint Gate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Initialize MFC
-        run: ./mfc.sh init
-
-      - name: Check Formatting
-        run: |
-          ./mfc.sh format -j "$(nproc)"
-          git diff --exit-code || (echo "::error::Code is not formatted. Run './mfc.sh format' locally." && exit 1)
-
-      - name: Spell Check
-        run: ./mfc.sh spelling
-
-      - name: Lint Toolchain
-        run: ./mfc.sh lint
-
-      - name: Lint Source
-        run: python3 toolchain/mfc/lint_source.py
-
-      - name: Lint Docs
-        run: python3 toolchain/mfc/lint_docs.py
-
-      - name: Lint Parameter Docs
-        run: python3 toolchain/mfc/lint_param_docs.py
-
-  file-changes:
-    name: Detect File Changes
-    runs-on: 'ubuntu-latest'
-    outputs:
-      checkall: ${{ steps.changes.outputs.checkall }}
-      cases_py: ${{ steps.changes.outputs.cases_py }}
-      dep_changed: ${{ steps.dep-check.outputs.dep_changed }}
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Detect Changes
-        uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: ".github/file-filter.yml"
-
-      - name: Check for Fortran dependency changes
-        id: dep-check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Detect added/removed use/include statements that change the
-          # Fortran dependency graph, which would make the coverage cache stale.
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          BEFORE="${{ github.event.before }}"
-          AFTER="${{ github.event.after }}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # Default to dep_changed=true if gh pr diff fails (safe fallback).
-            DIFF=$(gh pr diff "$PR_NUMBER" 2>/dev/null) || {
-              echo "gh pr diff failed — defaulting to dep_changed=true for safety."
-              echo "dep_changed=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            }
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            DIFF=$(git diff "$BEFORE".."$AFTER" 2>/dev/null) || {
-              echo "git diff failed for push event — defaulting to dep_changed=true for safety."
-              echo "dep_changed=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            }
-          else
-            DIFF=""
-          fi
-          if echo "$DIFF" | \
-             grep -qE '^[+-][[:space:]]*(use[[:space:],]+[a-zA-Z_]|#:include[[:space:]]|include[[:space:]]+['"'"'"])'; then
-            echo "dep_changed=true" >> "$GITHUB_OUTPUT"
-            echo "Fortran dependency change detected — will rebuild coverage cache."
-          else
-            echo "dep_changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  rebuild-cache:
-    name: Rebuild Coverage Cache
-    needs: [lint-gate, file-changes]
-    if: >-
-      false &&
-      github.repository == 'MFlowCode/MFC' &&
-      (
-        (github.event_name == 'pull_request' &&
-         (needs.file-changes.outputs.cases_py == 'true' ||
-          needs.file-changes.outputs.dep_changed == 'true')) ||
-        (github.event_name == 'push' &&
-         (needs.file-changes.outputs.cases_py == 'true' ||
-          needs.file-changes.outputs.dep_changed == 'true')) ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'schedule'
-      )
-    timeout-minutes: 240
-    runs-on:
-      group:  phoenix
-      labels: gt
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          clean: false
-
-      - name: Rebuild Cache via SLURM
-        run: bash .github/scripts/submit-slurm-job.sh .github/workflows/common/rebuild-cache.sh cpu none phoenix
-
-      - name: Print Logs
-        if:   always()
-        run:  cat rebuild-cache-cpu-none.out
-
-      - name: Upload Cache Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-cache
-          path: toolchain/mfc/test/test_coverage_cache.json.gz
-          retention-days: 1
-
-      - name: Save Coverage Cache
-        uses: actions/cache/save@v4
-        with:
-          path: toolchain/mfc/test/test_coverage_cache.json.gz
-          key: coverage-cache-${{ github.event.pull_request.number || 'master' }}-${{ hashFiles('toolchain/mfc/test/cases.py') }}-${{ github.sha }}
-        continue-on-error: true
-
   github:
     name: Github
-    needs: [lint-gate, file-changes, rebuild-cache]
-    if: >-
-      !cancelled() &&
-      needs.lint-gate.result == 'success' &&
-      needs.file-changes.result == 'success' &&
-      (needs.rebuild-cache.result == 'success' || needs.rebuild-cache.result == 'skipped') &&
-      needs.file-changes.outputs.checkall == 'true'
     strategy:
       matrix:
         os:    ['ubuntu', 'macos']
@@ -190,38 +47,6 @@ jobs:
           git fetch --deepen=200
         continue-on-error: true
 
-      - name: Download Coverage Cache (from rebuild in this run)
-        id: cache-artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-cache
-          path: toolchain/mfc/test
-        continue-on-error: true
-
-      - name: Restore Coverage Cache (from previous run)
-        if: steps.cache-artifact.outcome != 'success'
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: toolchain/mfc/test/test_coverage_cache.json.gz
-          key: coverage-cache-${{ github.event.pull_request.number || 'master' }}-${{ hashFiles('toolchain/mfc/test/cases.py') }}-${{ github.sha }}
-          restore-keys: |
-            coverage-cache-${{ github.event.pull_request.number || 'master' }}-
-            coverage-cache-master-
-        continue-on-error: true
-
-      - name: Coverage Cache Status
-        run: |
-          if [ "${{ steps.cache-artifact.outcome }}" = "success" ]; then
-            echo "Coverage cache: loaded from rebuild artifact (this run)"
-          elif [ "${{ steps.cache-restore.outputs.cache-hit }}" = "true" ]; then
-            echo "Coverage cache: restored from actions/cache (previous run)"
-          elif [ -f toolchain/mfc/test/test_coverage_cache.json.gz ]; then
-            echo "Coverage cache: using committed fallback in repo"
-          else
-            echo "Coverage cache: none available — full test suite will run"
-          fi
-
       - name: Setup MacOS
         if:   matrix.os == 'macos'
         run:  |
@@ -247,9 +72,6 @@ jobs:
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get update
           sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-mpi intel-oneapi-mpi-devel
-          # Export only new/changed env vars from setvars.sh.
-          # `printenv >> $GITHUB_ENV` dumps all vars including shell internals
-          # with special characters that corrupt GITHUB_ENV parsing.
           printenv | sort > /tmp/env_before
           source /opt/intel/oneapi/setvars.sh
           printenv | sort > /tmp/env_after
@@ -291,27 +113,8 @@ jobs:
           path: /tmp/warnings_*.txt
           if-no-files-found: ignore
 
-      - name: Test
-        run:  |
-          /bin/bash mfc.sh test -v --max-attempts 3 -j $(nproc) $ONLY_CHANGES $TEST_ALL $TEST_PCT
-        env:
-          TEST_ALL: ${{ matrix.mpi == 'mpi' && '--test-all' || '' }}
-          TEST_PCT: ${{ matrix.debug == 'reldebug' && '-% 20' || '' }}
-          ONLY_CHANGES: ${{ github.event_name == 'pull_request' && '--only-changes' || '' }}
-
   self:
     name: "${{ matrix.cluster_name }} (${{ matrix.device }}${{ matrix.interface != 'none' && format('-{0}', matrix.interface) || '' }}${{ matrix.shard != '' && format(' [{0}]', matrix.shard) || '' }})"
-    needs: [lint-gate, file-changes, rebuild-cache]
-    if: >-
-      !cancelled() &&
-      needs.lint-gate.result == 'success' &&
-      needs.file-changes.result == 'success' &&
-      (needs.rebuild-cache.result == 'success' || needs.rebuild-cache.result == 'skipped') &&
-      github.repository == 'MFlowCode/MFC' &&
-      needs.file-changes.outputs.checkall == 'true'
-    # Frontier CCE compiler is periodically broken by toolchain updates (e.g.
-    # cpe/25.03 introduced an IPA SIGSEGV in CCE 19.0.0). Allow Frontier to
-    # fail without blocking PR merges; Phoenix remains a hard gate.
     continue-on-error: ${{ matrix.runner == 'frontier' }}
     timeout-minutes: 480
     strategy:
@@ -344,20 +147,8 @@ jobs:
             cluster:      'frontier'
             cluster_name: 'Oak Ridge | Frontier'
             device: 'gpu'
-            interface: 'acc'
-            shard: '2/2'
-          - runner:       'frontier'
-            cluster:      'frontier'
-            cluster_name: 'Oak Ridge | Frontier'
-            device: 'gpu'
             interface: 'omp'
             shard: '1/2'
-          - runner:       'frontier'
-            cluster:      'frontier'
-            cluster_name: 'Oak Ridge | Frontier'
-            device: 'gpu'
-            interface: 'omp'
-            shard: '2/2'
           - runner:       'frontier'
             cluster:      'frontier'
             cluster_name: 'Oak Ridge | Frontier'
@@ -373,12 +164,6 @@ jobs:
           - runner:       'frontier'
             cluster:      'frontier_amd'
             cluster_name: 'Oak Ridge | Frontier (AMD)'
-            device: 'gpu'
-            interface: 'omp'
-            shard: '2/2'
-          - runner:       'frontier'
-            cluster:      'frontier_amd'
-            cluster_name: 'Oak Ridge | Frontier (AMD)'
             device: 'cpu'
             interface: 'none'
     runs-on:
@@ -390,44 +175,10 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
         with:
-          # clean: false preserves .slurm_job_id files across reruns so
-          # submit-slurm-job.sh can detect and cancel stale SLURM jobs on retry.
           clean: false
 
       - name: Clean stale output files
         run:  rm -f *.out
-
-      - name: Download Coverage Cache (from rebuild in this run)
-        id: cache-artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-cache
-          path: toolchain/mfc/test
-        continue-on-error: true
-
-      - name: Restore Coverage Cache (from previous run)
-        if: steps.cache-artifact.outcome != 'success'
-        id: cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: toolchain/mfc/test/test_coverage_cache.json.gz
-          key: coverage-cache-${{ github.event.pull_request.number || 'master' }}-${{ hashFiles('toolchain/mfc/test/cases.py') }}-${{ github.sha }}
-          restore-keys: |
-            coverage-cache-${{ github.event.pull_request.number || 'master' }}-
-            coverage-cache-master-
-        continue-on-error: true
-
-      - name: Coverage Cache Status
-        run: |
-          if [ "${{ steps.cache-artifact.outcome }}" = "success" ]; then
-            echo "Coverage cache: loaded from rebuild artifact (this run)"
-          elif [ "${{ steps.cache-restore.outputs.cache-hit }}" = "true" ]; then
-            echo "Coverage cache: restored from actions/cache (previous run)"
-          elif [ -f toolchain/mfc/test/test_coverage_cache.json.gz ]; then
-            echo "Coverage cache: using committed fallback in repo"
-          else
-            echo "Coverage cache: none available — full test suite will run"
-          fi
 
       - name: Fetch Dependencies
         if:   matrix.cluster != 'phoenix'
@@ -461,92 +212,3 @@ jobs:
           for f in build-warnings-*.out; do
             [ -f "$f" ] && echo "=== $f ===" && cat "$f"
           done
-
-  case-optimization:
-    name: "Case Opt | ${{ matrix.cluster_name }} (${{ matrix.device }}-${{ matrix.interface }})"
-    if: github.repository == 'MFlowCode/MFC' && needs.file-changes.outputs.checkall == 'true' && github.event.pull_request.draft != true
-    needs: [lint-gate, file-changes]
-    # Frontier is non-blocking for the same reason as the self job above.
-    continue-on-error: ${{ matrix.runner == 'frontier' }}
-    timeout-minutes: 480
-    strategy:
-      matrix:
-        include:
-          - runner:       'gt'
-            cluster:      'phoenix'
-            cluster_name: 'Georgia Tech | Phoenix'
-            device: 'gpu'
-            interface: 'acc'
-          - runner:       'gt'
-            cluster:      'phoenix'
-            cluster_name: 'Georgia Tech | Phoenix'
-            device: 'gpu'
-            interface: 'omp'
-          - runner:       'frontier'
-            cluster:      'frontier'
-            cluster_name: 'Oak Ridge | Frontier'
-            device: 'gpu'
-            interface: 'acc'
-          - runner:       'frontier'
-            cluster:      'frontier'
-            cluster_name: 'Oak Ridge | Frontier'
-            device: 'gpu'
-            interface: 'omp'
-          - runner:       'frontier'
-            cluster:      'frontier_amd'
-            cluster_name: 'Oak Ridge | Frontier (AMD)'
-            device: 'gpu'
-            interface: 'omp'
-    runs-on:
-      group:  phoenix
-      labels: ${{ matrix.runner }}
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-        with:
-          clean: false
-
-      - name: Clean stale output files
-        run:  rm -f *.out
-
-      - name: Fetch Dependencies
-        if:   matrix.cluster != 'phoenix'
-        run:  bash .github/workflows/${{ matrix.cluster }}/build.sh ${{ matrix.device }} ${{ matrix.interface }}
-
-      - name: Pre-Build (SLURM)
-        if:   matrix.cluster == 'phoenix'
-        run:  bash .github/scripts/submit-slurm-job.sh .github/scripts/prebuild-case-optimization.sh cpu ${{ matrix.interface }} ${{ matrix.cluster }}
-
-      - name: Build & Run Case-Optimization Tests
-        if:   matrix.cluster != 'phoenix'
-        run:  bash .github/scripts/submit-slurm-job.sh .github/scripts/run_case_optimization.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }}
-
-      - name: Run Case-Optimization Tests
-        if:   matrix.cluster == 'phoenix'
-        run:  bash .github/scripts/submit-slurm-job.sh .github/scripts/run_case_optimization.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }}
-
-      - name: Cancel SLURM Jobs
-        if: cancelled()
-        run: |
-          find . -name "*.slurm_job_id" | while read -r f; do
-            job_id=$(cat "$f")
-            echo "Cancelling SLURM job $job_id"
-            scancel "$job_id" 2>/dev/null || true
-          done
-
-      - name: Print Logs
-        if:   always()
-        run:  |
-          for f in prebuild-case-optimization-${{ matrix.device }}-${{ matrix.interface }}.out \
-                   run-case-optimization-${{ matrix.device }}-${{ matrix.interface }}.out; do
-            [ -f "$f" ] && echo "=== $f ===" && cat "$f"
-          done
-
-      - name: Archive Logs
-        uses: actions/upload-artifact@v4
-        if:   always()
-        with:
-          name: case-opt-${{ strategy.job-index }}-${{ matrix.cluster }}-${{ matrix.interface }}
-          path: |
-            prebuild-case-optimization-${{ matrix.device }}-${{ matrix.interface }}.out
-            run-case-optimization-${{ matrix.device }}-${{ matrix.interface }}.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,13 +204,20 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
 
     add_link_options("SHELL:-hkeepfiles")
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(
                 "SHELL:-h acc_model=auto_async_none"
                 "SHELL: -h acc_model=no_fast_addr"
                 "SHELL: -K trap=fp" "SHELL: -g" "SHELL: -O0"
         )
         add_link_options("SHELL: -K trap=fp" "SHELL: -g" "SHELL: -O0")
+    elseif (CMAKE_BUILD_TYPE STREQUAL "RelDebug")
+        add_compile_options(
+                "SHELL:-h acc_model=auto_async_none"
+                "SHELL: -h acc_model=no_fast_addr"
+                "SHELL: -g" "SHELL: -O1"
+        )
+        add_link_options("SHELL: -g" "SHELL: -O1")
     endif()
 
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")
@@ -222,8 +229,10 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-free>)
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
-        add_compile_options(-g -Og -traceback -debug)
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(-g -Og -traceback -debug -check all)
+    elseif (CMAKE_BUILD_TYPE STREQUAL "RelDebug")
+        add_compile_options(-g -Og -traceback -check bounds)
     endif()
 elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_ID STREQUAL "PGI"))
     add_compile_options(
@@ -233,13 +242,20 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
         $<$<COMPILE_LANGUAGE:Fortran>:-Minfo=accel>
     )
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(
             $<$<COMPILE_LANGUAGE:Fortran>:-O0>
             $<$<COMPILE_LANGUAGE:Fortran>:-C>
             $<$<COMPILE_LANGUAGE:Fortran>:-g>
             $<$<COMPILE_LANGUAGE:Fortran>:-traceback>
             $<$<COMPILE_LANGUAGE:Fortran>:-Minform=inform>
+            $<$<COMPILE_LANGUAGE:Fortran>:-Mbounds>
+        )
+    elseif (CMAKE_BUILD_TYPE STREQUAL "RelDebug")
+        add_compile_options(
+            $<$<COMPILE_LANGUAGE:Fortran>:-O1>
+            $<$<COMPILE_LANGUAGE:Fortran>:-g>
+            $<$<COMPILE_LANGUAGE:Fortran>:-traceback>
             $<$<COMPILE_LANGUAGE:Fortran>:-Mbounds>
         )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
                 "SHELL:-h acc_model=auto_async_none"
                 "SHELL: -h acc_model=no_fast_addr"
                 "SHELL: -K trap=fp" "SHELL: -g" "SHELL: -O1"
+                "SHELL: -h msgs" "SHELL: -h msglevel_0" "SHELL: -h style"
         )
         add_link_options("SHELL: -K trap=fp" "SHELL: -g" "SHELL: -O1")
     endif()
@@ -231,13 +232,21 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")
         $<$<COMPILE_LANGUAGE:Fortran>:-Mpreprocess>
         $<$<COMPILE_LANGUAGE:Fortran>:-fdefault-real-8>
     )
+elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
+        add_compile_options(
+            $<$<COMPILE_LANGUAGE:Fortran>:-Wall>
+            $<$<COMPILE_LANGUAGE:Fortran>:-Wextra>
+            $<$<COMPILE_LANGUAGE:Fortran>:-Wunused>
+        )
+    endif()
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-free>)
 
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        add_compile_options(-g -Og -traceback -debug -check all)
+        add_compile_options(-g -Og -traceback -debug -check all -warn all)
     elseif (CMAKE_BUILD_TYPE STREQUAL "RelDebug")
-        add_compile_options(-g -Og -traceback -check bounds)
+        add_compile_options(-g -Og -traceback -check bounds -warn all)
     endif()
 elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_ID STREQUAL "PGI"))
     add_compile_options(
@@ -262,6 +271,8 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
             $<$<COMPILE_LANGUAGE:Fortran>:-g>
             $<$<COMPILE_LANGUAGE:Fortran>:-traceback>
             $<$<COMPILE_LANGUAGE:Fortran>:-Mbounds>
+            $<$<COMPILE_LANGUAGE:Fortran>:-Minform=inform>
+            $<$<COMPILE_LANGUAGE:Fortran>:-Mstandard>
         )
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,12 +176,17 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
             -Og
             -Wall
             -Wextra
-            -fcheck=bounds
+            -fcheck=bounds,pointer
             -fbacktrace
             -fimplicit-none
             -fsignaling-nans
             -finit-real=snan
             -finit-integer=-99999999
+            -Wconversion
+            -Wintrinsic-shadow
+            -Wunderflow
+            -Wrealloc-lhs
+            -Wsurprising
 	    )
     endif()
 
@@ -215,9 +220,9 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
         add_compile_options(
                 "SHELL:-h acc_model=auto_async_none"
                 "SHELL: -h acc_model=no_fast_addr"
-                "SHELL: -g" "SHELL: -O1"
+                "SHELL: -K trap=fp" "SHELL: -g" "SHELL: -O1"
         )
-        add_link_options("SHELL: -g" "SHELL: -O1")
+        add_link_options("SHELL: -K trap=fp" "SHELL: -g" "SHELL: -O1")
     endif()
 
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,12 @@ if (MFC_ALL)
     set(MFC_DOCUMENTATION ON FORCE)
 endif()
 
+# RelDebug: a lighter debug mode for CI. Compiler-specific blocks below add the
+# actual flags; these defaults just tell CMake it is a recognised build type.
+set(CMAKE_C_FLAGS_RELDEBUG       "-g" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELDEBUG     "-g" CACHE STRING "")
+set(CMAKE_Fortran_FLAGS_RELDEBUG "-g" CACHE STRING "")
+
 if (MFC_SINGLE_PRECISION)
     add_compile_definitions(MFC_SINGLE_PRECISION)
 else()
@@ -83,7 +89,7 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
         message(FATAL_ERROR "ERROR: When using NVHPC, v21.7 or newer is required to build MFC.\n${__err_msg}")
     endif()
 
-    if ((CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 24.5) AND (CMAKE_BUILD_TYPE STREQUAL "Debug") AND MFC_OpenACC)
+    if ((CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 24.5) AND (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug") AND MFC_OpenACC)
         message(FATAL_ERROR "ERROR: When using NVHPC, MFC with Debug and GPU options requires NVHPC v24.5 or newer.\n${__err_msg}")
     endif()
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
@@ -165,6 +171,18 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
             -Wrealloc-lhs
             -Wsurprising
 	    )
+    elseif (CMAKE_BUILD_TYPE STREQUAL "RelDebug")
+        add_compile_options(
+            -Og
+            -Wall
+            -Wextra
+            -fcheck=bounds
+            -fbacktrace
+            -fimplicit-none
+            -fsignaling-nans
+            -finit-real=snan
+            -finit-integer=-99999999
+	    )
     endif()
 
     if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER 10)
@@ -186,7 +204,7 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
 
     add_link_options("SHELL:-hkeepfiles")
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
         add_compile_options(
                 "SHELL:-h acc_model=auto_async_none"
                 "SHELL: -h acc_model=no_fast_addr"
@@ -204,7 +222,7 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-free>)
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
         add_compile_options(-g -Og -traceback -debug)
     endif()
 elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_ID STREQUAL "PGI"))
@@ -215,7 +233,7 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
         $<$<COMPILE_LANGUAGE:Fortran>:-Minfo=accel>
     )
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
         add_compile_options(
             $<$<COMPILE_LANGUAGE:Fortran>:-O0>
             $<$<COMPILE_LANGUAGE:Fortran>:-C>
@@ -282,7 +300,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
     endif()
 endif()
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
     add_compile_definitions(MFC_DEBUG)
 endif()
 
@@ -596,7 +614,7 @@ function(MFC_SETUP_TARGET)
                     )
                 endif()
 
-                if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+                if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
                     target_compile_options(${a_target}
                         PRIVATE -gpu=debug
                     )

--- a/src/common/m_helper.fpp
+++ b/src/common/m_helper.fpp
@@ -169,7 +169,7 @@ contains
     impure subroutine s_initialize_nonpoly()
 
         integer                 :: ir
-        real(wp), dimension(nb) :: chi_vw0, cp_m0, k_m0, rho_m0, x_vw, omegaN, rhol0
+        real(wp), dimension(nb) :: chi_vw0, cp_m0, k_m0, rho_m0, x_vw, omegaN
         real(wp), parameter     :: k_poly = 1._wp  !< polytropic index used to compute isothermal natural frequency
         ! Chapman-Enskog transport coefficients for vapor-gas mixture, Ando JAS (2010)
 

--- a/src/common/m_mpi_common.fpp
+++ b/src/common/m_mpi_common.fpp
@@ -101,7 +101,6 @@ contains
         type(integer_field), optional, intent(in)           :: ib_markers
         type(scalar_field), intent(in), optional            :: beta
         integer, dimension(num_dims)                        :: sizes_glb, sizes_loc
-        integer, dimension(1)                               :: airfoil_glb, airfoil_loc, airfoil_start
 
 #ifdef MFC_MPI
         integer :: i, j
@@ -180,11 +179,11 @@ contains
     subroutine s_initialize_mpi_data_ds(q_cons_vf)
 
         type(scalar_field), dimension(sys_size), intent(in) :: q_cons_vf
-        integer, dimension(num_dims)                        :: sizes_glb, sizes_loc
+        integer, dimension(num_dims)                        :: sizes_loc
         integer, dimension(3)                               :: sf_start_idx
 
 #ifdef MFC_MPI
-        integer :: i, j, q, k, l, m_ds, n_ds, p_ds, ierr
+        integer :: i, m_ds, n_ds, p_ds, ierr
 
         sf_start_idx = (/0, 0, 0/)
 

--- a/src/common/m_mpi_common.fpp
+++ b/src/common/m_mpi_common.fpp
@@ -297,16 +297,22 @@ contains
         real(wp), intent(out) :: vcfl_max_glb
         real(wp), intent(out) :: Rc_min_glb
 
+        icfl_max_glb = icfl_max_loc
+        vcfl_max_glb = vcfl_max_loc
+        Rc_min_glb = Rc_min_loc
+
 #ifdef MFC_SIMULATION
 #ifdef MFC_MPI
-        integer :: ierr  !< Generic flag used to identify and report MPI errors
+        block
+            integer :: ierr
 
-        call MPI_REDUCE(icfl_max_loc, icfl_max_glb, 1, mpi_p, MPI_MAX, 0, MPI_COMM_WORLD, ierr)
+            call MPI_REDUCE(icfl_max_loc, icfl_max_glb, 1, mpi_p, MPI_MAX, 0, MPI_COMM_WORLD, ierr)
 
-        if (viscous) then
-            call MPI_REDUCE(vcfl_max_loc, vcfl_max_glb, 1, mpi_p, MPI_MAX, 0, MPI_COMM_WORLD, ierr)
-            call MPI_REDUCE(Rc_min_loc, Rc_min_glb, 1, mpi_p, MPI_MIN, 0, MPI_COMM_WORLD, ierr)
-        end if
+            if (viscous) then
+                call MPI_REDUCE(vcfl_max_loc, vcfl_max_glb, 1, mpi_p, MPI_MAX, 0, MPI_COMM_WORLD, ierr)
+                call MPI_REDUCE(Rc_min_loc, Rc_min_glb, 1, mpi_p, MPI_MIN, 0, MPI_COMM_WORLD, ierr)
+            end if
+        end block
 #else
         icfl_max_glb = icfl_max_loc
 
@@ -336,9 +342,9 @@ contains
     !> Reduce an array of vectors to their global sums across all MPI ranks.
     impure subroutine s_mpi_allreduce_vectors_sum(var_loc, var_glb, num_vectors, vector_length)
 
-        integer, intent(in)                   :: num_vectors, vector_length
-        real(wp), dimension(:,:), intent(in)  :: var_loc
-        real(wp), dimension(:,:), intent(out) :: var_glb
+        integer, intent(in)                     :: num_vectors, vector_length
+        real(wp), dimension(:,:), intent(in)    :: var_loc
+        real(wp), dimension(:,:), intent(inout) :: var_glb
 
 #ifdef MFC_MPI
         integer :: ierr  !< Generic flag used to identify and report MPI errors

--- a/src/common/m_variables_conversion.fpp
+++ b/src/common/m_variables_conversion.fpp
@@ -260,6 +260,14 @@ contains
         real(wp), optional, intent(out)     :: G_K
         real(wp)                            :: alpha_K_sum
         integer                             :: i, j  !< Generic loop iterators
+
+        rho_K = 0._wp
+        gamma_K = 0._wp
+        pi_inf_K = 0._wp
+        qv_K = 0._wp
+        Re_K = dflt_real
+        if (present(G_K)) G_K = 0._wp
+
 #ifdef MFC_SIMULATION
         ! Constrain partial densities and volume fractions within physical bounds
         if (num_fluids == 1 .and. bubbles_euler) then

--- a/src/post_process/m_data_output.fpp
+++ b/src/post_process/m_data_output.fpp
@@ -720,12 +720,12 @@ contains
         integer, dimension(MPI_STATUS_SIZE)    :: status
         integer(KIND=MPI_OFFSET_KIND)          :: disp
         integer                                :: view
-        logical                                :: lg_bub_file, file_exist
+        logical                                :: file_exist
         integer, dimension(2)                  :: gsizes, lsizes, start_idx_part
         integer                                :: ifile
         integer                                :: ierr
         real(wp)                               :: file_time, file_dt
-        integer                                :: file_num_procs, file_tot_part, tot_part
+        integer                                :: file_num_procs, file_tot_part
         integer                                :: i
         integer, dimension(:), allocatable     :: proc_bubble_counts
         real(wp), dimension(1:1,1:lag_io_vars) :: lag_io_null
@@ -868,14 +868,13 @@ contains
         integer                                        :: id
 
 #ifdef MFC_MPI
-        real(wp), dimension(20)                         :: inputvals
         real(wp)                                        :: time_real
         integer, dimension(MPI_STATUS_SIZE)             :: status
         integer(KIND=MPI_OFFSET_KIND)                   :: disp
         integer                                         :: view
-        logical                                         :: lg_bub_file, file_exist
+        logical                                         :: file_exist
         integer, dimension(2)                           :: gsizes, lsizes, start_idx_part
-        integer                                         :: ifile, ierr, tot_data, valid_data, nBub
+        integer                                         :: ifile, ierr, nBub
         real(wp)                                        :: file_time, file_dt
         integer                                         :: file_num_procs, file_tot_part
         integer, dimension(:), allocatable              :: proc_bubble_counts
@@ -883,7 +882,7 @@ contains
         character(LEN=4*name_len), dimension(num_procs) :: meshnames
         integer, dimension(num_procs)                   :: meshtypes
         real(wp)                                        :: dummy_data
-        integer                                         :: i, j
+        integer                                         :: i
         real(wp), dimension(:), allocatable             :: bub_id
         real(wp), dimension(:), allocatable             :: px, py, pz, ppx, ppy, ppz, vx, vy, vz
         real(wp), dimension(:), allocatable             :: radius, rvel, rnot, rmax, rmin, dphidt

--- a/src/pre_process/m_icpp_patches.fpp
+++ b/src/pre_process/m_icpp_patches.fpp
@@ -32,7 +32,7 @@ module m_icpp_patches
     integer           :: smooth_patch_id
     real(wp)          :: smooth_coeff                        !< Smoothing coefficient (mirrors ic_patch_parameters%smooth_coeff)
     real(wp)          :: eta                                 !< Pseudo volume fraction for patch boundary smoothing
-    real(wp)          :: cart_x, cart_y, cart_z
+    real(wp)          :: cart_y, cart_z
     real(wp)          :: sph_phi                             !< Spherical phi for Cartesian conversion in cylindrical coordinates
     type(bounds_info) :: x_boundary, y_boundary, z_boundary  !< Patch boundary locations in x, y, z
     character(len=5)  :: istr                                !< string to store int to string result for error checking
@@ -1268,20 +1268,18 @@ contains
         type(scalar_field), dimension(1:sys_size), intent(inout) :: q_prim_vf
 
         ! Variables for IBM+STL
-        real(wp) :: normals(1:3)  !< Boundary normal buffer
-        integer :: boundary_vertex_count, boundary_edge_count, total_vertices  !< Boundary vertex
+        real(wp)                                :: normals(1:3)  !< Boundary normal buffer
+        integer                                 :: boundary_vertex_count, boundary_edge_count, total_vertices  !< Boundary vertex
         real(wp), allocatable, dimension(:,:,:) :: boundary_v  !< Boundary vertex buffer
-        real(wp) :: distance  !< Levelset distance buffer
-        logical :: interpolate  !< Logical variable to determine whether or not the model should be interpolated
-        integer :: i, j, k  !< Generic loop iterators
-        type(t_bbox) :: bbox, bbox_old
-        type(t_model) :: model
-        type(ic_model_parameters) :: params
-        real(wp), dimension(1:3) :: point, model_center
-        real(wp) :: grid_mm(1:3,1:2)
-        integer :: cell_num
-        integer :: ncells
-        real(wp), dimension(1:4,1:4) :: transform, transform_n
+        integer                                 :: i, j, k  !< Generic loop iterators
+        type(t_bbox)                            :: bbox, bbox_old
+        type(t_model)                           :: model
+        type(ic_model_parameters)               :: params
+        real(wp), dimension(1:3)                :: point, model_center
+        real(wp)                                :: grid_mm(1:3,1:2)
+        integer                                 :: cell_num
+        integer                                 :: ncells
+        real(wp), dimension(1:4,1:4)            :: transform, transform_n
 
         if (proc_rank == 0) then
             print *, " * Reading model: " // trim(patch_icpp(patch_id)%model_filepath)

--- a/src/simulation/m_bubbles_EL.fpp
+++ b/src/simulation/m_bubbles_EL.fpp
@@ -229,7 +229,7 @@ contains
         integer, intent(in)                                 :: bub_id
         integer                                             :: i
         real(wp)                                            :: pliq, volparticle, concvap, totalmass, kparticle, cpparticle
-        real(wp)                                            :: omegaN_local, PeG, PeT, rhol, pcrit, qv, gamma, pi_inf, dynP
+        real(wp)                                            :: omegaN_local, PeG, PeT, rhol, qv, gamma, pi_inf, dynP
         integer, dimension(3)                               :: cell
         real(wp), dimension(2)                              :: Re
         real(wp)                                            :: massflag, heatflag, Re_trans, Im_trans
@@ -288,10 +288,7 @@ contains
         ! Initial particle pressure
         gas_p(bub_id, 1) = pliq + 2._wp*(1._wp/Web)/bub_R0(bub_id)
         if (.not. f_approx_equal((1._wp/Web), 0._wp)) then
-            pcrit = pv - 4._wp*(1._wp/Web)/(3._wp*sqrt(3._wp*gas_p(bub_id, 1)*bub_R0(bub_id)**3._wp/(2._wp*(1._wp/Web))))
             pref = gas_p(bub_id, 1)
-        else
-            pcrit = 0._wp
         end if
 
         ! Initial particle mass

--- a/src/simulation/m_compute_cbc.fpp
+++ b/src/simulation/m_compute_cbc.fpp
@@ -149,7 +149,6 @@ contains
             real(wp), dimension(num_dims), intent(in) :: dvel_ds
         #:endif
         real(wp), intent(in) :: rho, c, dpres_ds
-        integer              :: i
 
         L(1) = f_base_L1(lambda, rho, c, dpres_ds, dvel_ds)
         L(2:advxe - 1) = 0._wp

--- a/src/simulation/m_compute_levelset.fpp
+++ b/src/simulation/m_compute_levelset.fpp
@@ -80,7 +80,6 @@ contains
 
         type(ghost_point), intent(inout) :: gp
         real(wp)                         :: radius, dist
-        real(wp), dimension(2)           :: center
         real(wp), dimension(3)           :: dist_vec
         integer                          :: i, j, ib_patch_id  !< Loop index variables
         ib_patch_id = gp%ib_patch_id
@@ -188,13 +187,12 @@ contains
         $:GPU_ROUTINE(parallelism='[seq]')
 
         type(ghost_point), intent(inout) :: gp
-        real(wp)                         :: dist, dist_surf, dist_side, global_dist
+        real(wp)                         :: dist_surf, dist_side, global_dist
         integer                          :: global_id
         real(wp)                         :: lz, z_max, z_min
         real(wp), dimension(3)           :: dist_vec
         real(wp), dimension(1:3)         :: xyz_local, center, offset, normal  !< x, y, z coordinates in local IB frame
         real(wp), dimension(1:3,1:3)     :: rotation, inverse_rotation
-        real(wp)                         :: length_z
         integer                          :: i, j, k, l, ib_patch_id            !< Loop index variables
         ib_patch_id = gp%ib_patch_id
         i = gp%loc(1)
@@ -360,8 +358,7 @@ contains
         real(wp), dimension(1:3)         :: xy_local, normal_vector  !< x and y coordinates in local IB frame
         real(wp), dimension(2)           :: center                   !< x and y coordinates in local IB frame
         real(wp), dimension(1:3,1:3)     :: rotation, inverse_rotation
-        integer                          :: i, j, k                  !< Loop index variables
-        integer                          :: idx                      !< Shortest path direction indicator
+        integer                          :: i, j                     !< Loop index variables
         integer                          :: ib_patch_id              !< patch ID
         ib_patch_id = gp%ib_patch_id
         i = gp%loc(1)
@@ -601,7 +598,7 @@ contains
         $:GPU_ROUTINE(parallelism='[seq]')
 
         type(ghost_point), intent(inout) :: gp
-        integer                          :: i, j, k, patch_id, boundary_edge_count, total_vertices
+        integer                          :: i, j, k, patch_id, boundary_edge_count
         real(wp), dimension(1:3)         :: center, xyz_local
         real(wp)                         :: normals(1:3)  !< Boundary normal buffer
         real(wp)                         :: distance
@@ -614,7 +611,6 @@ contains
 
         ! load in model values
         boundary_edge_count = gpu_boundary_edge_count(patch_id)
-        total_vertices = gpu_total_vertices(patch_id)
 
         center = 0._wp
         if (.not. f_is_default(patch_ib(patch_id)%x_centroid)) center(1) = patch_ib(patch_id)%x_centroid + real(gp%x_periodicity, &

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -830,9 +830,8 @@ contains
     !> Initialize all simulation sub-modules in the required dependency order
     impure subroutine s_initialize_modules
 
-        integer  :: m_ds, n_ds, p_ds
-        integer  :: i, j, k, l, x_id, y_id, z_id, ix, iy, iz
-        real(wp) :: temp1, temp2, temp3, temp4
+        integer :: m_ds, n_ds, p_ds
+        integer :: i
 
         call s_initialize_global_parameters_module()
         #:if USING_AMD

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -455,7 +455,17 @@ class MFCTarget:
     def build(self, case: input.MFCInputFile):
         case.generate_fpp(self)
 
-        command = ["cmake", "--build", self.get_staging_dirpath(case), "--target", self.name, "--parallel", ARG("jobs"), "--config", "Debug" if ARG("debug") else "RelDebug" if ARG("reldebug") else "Release"]
+        command = [
+            "cmake",
+            "--build",
+            self.get_staging_dirpath(case),
+            "--target",
+            self.name,
+            "--parallel",
+            ARG("jobs"),
+            "--config",
+            "Debug" if ARG("debug") else "RelDebug" if ARG("reldebug") else "Release",
+        ]
 
         verbosity = ARG("verbose")
         # -vv or higher: add cmake --verbose flag for full compiler commands

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -383,9 +383,9 @@ class MFCTarget:
             # build the configured targets. This is mostly useful for debugging.
             # See: https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html.
             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-            # Set build type (e.g Debug, Release, etc.).
+            # Set build type (Debug, RelDebug, or Release).
             # See: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
-            f"-DCMAKE_BUILD_TYPE={'Debug' if ARG('debug') else 'Release'}",
+            f"-DCMAKE_BUILD_TYPE={'Debug' if ARG('debug') else 'RelDebug' if ARG('reldebug') else 'Release'}",
             # Used by FIND_PACKAGE (/FindXXX) to search for packages, with the
             # second highest level of priority, still letting users manually
             # specify <PackageName>_ROOT, which has precedence over CMAKE_PREFIX_PATH.
@@ -455,7 +455,7 @@ class MFCTarget:
     def build(self, case: input.MFCInputFile):
         case.generate_fpp(self)
 
-        command = ["cmake", "--build", self.get_staging_dirpath(case), "--target", self.name, "--parallel", ARG("jobs"), "--config", "Debug" if ARG("debug") else "Release"]
+        command = ["cmake", "--build", self.get_staging_dirpath(case), "--target", self.name, "--parallel", ARG("jobs"), "--config", "Debug" if ARG("debug") else "RelDebug" if ARG("reldebug") else "Release"]
 
         verbosity = ARG("verbose")
         # -vv or higher: add cmake --verbose flag for full compiler commands

--- a/toolchain/mfc/cli/argparse_gen.py
+++ b/toolchain/mfc/cli/argparse_gen.py
@@ -93,8 +93,9 @@ def _add_mfc_config_arguments(parser: argparse.ArgumentParser, config):
             )
             parser.add_argument(f"--no-{f.name}", action="store_const", const=gpuConfigOptions.NONE.value, dest=f.name, help=f"Turn the {f.name} option OFF.")
         else:
-            parser.add_argument(f"--{f.name}", action="store_true", help=f"Turn the {f.name} option ON.")
-            parser.add_argument(f"--no-{f.name}", action="store_false", dest=f.name, help=f"Turn the {f.name} option OFF.")
+            cli_name = f.name.replace("_", "-")
+            parser.add_argument(f"--{cli_name}", action="store_true", dest=f.name, help=f"Turn the {f.name} option ON.")
+            parser.add_argument(f"--no-{cli_name}", action="store_false", dest=f.name, help=f"Turn the {f.name} option OFF.")
 
     parser.set_defaults(**{f.name: getattr(config, f.name) for f in dataclasses.fields(config)})
 

--- a/toolchain/mfc/cli/docs_gen.py
+++ b/toolchain/mfc/cli/docs_gen.py
@@ -94,7 +94,8 @@ def _generate_options_table(cmd: Command, schema: CLISchema) -> List[str]:
         if "mfc_config" in cmd.include_common:
             lines.append("| `--mpi`, `--no-mpi` | Enable/disable MPI | `true` |")
             lines.append("| `--gpu [acc/mp]`, `--no-gpu` | Enable GPU (OpenACC/OpenMP) | `no` |")
-            lines.append("| `--debug`, `--no-debug` | Build with debug compiler flags | `false` |")
+            lines.append("| `--debug`, `--no-debug` | Build with full debug compiler flags | `false` |")
+            lines.append("| `--reldebug`, `--no-reldebug` | Build with lightweight debug flags (CI) | `false` |")
 
         lines.append("")
 
@@ -278,7 +279,8 @@ def generate_cli_reference(schema: CLISchema) -> str:
             "|------|-------------|",
             "| `--mpi` / `--no-mpi` | Enable/disable MPI support |",
             "| `--gpu [acc/mp]` / `--no-gpu` | Enable GPU with OpenACC or OpenMP |",
-            "| `--debug` / `--no-debug` | Build with debug compiler flags |",
+            "| `--debug` / `--no-debug` | Build with full debug compiler flags |",
+            "| `--reldebug` / `--no-reldebug` | Build with lightweight debug flags (CI) |",
             "| `--gcov` / `--no-gcov` | Enable code coverage |",
             "| `--single` / `--no-single` | Single precision |",
             "| `--mixed` / `--no-mixed` | Mixed precision |",

--- a/toolchain/mfc/state.py
+++ b/toolchain/mfc/state.py
@@ -15,6 +15,7 @@ class MFCConfig:
     mpi: bool = True
     gpu: str = gpuConfigOptions.NONE.value
     debug: bool = False
+    reldebug: bool = False
     gcov: bool = False
     unified: bool = False
     single: bool = False
@@ -43,10 +44,11 @@ class MFCConfig:
         Example: --no-debug --mpi --no-gpu --no-gcov --no-unified"""
         options = []
         for k, v in self.items():
+            cli_k = k.replace("_", "-")
             if k == "gpu":
-                options.append(f"--{v}-{k}")
+                options.append(f"--{v}-{cli_k}")
             else:
-                options.append(f"--{'no-' if not v else ''}{k}")
+                options.append(f"--{'no-' if not v else ''}{cli_k}")
         return options
 
     def make_slug(self) -> str:
@@ -54,10 +56,11 @@ class MFCConfig:
         identifies the configuration. Example: no-debug_no-gpu_no_mpi_no-gcov"""
         options = []
         for k, v in sorted(self.items(), key=lambda x: x[0]):
+            cli_k = k.replace("_", "-")
             if k == "gpu":
-                options.append(f"--{v}-{k}")
+                options.append(f"--{v}-{cli_k}")
             else:
-                options.append(f"--{'no-' if not v else ''}{k}")
+                options.append(f"--{'no-' if not v else ''}{cli_k}")
         return "_".join(options)
 
     def __eq__(self, other) -> bool:


### PR DESCRIPTION
## Summary
- Initialize `intent(out)` arguments unconditionally before `#ifdef MFC_SIMULATION` blocks to fix "INTENT(OUT) but was not set" warnings in non-simulation builds
- Change `intent(out)` to `intent(inout)` on `s_mpi_allreduce_vectors_sum` to fix aliasing violation when same array passed as both input and output
- Remove unused local variables verified across all build targets

## CI note
This draft includes a temporary CI step ("Collect Compiler Warnings") that rebuilds each target with `-j1` and captures all compiler warnings as artifacts. This is to collect warning lists from gfortran and ifx before making further removals. The CI step will be removed before merging.

## Test plan
- [x] `./mfc.sh precheck -j 8` passes
- [x] `./mfc.sh build -j 8` passes (gfortran, CPU, MPI)
- [x] `./mfc.sh test --reldebug -j 8 -% 5` passes (27/27)
- [ ] CI: gfortran (ubuntu) — warnings collected
- [ ] CI: ifx (ubuntu, intel) — warnings collected
- [ ] CI: gfortran (macos) — warnings collected