### PR TITLE
Phoenix GPU: bump nvhpc to 25.5 and use system openmpi

### DIFF
--- a/src/simulation/m_riemann_solvers.fpp
+++ b/src/simulation/m_riemann_solvers.fpp
@@ -908,7 +908,7 @@ contains
             & dqL_prim_dy_vf, dqL_prim_dz_vf, qR_prim_rsx_vf, qR_prim_rsy_vf, qR_prim_rsz_vf, dqR_prim_dx_vf, dqR_prim_dy_vf, &
             & dqR_prim_dz_vf, norm_dir, ix, iy, iz)
 
-        ! Reshaping inputted data based on dimensional splitting direction
+        ! Reshaping input data based on dimensional splitting direction
         call s_initialize_riemann_solver(flux_src_vf, norm_dir)
         #:for NORM_DIR, XYZ in [(1, 'x'), (2, 'y'), (3, 'z')]
             if (norm_dir == ${NORM_DIR}$) then

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -37,7 +37,7 @@ e-gpu CC=nvc CXX=nvc++ FC=nvfortran
 p     GT Phoenix
 p-all python/3.12.5
 p-cpu gcc/12.3.0 openmpi/4.1.5
-p-gpu python/3.12.5 nvhpc/24.5 hpcx/2.19-cuda cuda/12.1.1
+p-gpu python/3.12.5 nvhpc/25.5 cuda/12.1.1 openmpi
 p-gpu MFC_CUDA_CC=70,75,80,89,90 NVHPC_CUDA_HOME=$CUDA_HOME CC=nvc CXX=nvc++ FC=nvfortran
 p-gpu-unload xalt
 


### PR DESCRIPTION
## Summary
- Update Phoenix GPU module set: `nvhpc/24.5` → `nvhpc/25.5`, drop `hpcx/2.19-cuda`, add system `openmpi`.

## Test plan
- [ ] `source ./mfc.sh load -c p -m g` succeeds on Phoenix
- [ ] `./mfc.sh build --gpu acc -j 8` succeeds on Phoenix GPU node
- [ ] Run a representative GPU case to confirm runtime