### PR TITLE
Fix Claude Code Review CI quota exhaustion

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -182,7 +182,7 @@ jobs:
           plugins: "code-review@claude-code-plugins"
           claude_args: >
             --dangerously-skip-permissions
-            --max-turns 20
+            --max-turns 40
             --allowedTools
             "Bash"
           prompt: |


### PR DESCRIPTION
## Summary
- Remove `synchronize` event trigger that caused the Claude review to run on every push to a PR branch, exhausting the API quota (`You've hit your limit` errors)
- Remove all incremental review mode logic (dead code after `synchronize` removal)
- Filter out `tests/` directory from review inputs — golden files don't need code review

## Test plan
- [x] Verify the Claude Code Review workflow runs on PR open/reopen/ready_for_review/label events
- [x] Verify the workflow does NOT run on push (synchronize) events
- [x] Verify PRs that only change `tests/` files produce an empty review