### PR TITLE
Fix s_axis QBMM buffer reflection azimuthal index

### DIFF
--- a/src/common/m_boundary_common.fpp
+++ b/src/common/m_boundary_common.fpp
@@ -717,8 +717,13 @@ contains
             do i = 1, nb
                 do q = 1, nnode
                     do j = 1, buff_size
-                        pb_in(k, -j, l, q, i) = pb_in(k, j - 1, l - ((p + 1)/2), q, i)
-                        mv_in(k, -j, l, q, i) = mv_in(k, j - 1, l - ((p + 1)/2), q, i)
+                        if (z_cc(l) < pi) then
+                            pb_in(k, -j, l, q, i) = pb_in(k, j - 1, l + ((p + 1)/2), q, i)
+                            mv_in(k, -j, l, q, i) = mv_in(k, j - 1, l + ((p + 1)/2), q, i)
+                        else
+                            pb_in(k, -j, l, q, i) = pb_in(k, j - 1, l - ((p + 1)/2), q, i)
+                            mv_in(k, -j, l, q, i) = mv_in(k, j - 1, l - ((p + 1)/2), q, i)
+                        end if
                     end do
                 end do
             end do


### PR DESCRIPTION
Fixes #1357.

## Summary

- In `s_axis()`, the QBMM buffer reflection block always used `l - ((p+1)/2)` regardless of `z_cc(l)`, while the primitive variable reflection correctly branches on `z_cc(l) < pi`
- For `z_cc(l) < pi`, this read from an incorrect (potentially negative) azimuthal index
- Added the same `z_cc(l) < pi` branch to the `pb_in`/`mv_in` QBMM block to mirror the primitive variable logic

## Test plan

- [ ] 3D cylindrical QBMM simulation with axis BC (`bc_y%beg = -14`) and `z_cc(l) < pi` cells exercises the previously broken branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved axis boundary condition extrapolation for bubble pressure and vapor mass variables. The phase-shift direction is now conditionally selected based on geometric parameters for more accurate calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->