### PR TITLE
ci: remove AMD GPU container

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -7,8 +7,6 @@ ARG CXX_COMPILER
 ARG FC_COMPILER
 ARG COMPILER_PATH
 ARG COMPILER_LD_LIBRARY_PATH
-ARG AFAR_VERSION
-ARG OLCF_AFAR_ROOT=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
@@ -29,46 +27,9 @@ RUN apt-get update -y && \
             python3.12 python3.12-venv python3-pip \
             libfftw3-dev \
             openmpi-bin libopenmpi-dev; \
-    elif [ "$TARGET" = "amd" ]; then \
-        apt-get install -y \
-            build-essential git make gcc g++ gfortran bc \
-            python3.12 python3.12-venv python3-pip \
-            libfftw3-dev libnuma1 libdrm2 libdrm-amdgpu1; \
     fi && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# AMD: download AFAR, install cmake 3.28 (Ubuntu 22.04 ships 3.22 which doesn't
-# recognize amdflang as LLVMFlang), then build MPICH with amdflang so the
-# generated mpi.mod is compiler-compatible.
-RUN if [ "$TARGET" = "amd" ] && [ -n "$AFAR_VERSION" ]; then \
-        OLCF_AFAR_ROOT="/opt/${AFAR_VERSION}" && \
-        wget -q "https://repo.radeon.com/rocm/misc/flang/${AFAR_VERSION}-ubuntu.tar.bz2" -O /tmp/afar.tar.bz2 && \
-        tar -xjf /tmp/afar.tar.bz2 -C /opt/ && \
-        rm /tmp/afar.tar.bz2 && \
-        CMAKE_VER=3.28.6 && \
-        wget -q "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.sh" \
-            -O /tmp/cmake-install.sh && \
-        chmod +x /tmp/cmake-install.sh && \
-        /tmp/cmake-install.sh --prefix=/usr/local --skip-license --exclude-subdir && \
-        rm /tmp/cmake-install.sh && \
-        printf '#!/bin/bash\nargs=()\nwhile [ "$#" -gt 0 ]; do\n    if [ "$1" = "-soname" ]; then\n        args+=("-Wl,-soname,$2"); shift 2\n    else\n        args+=("$1"); shift\n    fi\ndone\nexec '"${OLCF_AFAR_ROOT}"'/bin/amdflang "${args[@]}"\n' \
-            > /usr/local/bin/amdflang-ld-wrap && \
-        chmod +x /usr/local/bin/amdflang-ld-wrap && \
-        MPICH_VER=3.4.3 && \
-        wget -q "https://www.mpich.org/static/downloads/${MPICH_VER}/mpich-${MPICH_VER}.tar.gz" \
-            -O /tmp/mpich.tar.gz && \
-        mkdir -p /tmp/mpich-src && \
-        tar -xzf /tmp/mpich.tar.gz -C /tmp/mpich-src --strip-components=1 && \
-        cd /tmp/mpich-src && \
-        FC=/usr/local/bin/amdflang-ld-wrap CC=gcc CXX=g++ \
-            ./configure --prefix=/opt/mpich --enable-shared --disable-static \
-            --with-device=ch3 2>&1 && \
-        make -j$(nproc) 2>&1 && \
-        make install 2>&1 && \
-        cd / && \
-        rm -rf /tmp/mpich-src /tmp/mpich.tar.gz; \
-    fi
 
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
@@ -80,7 +41,6 @@ COPY ../ /opt/MFC
 ENV CC=${CC_COMPILER}
 ENV CXX=${CXX_COMPILER}
 ENV FC=${FC_COMPILER}
-ENV OLCF_AFAR_ROOT=${OLCF_AFAR_ROOT}
 ENV PATH="${COMPILER_PATH}:/opt/mpich/bin:$PATH"
 ENV LD_LIBRARY_PATH="${COMPILER_LD_LIBRARY_PATH}:/opt/mpich/lib:${LD_LIBRARY_PATH:-}"
 
@@ -95,8 +55,6 @@ RUN echo "TARGET=$TARGET CC=$CC_COMPILER FC=$FC_COMPILER" && \
     cd /opt/MFC && \
     if [ "$TARGET" = "gpu" ]; then \
       ./mfc.sh build --gpu acc -j $(nproc); \
-    elif [ "$TARGET" = "amd" ]; then \
-      ./mfc.sh build --gpu mp -j $(nproc); \
     else \
       ./mfc.sh build -j $(nproc); \
     fi
@@ -104,8 +62,6 @@ RUN echo "TARGET=$TARGET CC=$CC_COMPILER FC=$FC_COMPILER" && \
 RUN cd /opt/MFC && \
     if [ "$TARGET" = "gpu" ]; then \
       ./mfc.sh test -a --dry-run --gpu acc -j $(nproc); \
