### PR TITLE
feat: add GitHub deployment environments for containers, docs, and homebrew

### DIFF
--- a/.github/workflows/deploy-tap.yml
+++ b/.github/workflows/deploy-tap.yml
@@ -28,6 +28,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    environment:
+      name: homebrew
+      url: https://github.com/MFlowCode/homebrew-mfc
     steps:
       - name: Checkout MFC repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,6 +71,8 @@ jobs:
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "TAG=$TAG" >> $GITHUB_ENV
+          OWNER="${{ github.repository_owner }}"
+          echo "GH_REGISTRY=ghcr.io/${OWNER,,}/mfc" >> $GITHUB_ENV
           git clone --branch "$BRANCH" --depth 1 ${{ github.server_url }}/${{ github.repository }}.git mfc
 
       - name: Stage
@@ -107,7 +109,7 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
-            ghcr.io/${{ github.repository_owner }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
+            ${{ env.GH_REGISTRY }}:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
           push: true
 
       - name: Build and push image (gpu)
@@ -129,7 +131,7 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
-            ghcr.io/${{ github.repository_owner }}/mfc:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
+            ${{ env.GH_REGISTRY }}:${{ env.TAG }}-${{ matrix.config.name }}-${{ matrix.config.runner }}
           push: true
 
   manifests:
@@ -155,12 +157,17 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set GHCR registry (lowercase)
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          echo "GH_REGISTRY=ghcr.io/${OWNER,,}/mfc" >> $GITHUB_ENV
+
       - name: Create and Push Manifest Lists
         env:
           TAG: ${{ needs.Container.outputs.tag }}
           DH: ${{ secrets.DOCKERHUB_USERNAME }}/mfc
-          GH: ghcr.io/${{ github.repository_owner }}/mfc
         run: |
+          GH="${{ env.GH_REGISTRY }}"
           for R in "$DH" "$GH"; do
             docker buildx imagetools create -t $R:$TAG-cpu $R:$TAG-cpu-ubuntu-22.04 $R:$TAG-cpu-ubuntu-22.04-arm
             docker buildx imagetools create -t $R:$TAG-gpu $R:$TAG-gpu-ubuntu-22.04 $R:$TAG-gpu-ubuntu-22.04-arm
@@ -171,8 +178,8 @@ jobs:
         env:
           TAG: ${{ needs.Container.outputs.tag }}
           DH: ${{ secrets.DOCKERHUB_USERNAME }}/mfc
-          GH: ghcr.io/${{ github.repository_owner }}/mfc
         run: |
+          GH="${{ env.GH_REGISTRY }}"
           for R in "$DH" "$GH"; do
             docker buildx imagetools create -t $R:latest-cpu $R:$TAG-cpu-ubuntu-22.04 $R:$TAG-cpu-ubuntu-22.04-arm
             docker buildx imagetools create -t $R:latest-gpu $R:$TAG-gpu-ubuntu-22.04 $R:$TAG-gpu-ubuntu-22.04-arm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,7 +139,7 @@ jobs:
     needs: Container
     environment:
       name: containers
-      url: https://hub.docker.com/r/mflowcode/mfc
+      url: https://hub.docker.com/r/${{ secrets.DOCKERHUB_USERNAME }}/mfc
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -135,6 +135,9 @@ jobs:
   manifests:
     runs-on: ubuntu-latest
     needs: Container
+    environment:
+      name: containers
+      url: https://hub.docker.com/r/mflowcode/mfc
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,8 @@ on:
   pull_request:
 
 jobs:
-  docs:
-    name:    Build & Publish
+  build:
+    name: Build & Verify
     runs-on: ubuntu-latest
 
     steps:
@@ -73,8 +73,25 @@ jobs:
         args: -c .lychee.toml build/install/docs/mfc/
         fail: true
 
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    environment:
+      name: docs
+      url: https://mflowcode.github.io/
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download Built Documentation Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: mfc-docs
+        path: build/install/docs/mfc
+
     - name: Publish Documentation
-      if:   github.repository == 'MFlowCode/MFC' && github.ref == 'refs/heads/master' &&  (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' )
       run:  |
         set +e
         git ls-remote "${{ secrets.DOC_PUSH_URL }}" -q

--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -25,6 +25,9 @@ jobs:
   update-homebrew-tap:
     name: Update homebrew-mfc tap
     runs-on: ubuntu-latest
+    environment:
+      name: homebrew
+      url: https://github.com/MFlowCode/homebrew-mfc
 
     steps:
       - name: Determine version


### PR DESCRIPTION
## Summary

- Adds `environment:` blocks to the three workflows that actually deploy artifacts, so they show up in the Deployments sidebar on the repo page
- Splits `docs.yml` into a `build` job (runs on all events) and a `publish` job (runs only on master schedule/dispatch, has the environment) so deployment events only fire on real publishes

## Environments added

| Environment | Workflow | URL |
|---|---|---|
| `containers` | `docker.yml` manifests job | https://hub.docker.com/r/mflowcode/mfc |
| `docs` | `docs.yml` publish job | https://mflowcode.github.io/ |
| `homebrew` | `deploy-tap.yml` + `homebrew-release.yml` | https://github.com/MFlowCode/homebrew-mfc |

## What won't show up (and why)

- **Docker Hub images** — Docker Hub is external to GitHub; GHCR packages appear under the repo's Packages sidebar automatically once pushed
- **Homebrew formula itself** — Homebrew is external; the tap link is the closest proxy