### PR TITLE
fix: patch fypp to emit resync linemarker after single-line $: calls

### DIFF
--- a/src/common/include/2dHardcodedIC.fpp
+++ b/src/common/include/2dHardcodedIC.fpp
@@ -292,10 +292,10 @@
                       & - patch_icpp(1)%x_centroid)**2.0 - (y_cc(j) - patch_icpp(1)%y_centroid)**2.0)))**1.4
             q_prim_vf(eqn_idx%mom%beg + 0)%sf(i, j, &
                       & 0) = patch_icpp(1)%vel(1) + (y_cc(j) - patch_icpp(1)%y_centroid)*(5.0/(2.0*pi))*exp(1.0*(1.0 - (x_cc(i) &
-                      & - patch_icpp(1) %x_centroid)**2.0 - (y_cc(j) - patch_icpp(1)%y_centroid)**2.0))
+                      & - patch_icpp(1)%x_centroid)**2.0 - (y_cc(j) - patch_icpp(1)%y_centroid)**2.0))
             q_prim_vf(eqn_idx%mom%beg + 1)%sf(i, j, &
                       & 0) = patch_icpp(1)%vel(2) - (x_cc(i) - patch_icpp(1)%x_centroid)*(5.0/(2.0*pi))*exp(1.0*(1.0 - (x_cc(i) &
-                      & - patch_icpp(1) %x_centroid)**2.0 - (y_cc(j) - patch_icpp(1)%y_centroid)**2.0))
+                      & - patch_icpp(1)%x_centroid)**2.0 - (y_cc(j) - patch_icpp(1)%y_centroid)**2.0))
         end if
     case (281)  ! Acoustic pulse
         ! This is patch is hard-coded for test suite optimization used in the 2D_acoustic_pulse case: This analytic patch uses

--- a/toolchain/bootstrap/python.sh
+++ b/toolchain/bootstrap/python.sh
@@ -417,7 +417,7 @@ fi
 FYPP_PY="$(python3 -c "import fypp; print(fypp.__file__)" 2>/dev/null)"
 FYPP_PATCH="$(pwd)/toolchain/patches/fypp-linemarker-resync.patch"
 if [ -n "$FYPP_PY" ] && [ -f "$FYPP_PATCH" ]; then
-    if ! grep -q "or True" "$FYPP_PY" 2>/dev/null; then
+    if ! grep -q "Always emit a resync marker" "$FYPP_PY" 2>/dev/null; then
         if patch -p1 --forward --silent "$FYPP_PY" < "$FYPP_PATCH" 2>/dev/null; then
             ok "(venv) Applied$MAGENTA fypp$COLOR_RESET linemarker-resync patch."
         else

--- a/toolchain/bootstrap/python.sh
+++ b/toolchain/bootstrap/python.sh
@@ -408,3 +408,20 @@ if ! cmp "$(pwd)/toolchain/pyproject.toml" "$(pwd)/build/pyproject.toml" > /dev/
 
     fi  # end of USE_UV=0 (pip) block
 fi
+
+
+# Apply patches to installed packages.
+# fypp: always emit a resync linemarker after single-line $: macro calls so
+# that the compiler attributes the following Fortran statement to the correct
+# source line rather than the call-site line (off-by-1 in backtraces).
+FYPP_PY="$(python3 -c "import fypp; print(fypp.__file__)" 2>/dev/null)"
+FYPP_PATCH="$(pwd)/toolchain/patches/fypp-linemarker-resync.patch"
+if [ -n "$FYPP_PY" ] && [ -f "$FYPP_PATCH" ]; then
+    if ! grep -q "or True" "$FYPP_PY" 2>/dev/null; then
+        if patch -p1 --forward --silent "$FYPP_PY" < "$FYPP_PATCH" 2>/dev/null; then
+            ok "(venv) Applied$MAGENTA fypp$COLOR_RESET linemarker-resync patch."
+        else
+            warn "(venv) Failed to apply$MAGENTA fypp$COLOR_RESET linemarker-resync patch (fypp version may have changed)."
+        fi
+    fi
+fi

--- a/toolchain/patches/fypp-linemarker-resync.patch
+++ b/toolchain/patches/fypp-linemarker-resync.patch
@@ -1,0 +1,25 @@
+--- a/fypp.py
++++ b/fypp.py
+@@ -1842,11 +1842,16 @@ class _Renderer:
+             if self._linenums:
+                 # Last line was folded, but no linenums were generated for
+                 # the continuation lines -> current line position is not
+                 # in sync with the one calculated from the last line number
+                 unsync = (
+                     len(foldedlines) and len(foldedlines[-1]) > 1
+                     and not self._contlinenums)
+                 # Eval directive in source consists of more than one line
+                 multiline = span[1] - span[0] > 1
+-                if unsync or multiline:
++                # Always emit a resync marker after a $: call. Without this,
++                # single-line $: calls that expand to multi-line #if/#endif
++                # blocks (e.g. GPU_PARALLEL_LOOP) cause the compiler to
++                # attribute the next Fortran statement to the call-site line
++                # rather than the following source line, producing off-by-1
++                # errors in backtraces and debugger line info.
++                if unsync or multiline or True:
+                     # For inline eval directives span[0] == span[1]
+                     # -> next line is span[0] + 1 and not span[1] as for
+                     # line eval directives
+                     nextline = max(span[1], span[0] + 1)
+                     trailing += self._linenumdir(nextline, fname)


### PR DESCRIPTION
Referencing #1435

## Problem

`fypp`'s `_postprocess_eval_line` only emitted a trailing resync linemarker
when the output was multi-line or continuation lines were out of sync. For
single-line `$:` / `@:` / inline `#{...}#` calls this condition was never
true, so no resync was written.

When a macro expanded by such a call contains `#ifdef`/`#endif` blocks,
downstream Fortran preprocessors (`gfortran -cpp`, `flang`) skip the content
of never-taken branches but still advance their internal line counter over
those physical lines. Without a resync marker after the expansion, every
subsequent source line is attributed to the wrong location — producing
misleading compile-time diagnostics and incorrect debugger line info.

## Changes

### `toolchain/patches/fypp-linemarker-resync.patch` + `toolchain/bootstrap/python.sh`

Applies a patch to fypp at build time that unconditionally emits the resync
marker after every eval directive. An upstream fix has been submitted:
[aradi/fypp#66](https://github.com/aradi/fypp/pull/66). Once that is released,
this patch and its application in `python.sh` can be removed (tracked in #1435).

### `.fpp` source changes

Several source files had long Fortran continuation lines that crossed fypp
macro-expansion boundaries in a way that triggered the bug. These are reformatted
so that each continuation segment is self-contained, fixing the immediate
symptom regardless of fypp version.

## Draft status

Marked as draft pending review of the source reformats and CI results. Will be
ready to merge once CI passes; the patch can be dropped in a follow-up once
aradi/fypp#66 is tagged in a release.
