### PR TITLE
test: show full error message on test failure

### DIFF
--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -611,11 +611,7 @@ def handle_case(case: TestCase, devices: typing.Set[int]):
             cons.print(f"    UUID: [magenta]{case.get_uuid()}[/magenta]")
             cons.print(f"    Attempts: {nAttempts}")
 
-            # Show truncated error message
-            exc_str = str(exc)
-            if len(exc_str) > 300:
-                exc_str = exc_str[:297] + "..."
-            cons.print(f"    Error: {exc_str}")
+            cons.print(f"    Error: {exc}")
 
             # Provide helpful hints based on error type
             exc_lower = str(exc).lower()


### PR DESCRIPTION
## Summary

- Removes the 300-character hard truncation of exception messages in the test runner (`handle_case` in `toolchain/mfc/test/test.py`)
- The limit was cutting off valuable diagnostic info on tolerance failures — e.g. the `rel:` value in the tolerance line was being truncated to `re...`
- Error messages from the test framework are already concise and well-structured, so truncation adds no value

## Test plan

- [ ] Run a test with a known golden file mismatch and verify the full tolerance info (both `abs:` and `rel:`) is displayed in the failure output