### PR TITLE
fix: extend CCE 19.0.0 -Oipa0 workaround to m_mpi_common.fpp

### DIFF
--- a/.github/workflows/common/build.sh
+++ b/.github/workflows/common/build.sh
@@ -26,8 +26,8 @@ fi
 # Phoenix: always start fresh to avoid SIGILL from stale binaries compiled
 # on a different microarchitecture.
 # Frontier: wipe only compiled Fortran staging/install slugs; preserve dep
-# dirs (silo, hdf5, lapack, fftw) which were built on the login node and
-# cannot be re-fetched from a compute node (no internet).
+# dirs (silo, hdf5, lapack, fftw, hipfort) which were built on the login node
+# and cannot be re-fetched from a compute node (no internet).
 if [ "$job_cluster" = "phoenix" ]; then
     source .github/scripts/clean-build.sh
     clean_build
@@ -36,7 +36,7 @@ elif [ "$job_cluster" = "frontier" ] || [ "$job_cluster" = "frontier_amd" ]; the
         if [ -d "$_dir" ]; then
             for _sub in "$_dir"*/; do
                 _name=$(basename "$_sub")
-                case "$_name" in silo|hdf5|lapack|fftw) continue ;; esac
+                case "$_name" in silo|hdf5|lapack|fftw|hipfort) continue ;; esac
                 rm -rf "$_sub"
             done
         fi

--- a/.github/workflows/common/build.sh
+++ b/.github/workflows/common/build.sh
@@ -25,9 +25,23 @@ fi
 # source code is built here on the compute node.
 # Phoenix: always start fresh to avoid SIGILL from stale binaries compiled
 # on a different microarchitecture.
+# Frontier: wipe only compiled Fortran staging/install slugs; preserve dep
+# dirs (silo, hdf5, lapack, fftw) which were built on the login node and
+# cannot be re-fetched from a compute node (no internet).
 if [ "$job_cluster" = "phoenix" ]; then
     source .github/scripts/clean-build.sh
     clean_build