-    elif [ "$TARGET" = "amd" ]; then \
-      ./mfc.sh test -a --dry-run --gpu mp -j $(nproc); \
     else \
       ./mfc.sh test -a --dry-run -j $(nproc); \
     fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,6 @@ jobs:
             - { name: 'cpu',  tag: 'cpu',       runner: 'ubuntu-22.04-arm', base_image: 'ubuntu:22.04' }
             - { name: 'gpu',  tag: 'gpu-nvidia', runner: 'ubuntu-22.04',     base_image: 'nvcr.io/nvidia/nvhpc:24.5-devel-cuda_multi-ubuntu22.04', compiler_arch: 'Linux_x86_64' }
             - { name: 'gpu',  tag: 'gpu-nvidia', runner: 'ubuntu-22.04-arm', base_image: 'nvcr.io/nvidia/nvhpc:24.5-devel-cuda_multi-ubuntu22.04', compiler_arch: 'Linux_aarch64' }
-            - { name: 'amd',  tag: 'gpu-amd',   runner: 'ubuntu-22.04',     base_image: 'ubuntu:22.04' }
     runs-on: ${{ matrix.config.runner }}
     outputs:
       tag: ${{ steps.clone.outputs.tag }}
@@ -135,37 +134,6 @@ jobs:
             ${{ env.GH_REGISTRY }}:${{ env.TAG }}-${{ matrix.config.tag }}-${{ matrix.config.runner }}
           push: true
 
-      - name: Set AMD AFAR vars
-        if: ${{ matrix.config.name == 'amd' }}
-        run: |
-          AFAR=rocm-afar-8873-drop-22.2.0
-          ROOT="/opt/${AFAR}"
-          echo "AFAR_VERSION=${AFAR}"      >> $GITHUB_ENV
-          echo "AFAR_ROOT=${ROOT}"         >> $GITHUB_ENV
-
-      - name: Build and push image (amd)
-        if: ${{ matrix.config.name == 'amd' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: /mnt/share
-          file: /mnt/share/Dockerfile
-          build-args: |
-            BASE_IMAGE=${{ matrix.config.base_image }}
-            TARGET=amd
-            AFAR_VERSION=${{ env.AFAR_VERSION }}
-            OLCF_AFAR_ROOT=${{ env.AFAR_ROOT }}
-            CC_COMPILER=gcc
-            CXX_COMPILER=g++
-            FC_COMPILER=${{ env.AFAR_ROOT }}/bin/amdflang
-            COMPILER_PATH=${{ env.AFAR_ROOT }}/lib/llvm/bin:${{ env.AFAR_ROOT }}/bin
-            COMPILER_LD_LIBRARY_PATH=${{ env.AFAR_ROOT }}/lib:${{ env.AFAR_ROOT }}/lib/llvm/lib
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/mfc:${{ env.TAG }}-gpu-amd-ubuntu-22.04
-            ${{ env.GH_REGISTRY }}:${{ env.TAG }}-gpu-amd-ubuntu-22.04
-          push: true
-
   manifests:
     runs-on: ubuntu-latest
     needs: Container
@@ -201,9 +169,8 @@ jobs:
         run: |
           GH="${{ env.GH_REGISTRY }}"
           for R in "$DH" "$GH"; do
-            docker buildx imagetools create -t $R:$TAG-cpu       $R:$TAG-cpu-ubuntu-22.04 $R:$TAG-cpu-ubuntu-22.04-arm
+            docker buildx imagetools create -t $R:$TAG-cpu        $R:$TAG-cpu-ubuntu-22.04 $R:$TAG-cpu-ubuntu-22.04-arm
             docker buildx imagetools create -t $R:$TAG-gpu-nvidia $R:$TAG-gpu-nvidia-ubuntu-22.04 $R:$TAG-gpu-nvidia-ubuntu-22.04-arm
-            docker buildx imagetools create -t $R:$TAG-gpu-amd   $R:$TAG-gpu-amd-ubuntu-22.04
           done
 
       - name: Update latest tags
@@ -214,7 +181,6 @@ jobs:
         run: |
           GH="${{ env.GH_REGISTRY }}"
           for R in "$DH" "$GH"; do
-            docker buildx imagetools create -t $R:latest-cpu       $R:$TAG-cpu-ubuntu-22.04 $R:$TAG-cpu-ubuntu-22.04-arm
+            docker buildx imagetools create -t $R:latest-cpu        $R:$TAG-cpu-ubuntu-22.04 $R:$TAG-cpu-ubuntu-22.04-arm
             docker buildx imagetools create -t $R:latest-gpu-nvidia $R:$TAG-gpu-nvidia-ubuntu-22.04 $R:$TAG-gpu-nvidia-ubuntu-22.04-arm
-            docker buildx imagetools create -t $R:latest-gpu-amd   $R:$TAG-gpu-amd-ubuntu-22.04
           done


### PR DESCRIPTION
## Summary

- Removes the AMD GPU (`gpu-amd`) container from the Docker build workflow and Dockerfile
- The AMD container required downloading and building AFAR (AMD Flang), installing cmake 3.28, and building a custom MPICH — too much maintenance burden for a container that can't be tested in CI
- CPU and NVIDIA GPU containers are unaffected

## Motivation

The AFAR drop used in the container (`rocm-afar-8873-drop-22.2.0`) is aging, and newer drops (`therock-23.x`) have an internally inconsistent hipfort (`.mod` files compiled with a different compiler), making them unusable without significant per-drop patching. AMD GPU builds on actual clusters (Frontier, hpcfund) continue to work via the system ROCm stack and are not affected by this change.