### PR TITLE
feat: publish container images to GHCR alongside Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,10 @@ on:
         description: 'tag to containerize'
         required: false
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: Containerization
   cancel-in-progress: false
@@ -39,11 +43,18 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - name: Login
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
@@ -92,7 +103,11 @@ jobs:
             FC_COMPILER=${{ 'gfortran' }}
             COMPILER_PATH=${{ '/usr/bin' }}
             COMPILER_LD_LIBRARY_PATH=${{ '/usr/lib' }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
+            ghcr.io/${{ github.repository_owner }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
           push: true
 
       - name: Build and push image (gpu)
@@ -110,18 +125,29 @@ jobs:
             FC_COMPILER=${{ 'nvfortran' }}
             COMPILER_PATH=/opt/nvidia/hpc_sdk/${{ matrix.config.compiler_arch }}/compilers/bin
             COMPILER_LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/${{ matrix.config.compiler_arch }}/compilers/lib
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner}}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
+            ghcr.io/${{ github.repository_owner }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
           push: true
 
   manifests:
     runs-on: ubuntu-latest
     needs: Container
     steps:
-      - name: Login
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
@@ -129,16 +155,22 @@ jobs:
       - name: Create and Push Manifest Lists
         env:
           TAG: ${{ needs.Container.outputs.tag }}
-          REGISTRY: ${{ secrets.DOCKERHUB_USERNAME }}/mfc
+          DH: ${{ secrets.DOCKERHUB_USERNAME }}/mfc
+          GH: ghcr.io/${{ github.repository_owner }}/mfc
         run: |
-          docker buildx imagetools create -t $REGISTRY:$TAG-cpu  $REGISTRY:$TAG-cpu-ubuntu-22.04 $REGISTRY:$TAG-cpu-ubuntu-22.04-arm
-          docker buildx imagetools create -t $REGISTRY:$TAG-gpu  $REGISTRY:$TAG-gpu-ubuntu-22.04 $REGISTRY:$TAG-gpu-ubuntu-22.04-arm
+          for R in "$DH" "$GH"; do
+            docker buildx imagetools create -t $R:$TAG-cpu $R:$TAG-cpu-ubuntu-22.04 $R:$TAG-cpu-ubuntu-22.04-arm
+            docker buildx imagetools create -t $R:$TAG-gpu $R:$TAG-gpu-ubuntu-22.04 $R:$TAG-gpu-ubuntu-22.04-arm
+          done
 
       - name: Update latest tags
         if: github.event_name == 'release'
         env:
           TAG: ${{ needs.Container.outputs.tag }}
-          REGISTRY: ${{ secrets.DOCKERHUB_USERNAME }}/mfc
+          DH: ${{ secrets.DOCKERHUB_USERNAME }}/mfc
+          GH: ghcr.io/${{ github.repository_owner }}/mfc
         run: |
-          docker buildx imagetools create -t $REGISTRY:latest-cpu $REGISTRY:$TAG-cpu-ubuntu-22.04 $REGISTRY:$TAG-cpu-ubuntu-22.04-arm
-          docker buildx imagetools create -t $REGISTRY:latest-gpu $REGISTRY:$TAG-gpu-ubuntu-22.04 $REGISTRY:$TAG-gpu-ubuntu-22.04-arm
+          for R in "$DH" "$GH"; do
+            docker buildx imagetools create -t $R:latest-cpu $R:$TAG-cpu-ubuntu-22.04 $R:$TAG-cpu-ubuntu-22.04-arm
+            docker buildx imagetools create -t $R:latest-gpu $R:$TAG-gpu-ubuntu-22.04 $R:$TAG-gpu-ubuntu-22.04-arm
+          done


### PR DESCRIPTION
## Summary

- Push every container image to both Docker Hub and GitHub Container Registry (GHCR) simultaneously
- Add `permissions: packages: write` so `GITHUB_TOKEN` can authenticate to GHCR
- Add OCI `org.opencontainers.image.source` label linking images back to this repo
- Use `imagetools create` consistently for all manifest operations (CPU and GPU)
- Simplify manifest steps with a `for R in "$DH" "$GH"` loop instead of duplicated commands

## Why GHCR

- GHCR has no pull rate limits for public repos; Docker Hub throttles anonymous pulls (a real pain on HPC clusters)
- Some institutions block Docker Hub entirely
- Images in GHCR are accessible at `ghcr.io/MFlowCode/mfc:<tag>-cpu` / `ghcr.io/MFlowCode/mfc:<tag>-gpu`

## Improvements over #1080

- Rebased on the fresh Docker workflow (#1418) with NVHPC 24.5, ARM compiler path fix, and `--gpu acc`
- Stays on `build-push-action@v5` for GPU jobs (v6 caused SIGTERM in dry-run)
- `latest-*` tags remain gated to `release` events only (not nightly)
- Consistent `imagetools` throughout — no `docker manifest create/push` mixing
- No Homebrew changes (already merged in #1419)

Closes #1080