### PR TITLE
Support module unload in modules file; unload xalt on Phoenix GPU

### DIFF
--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -68,7 +68,7 @@ module m_rhs
     $:GPU_DECLARE(create='[tau_Re_vf]')
 
     !> @name The cell-boundary values of the fluxes (src - source, gsrc - geometrical source). These are computed by applying the
-    !! chosen Riemann problem solver .on the left and right cell-boundary values of the primitive variables
+    !! chosen Riemann problem solver on the left and right cell-boundary values of the primitive variables
     !> @{
     type(vector_field), allocatable, dimension(:) :: flux_n
     type(vector_field), allocatable, dimension(:) :: flux_src_n

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -119,6 +119,13 @@ if [ $(echo "$VARIABLES" | grep = | wc -c) -gt 0 ]; then
     export $(eval "echo $VARIABLES") > /dev/null
 fi
 
+UNLOAD_MODULES="$(__extract "$u_c-all-unload") $(__extract "$u_c-$cg-unload")"
+UNLOAD_MODULES=$(echo "$UNLOAD_MODULES" | xargs)
+if [ -n "$UNLOAD_MODULES" ]; then
+    log " $ module unload $UNLOAD_MODULES"
+    module unload $UNLOAD_MODULES
+fi
+
 # Don't check for Cray paths on Carpenter, otherwise do check if they exist
 if [ ! -z ${CRAY_LD_LIBRARY_PATH+x} ] && [ "$u_c" '!=' 'c' ] &&  [ "$u_c" '!=' 'famd' ] ; then
     ok "Found $M\$CRAY_LD_LIBRARY_PATH$CR. Prepending to $M\$LD_LIBRARY_PATH$CR."

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -39,6 +39,7 @@ p-all python/3.12.5
 p-cpu gcc/12.3.0 openmpi/4.1.5
 p-gpu python/3.12.5 nvhpc/24.5 hpcx/2.19-cuda cuda/12.1.1
 p-gpu MFC_CUDA_CC=70,75,80,89,90 NVHPC_CUDA_HOME=$CUDA_HOME CC=nvc CXX=nvc++ FC=nvfortran
+p-gpu-unload xalt
 
 f     OLCF Frontier
 f-all cpe/25.03 rocm/6.3.1


### PR DESCRIPTION
## Summary
- Adds `<slug>-[all|cpu|gpu]-unload` line support to `toolchain/modules` for specifying modules to unload after loading
- Unloads `xalt` on Phoenix GPU (`p-gpu-unload xalt`)

## Test plan
- [x] Source `./mfc.sh load -c p -m g` on Phoenix and verify `xalt` is unloaded at the end