### PR TITLE
fix: inline Fortran constant defaults in _fc() to prevent Homebrew sync failures

### DIFF
--- a/toolchain/mfc/params/definitions.py
+++ b/toolchain/mfc/params/definitions.py
@@ -13,22 +13,21 @@ from .registry import REGISTRY, IndexedFamily
 from .schema import ParamDef, ParamType
 
 # Index limits — sourced from Fortran compile-time constants (m_constants.fpp).
-# These must stay in sync with Fortran; we error if the source can't be parsed.
+# Falls back to the inline default when src/ is unavailable (e.g. Homebrew).
+# Default must match src/common/m_constants.fpp — enforced by co-location.
 _FC = get_fortran_constants()
 
 
-def _fc(name: str) -> int:
-    """Get a required Fortran constant, raising if unavailable."""
-    if name not in _FC:
-        raise RuntimeError(f"Fortran constant '{name}' not found in m_constants.fpp. Toolchain is out of sync with Fortran source.")
-    return _FC[name]
+def _fc(name: str, default: int) -> int:
+    """Get a Fortran constant, using the inline default when m_constants.fpp is unavailable."""
+    return _FC.get(name, default)
 
 
-NF = _fc("num_fluids_max")  # fluid_pp
-NPR = _fc("num_probes_max")  # probe, acoustic, integral
-NB = _fc("num_bc_patches_max")  # patch_bc
-NUM_PATCHES_MAX = _fc("num_patches_max")  # patch_icpp (Fortran array bound)
-NIB = _fc("num_ib_patches_max")  # patch_ib (Fortran array bound)
+NF = _fc("num_fluids_max", 10)        # fluid_pp
+NPR = _fc("num_probes_max", 10)       # probe, acoustic, integral
+NB = _fc("num_bc_patches_max", 10)    # patch_bc
+NUM_PATCHES_MAX = _fc("num_patches_max", 10)   # patch_icpp (Fortran array bound)
+NIB = _fc("num_ib_patches_max", 50000)         # patch_ib (Fortran array bound)
 # Enumeration limits for families not yet converted to IndexedFamily.
 # These are smaller than the Fortran array bounds to keep the registry compact.
 # The CONSTRAINTS dict below uses the Fortran constants for validation.

--- a/toolchain/mfc/params/definitions.py
+++ b/toolchain/mfc/params/definitions.py
@@ -20,7 +20,14 @@ _FC = get_fortran_constants()
 
 def _fc(name: str, default: int) -> int:
     """Get a Fortran constant, using the inline default when m_constants.fpp is unavailable."""
-    return _FC.get(name, default)
+    if _FC:
+        if name not in _FC:
+            raise RuntimeError(
+                f"Fortran constant '{name}' not found in m_constants.fpp. "
+                f"Toolchain is out of sync with Fortran source."
+            )
+        return _FC[name]
+    return default
 
 
 NF = _fc("num_fluids_max", 10)        # fluid_pp

--- a/toolchain/mfc/params/namelist_parser.py
+++ b/toolchain/mfc/params/namelist_parser.py
@@ -492,27 +492,16 @@ def get_fortran_constants() -> Dict[str, int]:
     """
     Get Fortran compile-time constants from m_constants.fpp.
 
-    Cached after first call. Falls back to built-in defaults when the Fortran
-    source is unavailable (e.g. Homebrew installs where src/ is not shipped).
+    Cached after first call. Returns an empty dict when the Fortran source is
+    unavailable (e.g. Homebrew installs where src/ is not shipped); callers
+    supply their own inline defaults via _fc(name, default) in definitions.py.
     """
     global _FORTRAN_CONSTANTS_CACHE  # noqa: PLW0603
     if _FORTRAN_CONSTANTS_CACHE is None:
         root = get_mfc_root()
         path = root / "src" / "common" / "m_constants.fpp"
         _FORTRAN_CONSTANTS_CACHE = parse_fortran_constants(path)
-        if not _FORTRAN_CONSTANTS_CACHE:
-            _FORTRAN_CONSTANTS_CACHE = _FALLBACK_CONSTANTS.copy()
     return _FORTRAN_CONSTANTS_CACHE
-
-
-# Fallback values for when m_constants.fpp is not available at runtime.
-# Keep in sync with src/common/m_constants.fpp.
-_FALLBACK_CONSTANTS: Dict[str, int] = {
-    "num_fluids_max": 10,
-    "num_probes_max": 10,
-    "num_patches_max": 1000,
-    "num_bc_patches_max": 10,
-}
 
 
 def get_mfc_root() -> Path:


### PR DESCRIPTION
Fixes #1420.

## Summary

- Fixes the v5.3.1 Homebrew regression where every install crashed on startup with `RuntimeError: Fortran constant 'num_ib_patches_max' not found in m_constants.fpp`
- Root cause: `NIB = _fc("num_ib_patches_max")` was added to `definitions.py` (#1348) but `_FALLBACK_CONSTANTS` in `namelist_parser.py` was never updated — two places that must stay in sync with no enforcement
- On Homebrew, `src/` is not installed so `get_fortran_constants()` returns `{}`, making `_fc()` fall through to the stale fallback

## Fix

`_fc(name, default)` now requires an **inline default value** co-located with the call site. There is no longer a separate dict to forget. Adding a new `_fc()` call without a default is a type error.

```python
# Before — default lived in a separate dict, easy to miss:
NIB = _fc("num_ib_patches_max")   # raises on Homebrew if dict not updated

# After — default is right here, impossible to forget:
NIB = _fc("num_ib_patches_max", 50000)
```

`_FALLBACK_CONSTANTS` and the fallback logic in `get_fortran_constants()` are removed. The function now simply returns `{}` when `src/common/m_constants.fpp` is unavailable.

## Test plan

- [x] Verify `./mfc.sh precheck` passes (CI lint gate)
- [ ] Trigger homebrew-mfc bottle workflow and confirm Sod shock tube test passes