### PR TITLE
fix: update fypp linemarker-resync patch header for fypp 3.2

### DIFF
--- a/toolchain/patches/fypp-linemarker-resync.patch
+++ b/toolchain/patches/fypp-linemarker-resync.patch
@@ -1,17 +1,26 @@
---- a/fypp.py	2026-05-14 18:22:07.622131094 -0400
-+++ b/fypp.py	2026-05-14 18:22:07.650131330 -0400
-@@ -1848,7 +1848,13 @@
+--- a/fypp.py	2026-05-14 19:44:34.158817311 -0400
++++ b/fypp.py	2026-05-14 19:44:34.188817564 -0400
+@@ -1848,12 +1848,17 @@
                      and not self._contlinenums)
                  # Eval directive in source consists of more than one line
                  multiline = span[1] - span[0] > 1
 -                if unsync or multiline:
+-                    # For inline eval directives span[0] == span[1]
+-                    # -> next line is span[0] + 1 and not span[1] as for
+-                    # line eval directives
+-                    nextline = max(span[1], span[0] + 1)
+-                    trailing += self._linenumdir(nextline, fname)
 +                # Always emit a resync marker after a $: call. Without this,
 +                # single-line $: calls that expand to multi-line #if/#endif
 +                # blocks (e.g. GPU_PARALLEL_LOOP) cause the compiler to
 +                # attribute the next Fortran statement to the call-site line
 +                # rather than the following source line, producing off-by-1
 +                # errors in backtraces and debugger line info.
-+                if unsync or multiline or True:
-                     # For inline eval directives span[0] == span[1]
-                     # -> next line is span[0] + 1 and not span[1] as for
-                     # line eval directives
++                # For inline eval directives span[0] == span[1]
++                # -> next line is span[0] + 1 and not span[1] as for
++                # line eval directives
++                nextline = max(span[1], span[0] + 1)
++                trailing += self._linenumdir(nextline, fname)
+         else:
+             trailing = ''
+         return result + trailing

--- a/toolchain/patches/fypp-linemarker-resync.patch
+++ b/toolchain/patches/fypp-linemarker-resync.patch
@@ -1,12 +1,6 @@
---- a/fypp.py
-+++ b/fypp.py
-@@ -1842,11 +1842,16 @@ class _Renderer:
-             if self._linenums:
-                 # Last line was folded, but no linenums were generated for
-                 # the continuation lines -> current line position is not
-                 # in sync with the one calculated from the last line number
-                 unsync = (
-                     len(foldedlines) and len(foldedlines[-1]) > 1
+--- a/fypp.py	2026-05-14 18:22:07.622131094 -0400
++++ b/fypp.py	2026-05-14 18:22:07.650131330 -0400
+@@ -1848,7 +1848,13 @@
                      and not self._contlinenums)
                  # Eval directive in source consists of more than one line
                  multiline = span[1] - span[0] > 1
@@ -21,5 +15,3 @@
                      # For inline eval directives span[0] == span[1]
                      # -> next line is span[0] + 1 and not span[1] as for
                      # line eval directives
-                     nextline = max(span[1], span[0] + 1)
-                     trailing += self._linenumdir(nextline, fname)


### PR DESCRIPTION
## Summary

The fypp linemarker-resync patch (added in #1436) was written against an older fypp version where the target hunk began at line 1842 with `@@ -1842,11 +1842,16 @@`. In fypp 3.2 the same code sits at line 1848 and the surrounding context is smaller, so `patch` rejects the file as malformed and emits a warning on every `mfc.sh` invocation:

```
WARNING > (venv) Failed to apply fypp linemarker-resync patch (fypp version may have changed).
```

The patch header has been regenerated directly from the installed fypp 3.2 source, producing the correct `@@ -1848,7 +1848,13 @@` counts. The actual change to fypp (adding `or True` to always emit resync linemarkers after single-line `$:` calls) is identical.

## Test plan

- [x] `patch` applies cleanly against fypp 3.2 with no error
- [x] `grep "Always emit a resync marker" $FYPP_PY` confirms the patch is active
- [x] No startup warning on `./mfc.sh` invocations
- [x] `./mfc.sh precheck` passes (all 6 checks)