### PR TITLE
Fix Silo build with MPI-enabled HDF5

### DIFF
--- a/src/simulation/m_bubbles.fpp
+++ b/src/simulation/m_bubbles.fpp
@@ -4,8 +4,7 @@
 
 #:include 'macros.fpp'
 
-!> @brief Shared bubble-dynamics procedures (radial acceleration, wall pressure, sound speed) for ensemble- and volume-averaged
-!! models
+!> @brief Bubble-dynamics procedures for ensemble- and volume-averaged models
 module m_bubbles
 
     use m_derived_types

--- a/toolchain/dependencies/CMakeLists.txt
+++ b/toolchain/dependencies/CMakeLists.txt
@@ -82,6 +82,17 @@ if (MFC_SILO)
     else()
         find_package(Git REQUIRED)
 
+        # When the system HDF5 is the MPI-enabled variant (e.g. libhdf5-openmpi-dev),
+        # its headers transitively include mpi.h.  Propagate MPI include dirs into the
+        # silo sub-build so those headers can be found.
+        find_package(MPI COMPONENTS C QUIET)
+        set(_silo_c_flags "${CMAKE_C_FLAGS}")
+        if (MPI_C_FOUND)
+            foreach(_dir IN LISTS MPI_C_INCLUDE_DIRS)
+                string(APPEND _silo_c_flags " -I${_dir}")
+            endforeach()
+        endif()
+
         ExternalProject_Add(silo
             GIT_REPOSITORY "https://github.com/LLNL/Silo"
             GIT_TAG        4.12.0
@@ -98,6 +109,7 @@ if (MFC_SILO)
                            "-DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}"
                            "-DCMAKE_FIND_PACKAGE_REDIRECTS_DIR=${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}"
                            "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
+                           "-DCMAKE_C_FLAGS=${_silo_c_flags}"
                            "$<$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},Cray>:-DCMAKE_MODULE_PATH=${CMAKE_SOURCE_DIR}/../cmake/cce>"
         )
     endif()


### PR DESCRIPTION
## Description

Fix Silo build failures on systems using MPI-enabled HDF5. 
Non-breaking for existing successful builds.

- [x] Bug fix

## Testing

Verified build on a system with MPI-enabled HDF5.
Verified build on Frontier (GPU).

## AI code reviews

Reviews are not triggered automatically. To request a review, comment on the PR:
- `@coderabbitai review` — incremental review (new changes only)
- `@coderabbitai full review` — full review from scratch
- `/review` — Qodo review
- `/improve` — Qodo code suggestions
- `@claude full review` — Claude full review (also triggers on PR open/reopen/ready)
- Add label `claude-full-review` — Claude full review via label
