### PR TITLE
ci: skip FP stability and convergence when no relevant files changed

### DIFF
--- a/.github/file-filter.yml
+++ b/.github/file-filter.yml
@@ -30,6 +30,8 @@ yml: &yml
   - '.github/workflows/bench.yml'
   - '.github/workflows/test.yml'
   - '.github/workflows/formatting.yml'
+  - '.github/workflows/fp-stability.yml'
+  - '.github/workflows/convergence.yml'
 
 checkall: &checkall
   - *fortran_src

--- a/.github/workflows/convergence.yml
+++ b/.github/workflows/convergence.yml
@@ -4,15 +4,36 @@ on:
   push:
     branches: [master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  file-changes:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    outputs:
+      checkall: ${{ steps.changes.outputs.checkall }}
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Detect Changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: ".github/file-filter.yml"
+
   convergence:
     name: "Convergence"
     runs-on: ubuntu-latest
+    needs: [file-changes]
+    if: >-
+      !cancelled() &&
+      needs.file-changes.result == 'success' &&
+      (needs.file-changes.outputs.checkall == 'true' || github.event_name == 'workflow_dispatch')
     timeout-minutes: 240
 
     steps:

--- a/.github/workflows/fp-stability.yml
+++ b/.github/workflows/fp-stability.yml
@@ -35,9 +35,29 @@ on:
   workflow_dispatch:
 
 jobs:
+  file-changes:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    outputs:
+      checkall: ${{ steps.changes.outputs.checkall }}
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Detect Changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: ".github/file-filter.yml"
+
   fp-stability:
     name: Floating-Point Stability (Verrou)
     runs-on: ubuntu-latest
+    needs: [file-changes]
+    if: >-
+      !cancelled() &&
+      needs.file-changes.result == 'success' &&
+      (needs.file-changes.outputs.checkall == 'true' || github.event_name == 'workflow_dispatch')
 
     steps:
       - name: Clone


### PR DESCRIPTION
## Summary
- Adds a `file-changes` job (dorny/paths-filter) to both `fp-stability.yml` and `convergence.yml`
- Main job is gated: skips unless `checkall` is true (src/tests/scripts changed) or event is `workflow_dispatch`
- Registers both workflow files in `file-filter.yml` so edits to them trigger a run
- Also aligns `convergence.yml` `pull_request` trigger to use explicit `types:` like the other workflows

## Test plan
- [ ] Open a PR that only touches docs/CI-unrelated files — both workflows should show "Detect File Changes" passing and main job skipped
- [ ] Open a PR that touches a `.fpp` file — both workflows should run normally