### PR TITLE
Fix IB Periodicity Movement

### DIFF
--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -201,6 +201,7 @@ contains
                 k = gp%loc(2)
                 l = gp%loc(3)
                 patch_id = ghost_points(i)%ib_patch_id
+                call s_decode_patch_periodicity(patch_id, patch_id)
 
                 ! Calculate physical location of GP
                 if (p > 0) then


### PR DESCRIPTION
Ib patch periodicity was never decoded before state correction. This causes errors specifically when the IB is moving across the boundary periodically. One processor reads normal values. The other reads uninstantiated garbage, and this causes conflict.

This one-line change resolves the issue.