### PR TITLE
fix: use DBADDIAOPT for array SILO options (lo_offset, hi_offset)

### DIFF
--- a/src/post_process/m_data_output.fpp
+++ b/src/post_process/m_data_output.fpp
@@ -489,8 +489,8 @@ contains
 
             if (p > 0) then
                 err = DBMKOPTLIST(2, optlist)
-                err = DBADDIOPT(optlist, DBOPT_LO_OFFSET, lo_offset)
-                err = DBADDIOPT(optlist, DBOPT_HI_OFFSET, hi_offset)
+                err = DBADDIAOPT(optlist, DBOPT_LO_OFFSET, size(lo_offset), lo_offset)
+                err = DBADDIAOPT(optlist, DBOPT_HI_OFFSET, size(hi_offset), hi_offset)
                 if (grid_geometry == 3) then
                     err = DBPUTQM(dbfile, 'rectilinear_grid', 16, 'x', 1, 'y', 1, 'z', 1, y_cb, z_cb, x_cb, dims, 3, DB_DOUBLE, &
                                   & DB_COLLINEAR, optlist, ierr)
@@ -501,15 +501,15 @@ contains
                 err = DBFREEOPTLIST(optlist)
             else if (n > 0) then
                 err = DBMKOPTLIST(2, optlist)
-                err = DBADDIOPT(optlist, DBOPT_LO_OFFSET, lo_offset)
-                err = DBADDIOPT(optlist, DBOPT_HI_OFFSET, hi_offset)
+                err = DBADDIAOPT(optlist, DBOPT_LO_OFFSET, size(lo_offset), lo_offset)
+                err = DBADDIAOPT(optlist, DBOPT_HI_OFFSET, size(hi_offset), hi_offset)
                 err = DBPUTQM(dbfile, 'rectilinear_grid', 16, 'x', 1, 'y', 1, 'z', 1, x_cb, y_cb, DB_F77NULL, dims, 2, DB_DOUBLE, &
                               & DB_COLLINEAR, optlist, ierr)
                 err = DBFREEOPTLIST(optlist)
             else
                 err = DBMKOPTLIST(2, optlist)
-                err = DBADDIOPT(optlist, DBOPT_LO_OFFSET, lo_offset)
-                err = DBADDIOPT(optlist, DBOPT_HI_OFFSET, hi_offset)
+                err = DBADDIAOPT(optlist, DBOPT_LO_OFFSET, size(lo_offset), lo_offset)
+                err = DBADDIAOPT(optlist, DBOPT_HI_OFFSET, size(hi_offset), hi_offset)
                 err = DBPUTQM(dbfile, 'rectilinear_grid', 16, 'x', 1, 'y', 1, 'z', 1, x_cb, DB_F77NULL, DB_F77NULL, dims, 1, &
                               & DB_DOUBLE, DB_COLLINEAR, optlist, ierr)
                 err = DBFREEOPTLIST(optlist)


### PR DESCRIPTION
## Summary

`lo_offset` and `hi_offset` are integer arrays (size 1-3 depending on dimensionality), but they were being passed to `DBADDIOPT` which expects a scalar integer. SILO's Fortran wrapper for `DBADDIOPT` stores a pointer to a single `int`, so only the first element was read — meaning 2D and 3D ghost zone offsets beyond the first dimension were silently lost in SILO output files.

Fix: use `DBADDIAOPT(optlist, option, nval, array)` which is the correct SILO function for integer array options.

Verified by reading the SILO Fortran wrapper source (`silo_f.c`):
- `DBADDIOPT_FC(optlist_id, option, ivalue)` — scalar, stores pointer to single int
- `DBADDIAOPT_FC(optlist_id, option, nval, ivalues)` — array, stores pointer to int array with length

## Test plan
- [x] `./mfc.sh precheck -j 8`
- [x] `./mfc.sh build -j 4` (all targets)
- [x] Tested 3D 64^3 case with `format = 2` (SILO output), 4 MPI ranks — post_process completes successfully and produces correct SILO files