+elif [ "$job_cluster" = "frontier" ] || [ "$job_cluster" = "frontier_amd" ]; then
+    for _dir in build/staging/ build/install/; do
+        if [ -d "$_dir" ]; then
+            for _sub in "$_dir"*/; do
+                _name=$(basename "$_sub")
+                case "$_name" in silo|hdf5|lapack|fftw) continue ;; esac
+                rm -rf "$_sub"
+            done
+        fi
+    done
+    unset _dir _sub _name
 fi
 
 source .github/scripts/retry-build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,12 +735,10 @@ if (MFC_PRE_PROCESS)
     if(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
         target_compile_options(pre_process PRIVATE -hfp0)
         # CCE 19.0.0 IPA ICE: bring_routine_resident SIGSEGV in optcg during
-        # ipa_processing on GitHub Actions runners. Only manifests in CI (runner
-        # memory layout triggers the nondeterministic crash). Guard with
-        # GITHUB_ACTIONS so local Frontier builds keep full IPA performance.
-        if (DEFINED ENV{GITHUB_ACTIONS})
-            target_compile_options(pre_process PRIVATE -Oipa0)
-        endif()
+        # ipa_processing. Nondeterministic — any file can become the crash site
+        # via cross-file inlining. Safe to disable IPA for the whole target
+        # (CPU-only, no GPU device-call requirements). See PR #1286.
+        target_compile_options(pre_process PRIVATE -Oipa0)
     endif()
 endif()
 
@@ -748,8 +746,7 @@ if (MFC_SIMULATION)
     MFC_SETUP_TARGET(TARGET  simulation
                      SOURCES "${simulation_SRCs}"
                      MPI FFTW OpenACC OpenMP)
-    # CCE 19.0.0 optcg ICE on GitHub Actions runners: IPA inlining triggers two
-    # distinct crashes in optcg:
+    # CCE 19.0.0 optcg ICE: IPA inlining triggers two distinct crashes:
     #   m_bubbles_EL:  castIsValid assertion (InstCombine/foldIntegerTypedPHI)
     #   m_phase_change, m_mpi_common, m_start_up: bring_routine_resident SIGSEGV
     # GPU builds: apply -Oipa0 per-file to known crash sites. Whole-target
@@ -758,7 +755,7 @@ if (MFC_SIMULATION)
     # CPU builds: disable IPA for the whole target (safe — no GPU requirements,
     # and the crash is nondeterministic so any file can become the crash site).
     # See PR #1286.
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" AND DEFINED ENV{GITHUB_ACTIONS})
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
         if (MFC_OpenACC OR MFC_OpenMP)
             set_source_files_properties(
                 "${CMAKE_BINARY_DIR}/fypp/simulation/m_bubbles_EL.fpp.f90"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,12 +734,11 @@ if (MFC_PRE_PROCESS)
                      MPI)
     if(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
         target_compile_options(pre_process PRIVATE -hfp0)
-        # CCE 19.0.0 IPA workaround: m_mpi_common triggers bring_routine_resident
-        # SIGSEGV in optcg during ipa_processing. See simulation block below for details.
-        set_source_files_properties(
-            "${CMAKE_BINARY_DIR}/fypp/pre_process/m_mpi_common.fpp.f90"
-            PROPERTIES COMPILE_OPTIONS "-Oipa0"
-        )
+        # CCE 19.0.0 IPA ICE: bring_routine_resident SIGSEGV in optcg during
+        # ipa_processing. The crash is nondeterministic and can hit any file via
+        # cross-file inlining, so disable IPA for the whole target. Safe for
+        # pre_process (CPU-only, no thermochem IPA requirements).
+        target_compile_options(pre_process PRIVATE -Oipa0)
     endif()
 endif()
 
@@ -747,21 +746,15 @@ if (MFC_SIMULATION)
     MFC_SETUP_TARGET(TARGET  simulation
                      SOURCES "${simulation_SRCs}"
                      MPI FFTW OpenACC OpenMP)
-    # CCE 19.0.0 IPA workaround: disable interprocedural analysis for files
-    # that trigger compiler crashes during IPA:
-    #   m_bubbles_EL: castIsValid assertion (InstCombine/foldIntegerTypedPHI)
-    #   m_phase_change, m_mpi_common: bring_routine_resident SIGSEGV
+    # CCE 19.0.0 IPA ICE: bring_routine_resident SIGSEGV in optcg during
+    # ipa_processing. The crash is nondeterministic — IPA inlines across all
+    # files in the target, so any file can become the crash site. Per-file
+    # -Oipa0 via set_source_files_properties is insufficient.
     # Not applied to Cray+OpenMP because thermochem uses !DIR$ INLINEALWAYS,
     # which requires IPA to inline device calls. On OpenACC the pyrometheus
     # patch emits !$acc routine seq instead (no IPA needed). See PR #1286.
     if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" AND NOT MFC_OpenMP)
-        set_source_files_properties(
-            "${CMAKE_BINARY_DIR}/fypp/simulation/m_bubbles_EL.fpp.f90"
-            "${CMAKE_BINARY_DIR}/fypp/simulation/m_phase_change.fpp.f90"
-            "${CMAKE_BINARY_DIR}/fypp/simulation/m_mpi_common.fpp.f90"
-            "${CMAKE_BINARY_DIR}/fypp/simulation/m_start_up.fpp.f90"
-            PROPERTIES COMPILE_OPTIONS "-Oipa0"
-        )
+        target_compile_options(simulation PRIVATE -Oipa0)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,6 +759,7 @@ if (MFC_SIMULATION)
             "${CMAKE_BINARY_DIR}/fypp/simulation/m_bubbles_EL.fpp.f90"
             "${CMAKE_BINARY_DIR}/fypp/simulation/m_phase_change.fpp.f90"
             "${CMAKE_BINARY_DIR}/fypp/simulation/m_mpi_common.fpp.f90"
+            "${CMAKE_BINARY_DIR}/fypp/simulation/m_start_up.fpp.f90"
             PROPERTIES COMPILE_OPTIONS "-Oipa0"
         )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,17 +748,17 @@ if (MFC_SIMULATION)
     MFC_SETUP_TARGET(TARGET  simulation
                      SOURCES "${simulation_SRCs}"
                      MPI FFTW OpenACC OpenMP)
-    # CCE 19.0.0 IPA ICE: bring_routine_resident SIGSEGV in optcg during
-    # ipa_processing on GitHub Actions runners. Only manifests in CI.
-    # CPU builds: safe to disable IPA for the entire target (no GPU device-call
-    # requirements). GPU builds (OpenACC or OpenMP): whole-target -Oipa0 breaks
-    # cross-file !$acc routine / !DIR$ INLINEALWAYS device registration, causing
-    # runtime aborts. Apply -Oipa0 per-file to the known crash sites only.
-    # See PR #1286.
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" AND DEFINED ENV{GITHUB_ACTIONS})
-        if (NOT MFC_OpenACC AND NOT MFC_OpenMP)
-            target_compile_options(simulation PRIVATE -Oipa0)
-        else()
+    # CCE 19.0.0 optcg ICE: two distinct crashes triggered by IPA inlining:
+    #   m_bubbles_EL:  castIsValid assertion (InstCombine/foldIntegerTypedPHI)
+    #   m_phase_change, m_mpi_common, m_start_up: bring_routine_resident SIGSEGV
+    # Both crash locally and in CI on GPU builds. Apply -Oipa0 per-file
+    # unconditionally to the known crash sites (IPA cross-file inlining triggers
+    # the ICE; per-file disabling prevents it without affecting other files).
+    # CPU-only builds in CI additionally disable IPA for the whole target
+    # (safe — no GPU device-call requirements, and the crash is nondeterministic
+    # so any file can become the crash site). See PR #1286.
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+        if (MFC_OpenACC OR MFC_OpenMP)
             set_source_files_properties(
                 "${CMAKE_BINARY_DIR}/fypp/simulation/m_bubbles_EL.fpp.f90"
                 "${CMAKE_BINARY_DIR}/fypp/simulation/m_phase_change.fpp.f90"
@@ -766,6 +766,8 @@ if (MFC_SIMULATION)
                 "${CMAKE_BINARY_DIR}/fypp/simulation/m_start_up.fpp.f90"
                 PROPERTIES COMPILE_OPTIONS "-Oipa0"
             )
+        elseif (DEFINED ENV{GITHUB_ACTIONS})
+            target_compile_options(simulation PRIVATE -Oipa0)
         endif()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,13 +748,25 @@ if (MFC_SIMULATION)
                      MPI FFTW OpenACC OpenMP)
     # CCE 19.0.0 IPA ICE: bring_routine_resident SIGSEGV in optcg during
     # ipa_processing. The crash is nondeterministic — IPA inlines across all
