### PR TITLE
Validate riemann_solver: require explicit value, remove unimplemented option 3

### DIFF
--- a/benchmarks/igr/case.py
+++ b/benchmarks/igr/case.py
@@ -69,6 +69,7 @@ print(
             "num_patches": 1,
             "model_eqns": 2,
             "num_fluids": 1,
+            "riemann_solver": 5,
             "time_stepper": 3,
             "bc_x%beg": -1,
             "bc_x%end": -1,

--- a/examples/2D_IGR_2fluid/case.py
+++ b/examples/2D_IGR_2fluid/case.py
@@ -45,6 +45,7 @@ data = {
     "mixture_err": "T",
     "mpp_lim": "F",
     "time_stepper": 3,
+    "riemann_solver": 5,
     "bc_x%beg": -1,
     "bc_x%end": -1,
     "bc_y%beg": -1,

--- a/examples/2D_IGR_triple_point/case.py
+++ b/examples/2D_IGR_triple_point/case.py
@@ -30,6 +30,7 @@ print(
             "alt_soundspeed": "F",
             "num_fluids": 2,
             "time_stepper": 3,
+            "riemann_solver": 5,
             "elliptic_smoothing": "T",
             "elliptic_smoothing_iters": 50,
             "igr": "T",

--- a/examples/3D_IGR_33jet/case.py
+++ b/examples/3D_IGR_33jet/case.py
@@ -52,6 +52,7 @@ print(
             "num_fluids": 1,
             "mpp_lim": "F",
             "time_stepper": 3,
+            "riemann_solver": 5,
             "igr": "T",
             "igr_order": 3,
             "igr_pres_lim": "T",

--- a/examples/3D_IGR_TaylorGreenVortex/case.py
+++ b/examples/3D_IGR_TaylorGreenVortex/case.py
@@ -49,6 +49,7 @@ print(
             "model_eqns": 2,
             "num_fluids": 1,
             "time_stepper": 3,
+            "riemann_solver": 5,
             "bc_x%beg": -1,
             "bc_x%end": -1,
             "bc_y%beg": -1,

--- a/examples/3D_IGR_TaylorGreenVortex_nvidia/case.py
+++ b/examples/3D_IGR_TaylorGreenVortex_nvidia/case.py
@@ -54,6 +54,7 @@ print(
             "model_eqns": 2,
             "num_fluids": 1,
             "time_stepper": 3,
+            "riemann_solver": 5,
             "bc_x%beg": -1,
             "bc_x%end": -1,
             "bc_y%beg": -1,

--- a/examples/3D_IGR_jet/case.py
+++ b/examples/3D_IGR_jet/case.py
@@ -78,6 +78,7 @@ print(
             "num_fluids": 2,
             "mpp_lim": "T",
             "time_stepper": 3,
+            "riemann_solver": 5,
             "igr": "T",
             "igr_order": 3,
             "igr_pres_lim": "T",

--- a/examples/3D_IGR_jet_1fluid/case.py
+++ b/examples/3D_IGR_jet_1fluid/case.py
@@ -53,6 +53,7 @@ print(
             "num_fluids": 1,
             "mpp_lim": "F",
             "time_stepper": 3,
+            "riemann_solver": 5,
             "igr": "T",
             "igr_order": 5,
             "igr_pres_lim": "T",

--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -673,16 +673,16 @@ class CaseValidator:
         cyl_coord = self.get("cyl_coord", "F") == "T"
         viscous = self.get("viscous", "F") == "T"
 
+        self.prohibit(riemann_solver is None, "riemann_solver must be specified (1=HLL, 2=HLLC, 4=HLLD, 5=Lax-Friedrichs)")
         if riemann_solver is None:
             return
 
-        self.prohibit(riemann_solver < 1 or riemann_solver > 5, "riemann_solver must be 1, 2, 3, 4 or 5")
+        self.prohibit(riemann_solver not in [1, 2, 4, 5], "riemann_solver must be 1 (HLL), 2 (HLLC), 4 (HLLD), or 5 (Lax-Friedrichs)")
         self.prohibit(riemann_solver != 2 and model_eqns == 3, "6-equation model (model_eqns = 3) requires riemann_solver = 2 (HLLC)")
         self.prohibit(wave_speeds is not None and wave_speeds not in [1, 2], "wave_speeds must be 1 or 2")
-        self.prohibit(riemann_solver == 3 and wave_speeds is not None, "Exact Riemann (riemann_solver = 3) does not support wave_speeds")
         self.prohibit(avg_state is not None and avg_state not in [1, 2], "avg_state must be 1 or 2")
-        self.prohibit(riemann_solver not in [3, 5] and wave_speeds is None, "wave_speeds must be set if riemann_solver != 3,5")
-        self.prohibit(riemann_solver not in [3, 5] and avg_state is None, "avg_state must be set if riemann_solver != 3,5")
+        self.prohibit(riemann_solver != 5 and wave_speeds is None, "wave_speeds must be set for riemann_solver 1, 2, or 4")
+        self.prohibit(riemann_solver != 5 and avg_state is None, "avg_state must be set for riemann_solver 1, 2, or 4")
         self.prohibit(low_Mach not in [0, 1, 2], "low_Mach must be 0, 1, or 2")
         self.prohibit(riemann_solver != 2 and low_Mach == 2, "low_Mach = 2 requires riemann_solver = 2")
         self.prohibit(low_Mach != 0 and model_eqns not in [2, 3], "low_Mach = 1 or 2 requires model_eqns = 2 or 3")

--- a/toolchain/mfc/params/definitions.py
+++ b/toolchain/mfc/params/definitions.py
@@ -623,8 +623,8 @@ CONSTRAINTS = {
     },
     # Riemann solver
     "riemann_solver": {
-        "choices": [1, 2, 3, 4, 5],
-        "value_labels": {1: "HLL", 2: "HLLC", 3: "Exact", 4: "HLLD", 5: "Lax-Friedrichs"},
+        "choices": [1, 2, 4, 5],
+        "value_labels": {1: "HLL", 2: "HLLC", 4: "HLLD", 5: "Lax-Friedrichs"},
     },
     "wave_speeds": {
         "choices": [1, 2],


### PR DESCRIPTION
## Summary

Closes #1410.

- **Prohibit `None` `riemann_solver`**: Previously, omitting `riemann_solver` from a case file caused `case_validator.py` to silently `return` early, and Fortran would run with `riemann_solver = dflt_int = -100`. Since `-100` is not in the Fypp dispatch list `[1, 2, 4, 5]`, no Riemann solver would execute and fluxes would retain garbage values — leading to silent blow-up rather than an actionable error.
- **Remove `riemann_solver = 3` ("Exact")**: This value has never been implemented. It was accepted by the validator and the parameter definition, but the Fypp dispatch loop in `m_riemann_solvers.fpp` only handles `[1, 2, 4, 5]`, so selecting `3` caused the same silent no-op.

## Changes

- `toolchain/mfc/case_validator.py`: prohibit `None`, restrict valid set to `[1, 2, 4, 5]`, update `wave_speeds`/`avg_state` dependency checks (previously exempted `3` and `5`; now only exempt `5`)
- `toolchain/mfc/params/definitions.py`: remove `3` from `choices` and `value_labels`

No Fortran changes — both issues are fully caught at the Python validation layer before any input file is written.