### PR TITLE
Fix  bug with num_fluids = 3 and AMD 

### DIFF
--- a/src/simulation/m_pressure_relaxation.fpp
+++ b/src/simulation/m_pressure_relaxation.fpp
@@ -217,7 +217,7 @@ contains
         type(scalar_field), dimension(sys_size), intent(inout) :: q_cons_vf
         integer, intent(in)                                    :: j, k, l
         #:if not MFC_CASE_OPTIMIZATION and USING_AMD
-            real(wp), dimension(2) :: alpha_rho, alpha
+            real(wp), dimension(3) :: alpha_rho, alpha
         #:else
             real(wp), dimension(num_fluids) :: alpha_rho, alpha
         #:endif


### PR DESCRIPTION
## Description

Fixing a bug when num_fluids = 3 and MFC_CASE_OPTIMIZATION is off with AMD compilers. 

There is a check guarding this when num_fluids > 3 with these conditions, that can be resolved once the internal issue is fixed with private arrays

Closes #1368 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other: _describe_

## Testing

How did you test your changes?

## Checklist

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed

See the [developer guide](https://mflowcode.github.io/documentation/contributing.html) for full coding standards.

<details>
<summary><strong>GPU changes</strong> (expand if you modified <code>src/simulation/</code>)</summary>

- [ ] GPU results match CPU results
- [ ] Tested on NVIDIA GPU or AMD GPU

</details>

## AI code reviews

Reviews are not triggered automatically. To request a review, comment on the PR:
- `@coderabbitai review` — incremental review (new changes only)
- `@coderabbitai full review` — full review from scratch
- `/review` — Qodo review
- `/improve` — Qodo code suggestions
- `@claude full review` — Claude full review (also triggers on PR open/reopen/ready)
- Add label `claude-full-review` — Claude full review via label