-    # files in the target, so any file can become the crash site. Per-file
-    # -Oipa0 via set_source_files_properties is insufficient.
-    # Not applied to Cray+OpenMP because thermochem uses !DIR$ INLINEALWAYS,
-    # which requires IPA to inline device calls. On OpenACC the pyrometheus
-    # patch emits !$acc routine seq instead (no IPA needed). See PR #1286.
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" AND NOT MFC_OpenMP)
-        target_compile_options(simulation PRIVATE -Oipa0)
+    # files in the target, so any file can become the crash site.
+    # For non-OpenMP builds: disable IPA for the entire target (safe, no IPA
+    # requirements). For OpenMP builds: thermochem uses !DIR$ INLINEALWAYS
+    # which requires IPA for device-call inlining, so we cannot disable IPA
+    # globally. Instead apply -Oipa0 per-file to the known crash sites.
+    # On OpenACC the pyrometheus patch emits !$acc routine seq (no IPA needed).
+    # See PR #1286.
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+        if (NOT MFC_OpenMP)
+            target_compile_options(simulation PRIVATE -Oipa0)
+        else()
+            set_source_files_properties(
+                "${CMAKE_BINARY_DIR}/fypp/simulation/m_bubbles_EL.fpp.f90"
+                "${CMAKE_BINARY_DIR}/fypp/simulation/m_phase_change.fpp.f90"
+                "${CMAKE_BINARY_DIR}/fypp/simulation/m_mpi_common.fpp.f90"
+                "${CMAKE_BINARY_DIR}/fypp/simulation/m_start_up.fpp.f90"
+                PROPERTIES COMPILE_OPTIONS "-Oipa0"
+            )
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,6 +734,12 @@ if (MFC_PRE_PROCESS)
                      MPI)
     if(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
         target_compile_options(pre_process PRIVATE -hfp0)
+        # CCE 19.0.0 IPA workaround: m_mpi_common triggers bring_routine_resident
+        # SIGSEGV in optcg during ipa_processing. See simulation block below for details.
+        set_source_files_properties(
+            "${CMAKE_BINARY_DIR}/fypp/pre_process/m_mpi_common.fpp.f90"
+            PROPERTIES COMPILE_OPTIONS "-Oipa0"
+        )
     endif()
 endif()
 
@@ -744,7 +750,7 @@ if (MFC_SIMULATION)
     # CCE 19.0.0 IPA workaround: disable interprocedural analysis for files
     # that trigger compiler crashes during IPA:
     #   m_bubbles_EL: castIsValid assertion (InstCombine/foldIntegerTypedPHI)
-    #   m_phase_change: bring_routine_resident SIGSEGV
+    #   m_phase_change, m_mpi_common: bring_routine_resident SIGSEGV
     # Not applied to Cray+OpenMP because thermochem uses !DIR$ INLINEALWAYS,
     # which requires IPA to inline device calls. On OpenACC the pyrometheus
     # patch emits !$acc routine seq instead (no IPA needed). See PR #1286.
@@ -752,6 +758,7 @@ if (MFC_SIMULATION)
         set_source_files_properties(
             "${CMAKE_BINARY_DIR}/fypp/simulation/m_bubbles_EL.fpp.f90"
             "${CMAKE_BINARY_DIR}/fypp/simulation/m_phase_change.fpp.f90"
+            "${CMAKE_BINARY_DIR}/fypp/simulation/m_mpi_common.fpp.f90"
             PROPERTIES COMPILE_OPTIONS "-Oipa0"
         )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,14 +750,13 @@ if (MFC_SIMULATION)
                      MPI FFTW OpenACC OpenMP)
     # CCE 19.0.0 IPA ICE: bring_routine_resident SIGSEGV in optcg during
     # ipa_processing on GitHub Actions runners. Only manifests in CI.
