### PR TITLE
Fix Cray GPU routine macros: INLINENEVER directive and cray_inline scoping

### DIFF
--- a/src/common/include/parallel_macros.fpp
+++ b/src/common/include/parallel_macros.fpp
@@ -67,10 +67,11 @@
         #:if not isinstance(function_name, str)
             #:stop "When using cray_noinline, function name must be given and given as a string"
         #:endif
-        #:set cray_noinline_directive = ('!DIR$ NOINLINE ' + function_name).strip('\n')
+        #:set cray_noinline_directive = ('!DIR$ INLINENEVER ' + function_name).strip('\n')
 #ifdef _CRAYFTN
 #if MFC_OpenACC
         $:acc_directive
+        $:cray_noinline_directive
 #elif MFC_OpenMP
         $:omp_directive
 #else
@@ -91,6 +92,7 @@
 #ifdef _CRAYFTN
 #if MFC_OpenACC
         $:acc_directive
+        $:cray_directive
 #elif MFC_OpenMP
         $:omp_directive
 #else
@@ -98,6 +100,7 @@
 #endif
 #elif MFC_OpenACC
         $:acc_directive
+        $:cray_directive
 #elif MFC_OpenMP
         $:omp_directive
 #endif

--- a/src/common/include/parallel_macros.fpp
+++ b/src/common/include/parallel_macros.fpp
@@ -78,7 +78,7 @@
         $:cray_noinline_directive
 #endif
         #! On non-Cray CPU builds (no _CRAYFTN, no MFC_OpenACC, no MFC_OpenMP), nothing is
-        #! emitted — intentional, since !DIR$ NOINLINE is a Cray-specific directive.
+        #! emitted — intentional, since !DIR$ INLINENEVER is a Cray-specific directive.
 #elif MFC_OpenACC
         $:acc_directive
 #elif MFC_OpenMP
@@ -100,7 +100,6 @@
 #endif
 #elif MFC_OpenACC
         $:acc_directive
-        $:cray_directive
 #elif MFC_OpenMP
         $:omp_directive
 #endif

--- a/src/common/m_variables_conversion.fpp
+++ b/src/common/m_variables_conversion.fpp
@@ -82,7 +82,7 @@ contains
     !> Compute the pressure from the appropriate equation of state
     subroutine s_compute_pressure(energy, alf, dyn_p, pi_inf, gamma, rho, qv, rhoYks, pres, T, stress, mom, G, pres_mag)
 
-        $:GPU_ROUTINE(function_name='s_compute_pressure',parallelism='[seq]', cray_noinline=True)
+        $:GPU_ROUTINE(function_name='s_compute_pressure',parallelism='[seq]', cray_inline=True)
 
         real(stp), intent(in)           :: energy, alf
         real(wp), intent(in)            :: dyn_p
@@ -501,7 +501,6 @@ contains
         real(wp)               :: E, D                     !< Prim/Cons variables within Newton-Raphson iteration
         real(wp)               :: f, dGa_dW, dp_dW, df_dW  !< Functions within Newton-Raphson iteration
         integer                :: iter                     !< Newton-Raphson iteration counter
-
         $:GPU_PARALLEL_LOOP(collapse=3, private='[alpha_K, alpha_rho_K, Re_K, nRtmp, rho_K, gamma_K, pi_inf_K, qv_K, dyn_pres_K, &
                             & rhoYks, B, pres, vftmp, nbub_sc, G_K, T, pres_mag, Ga, B2, m2, S, W, dW, E, D, f, dGa_dW, dp_dW, &
                             & df_dW, iter]')


### PR DESCRIPTION
## Summary

- Renames `!DIR$ NOINLINE` → `!DIR$ INLINENEVER` in the `cray_noinline` branch of `GPU_ROUTINE` (the correct Cray CCE directive name)
- Adds the missing `$:cray_noinline_directive` emission in the Cray+OpenACC path
- Introduces `cray_inline=True` option for `GPU_ROUTINE` emitting `!DIR$ INLINEALWAYS`, used by `s_compute_pressure`
- Fixes a scoping bug where `!DIR$ INLINEALWAYS` was incorrectly emitted on non-Cray OpenACC builds (e.g. NVIDIA nvfortran); the directive is now Cray-only, matching the `cray_noinline` pattern

## Test plan

- [ ] Verify Cray CCE OpenACC build compiles with correct `!DIR$ INLINENEVER` / `!DIR$ INLINEALWAYS` directives on targeted routines
- [ ] Verify NVIDIA nvfortran OpenACC build does not emit any `!DIR$` directives
- [ ] Verify OpenMP target offload build is unaffected
- [ ] Verify CPU-only build is unaffected
- [x] `./mfc.sh precheck -j 8` passes (all 6 lint gates)