### PR TITLE
Fix post_process silo coord corruption from assumed-shape re-mapping

### DIFF
--- a/src/post_process/m_data_input.f90
+++ b/src/post_process/m_data_input.f90
@@ -211,13 +211,17 @@ contains
             call s_assign_default_bc_type(bc_type)
         end if
 
-        call s_read_grid_data_direction(t_step_dir, 'x', x_cb, dx, x_cc, m)
+        ! Pass explicit slices so the dummy `dimension(-1:)` / `dimension(0:)` arguments map to the correct interior indices of the
+        ! actual arrays. Without slicing, when offset_x%beg or buff_size > 0 (i.e. format=1 parallel 3D ranks), Fortran's
+        ! assumed-shape re-mapping shifts the read by that many slots and leaves the last interior cells uninitialized - corrupting
+        ! downstream ghost-cell extrapolation.
+        call s_read_grid_data_direction(t_step_dir, 'x', x_cb(-1:m), dx(0:m), x_cc(0:m), m)
 
         if (n > 0) then
-            call s_read_grid_data_direction(t_step_dir, 'y', y_cb, dy, y_cc, n)
+            call s_read_grid_data_direction(t_step_dir, 'y', y_cb(-1:n), dy(0:n), y_cc(0:n), n)
 
             if (p > 0) then
-                call s_read_grid_data_direction(t_step_dir, 'z', z_cb, dz, z_cc, p)
+                call s_read_grid_data_direction(t_step_dir, 'z', z_cb(-1:p), dz(0:p), z_cc(0:p), p)
             end if
         end if
 


### PR DESCRIPTION
## Summary

`s_read_grid_data_direction` (post_process serial-IO grid read, [`m_data_input.f90:50`](https://github.com/MFlowCode/MFC/blob/master/src/post_process/m_data_input.f90#L50)) declares dummy arguments `dimension(-1:)` / `dimension(0:)`. When the actual `x_cb` / `dx` / `x_cc` arrays have shifted lower bounds (`offset_x%beg > 0` or `buff_size > 0` — set non-zero for `format=1` parallel 3D ranks not at the left domain boundary), Fortran's assumed-shape re-mapping makes the dummy's first element correspond to the actual's first storage slot rather than the intended interior index. The read then writes into the wrong range of the actual array and leaves the last `offset_x%beg` interior cell-boundaries uninitialized; `s_populate_grid_variables_buffers` later propagates those uninitialized values into the right ghost zone and the silo output.

Fix: pass explicit slices `x_cb(-1:m)`, `dx(0:m)`, `x_cc(0:m)` (and y/z equivalents) so the dummy maps to the intended index range regardless of the actual's allocation bounds.

## Background

Regression from #902 (June 2025); pre-refactor code used inline `read (1) x_cb(-1:m)` which avoided the re-mapping by writing directly to the actual's correct indices. `format=2` (binary) is unaffected because [`m_global_parameters.fpp:779`](https://github.com/MFlowCode/MFC/blob/master/src/post_process/m_global_parameters.fpp#L779) zeros all offsets when `format /= 1`, so allocations match dummy bounds. `parallel_io=T` is also unaffected because that path uses explicit slice assignment instead of the helper.

The bug is mostly silent: shifted coords on a uniform grid look identical to the correct grid, so the field data renders fine. It surfaces visibly only when the uninitialized memory the read leaves behind happens to contain NaN or an extreme value, which then gets written to `{step}.silo` for that rank.

## Verification

128-rank 3D droplet-coalescence case, `parallel_io: F`, `format: 1`:

| | Bad ranks (NaN / |coord| > 1 m) | Assembled global grid |
| --- | --- | --- |
| Before | 9 / 128 | 193 × 3 × 159 (y collapsed by dedup) |
| After | 0 / 128 | 180 × 120 × 120 (matches `format=2`) |

## Test plan

- [x] `./mfc.sh format -j 8`
- [x] `./mfc.sh precheck -j 8` (ran via pre-commit hook)
- [x] `./mfc.sh build -t post_process -j 8`
- [x] Re-ran the affected case with `format: 1` on 128 ranks; all coord arrays clean.
- [ ] CI: full test suite across compiler matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)