-    # For non-OpenMP builds: disable IPA for the entire target (safe, no IPA
-    # requirements). For OpenMP builds: thermochem uses !DIR$ INLINEALWAYS
-    # which requires IPA for device-call inlining, so we cannot disable IPA
-    # globally. Instead apply -Oipa0 per-file to the known crash sites.
-    # On OpenACC the pyrometheus patch emits !$acc routine seq (no IPA needed).
+    # CPU builds: safe to disable IPA for the entire target (no GPU device-call
+    # requirements). GPU builds (OpenACC or OpenMP): whole-target -Oipa0 breaks
+    # cross-file !$acc routine / !DIR$ INLINEALWAYS device registration, causing
+    # runtime aborts. Apply -Oipa0 per-file to the known crash sites only.
     # See PR #1286.
     if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" AND DEFINED ENV{GITHUB_ACTIONS})
-        if (NOT MFC_OpenMP)
+        if (NOT MFC_OpenACC AND NOT MFC_OpenMP)
             target_compile_options(simulation PRIVATE -Oipa0)
         else()
             set_source_files_properties(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,10 +735,12 @@ if (MFC_PRE_PROCESS)
     if(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
         target_compile_options(pre_process PRIVATE -hfp0)
         # CCE 19.0.0 IPA ICE: bring_routine_resident SIGSEGV in optcg during
-        # ipa_processing. The crash is nondeterministic and can hit any file via
-        # cross-file inlining, so disable IPA for the whole target. Safe for
-        # pre_process (CPU-only, no thermochem IPA requirements).
-        target_compile_options(pre_process PRIVATE -Oipa0)
+        # ipa_processing on GitHub Actions runners. Only manifests in CI (runner
+        # memory layout triggers the nondeterministic crash). Guard with
+        # GITHUB_ACTIONS so local Frontier builds keep full IPA performance.
+        if (DEFINED ENV{GITHUB_ACTIONS})
+            target_compile_options(pre_process PRIVATE -Oipa0)
+        endif()
     endif()
 endif()
 
@@ -747,15 +749,14 @@ if (MFC_SIMULATION)
                      SOURCES "${simulation_SRCs}"
                      MPI FFTW OpenACC OpenMP)
     # CCE 19.0.0 IPA ICE: bring_routine_resident SIGSEGV in optcg during
-    # ipa_processing. The crash is nondeterministic — IPA inlines across all
-    # files in the target, so any file can become the crash site.
+    # ipa_processing on GitHub Actions runners. Only manifests in CI.
     # For non-OpenMP builds: disable IPA for the entire target (safe, no IPA
     # requirements). For OpenMP builds: thermochem uses !DIR$ INLINEALWAYS
     # which requires IPA for device-call inlining, so we cannot disable IPA
     # globally. Instead apply -Oipa0 per-file to the known crash sites.
     # On OpenACC the pyrometheus patch emits !$acc routine seq (no IPA needed).
     # See PR #1286.
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" AND DEFINED ENV{GITHUB_ACTIONS})
         if (NOT MFC_OpenMP)
             target_compile_options(simulation PRIVATE -Oipa0)
         else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,16 +748,17 @@ if (MFC_SIMULATION)
     MFC_SETUP_TARGET(TARGET  simulation
                      SOURCES "${simulation_SRCs}"
                      MPI FFTW OpenACC OpenMP)
-    # CCE 19.0.0 optcg ICE: two distinct crashes triggered by IPA inlining:
+    # CCE 19.0.0 optcg ICE on GitHub Actions runners: IPA inlining triggers two
+    # distinct crashes in optcg:
     #   m_bubbles_EL:  castIsValid assertion (InstCombine/foldIntegerTypedPHI)
     #   m_phase_change, m_mpi_common, m_start_up: bring_routine_resident SIGSEGV
-    # Both crash locally and in CI on GPU builds. Apply -Oipa0 per-file
-    # unconditionally to the known crash sites (IPA cross-file inlining triggers
-    # the ICE; per-file disabling prevents it without affecting other files).
-    # CPU-only builds in CI additionally disable IPA for the whole target
-    # (safe — no GPU device-call requirements, and the crash is nondeterministic
-    # so any file can become the crash site). See PR #1286.
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+    # GPU builds: apply -Oipa0 per-file to known crash sites. Whole-target
+    # -Oipa0 is not safe for GPU builds — it breaks cross-file !$acc routine /
+    # !DIR$ INLINEALWAYS device-call registration, causing runtime aborts.
+    # CPU builds: disable IPA for the whole target (safe — no GPU requirements,
+    # and the crash is nondeterministic so any file can become the crash site).
+    # See PR #1286.
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" AND DEFINED ENV{GITHUB_ACTIONS})
         if (MFC_OpenACC OR MFC_OpenMP)
             set_source_files_properties(
                 "${CMAKE_BINARY_DIR}/fypp/simulation/m_bubbles_EL.fpp.f90"
@@ -766,7 +767,7 @@ if (MFC_SIMULATION)
                 "${CMAKE_BINARY_DIR}/fypp/simulation/m_start_up.fpp.f90"
                 PROPERTIES COMPILE_OPTIONS "-Oipa0"
             )
-        elseif (DEFINED ENV{GITHUB_ACTIONS})
+        else()
             target_compile_options(simulation PRIVATE -Oipa0)
         endif()
     endif()

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -145,7 +145,7 @@ if [ "$u_c" '==' 'famd' ]; then
     export CRAY_MPICH_LIB="-L${CRAY_MPICH_PREFIX}/lib \
                         ${CRAY_PMI_POST_LINK_OPTS} \
                         -lmpifort_amd -lmpi_amd -lmpi -lpmi -lpmi2"
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CRAY_LD_LIBRARY_PATH}" 
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CRAY_LD_LIBRARY_PATH}"
     export CMAKE_PREFIX_PATH="${OLCF_AFAR_ROOT}:${CMAKE_PREFIX_PATH}"
     export FC="${OLCF_AFAR_ROOT}/bin/amdflang"
 


### PR DESCRIPTION
## Summary

- `m_mpi_common.fpp` triggers the same CCE 19.0.0 `optcg` IPA crash (`bring_routine_resident` SIGSEGV) as `m_phase_change.fpp`, consistently failing the `Oak Ridge | Frontier (cpu)` CI job (e.g. run [25553342717](https://github.com/MFlowCode/MFC/actions/runs/25553342717/job/75006365360))
- Adds `-Oipa0` for `pre_process/m_mpi_common.fpp.f90` (confirmed failing target) and `simulation/m_mpi_common.fpp.f90` (precautionary — pre_process fails first, masking whether simulation also crashes)
- Same workaround pattern as PR #1286; all 6 precheck tests pass; build verified on Frontier batch node with CCE 19.0.0

## Test plan

- [ ] `Oak Ridge | Frontier (cpu)` CI job passes (this is the only currently failing job on master)
- [ ] `Oak Ridge | Frontier (gpu-acc)` CI job still passes (existing workaround unchanged)
- [ ] All other CI jobs unaffected