### PR TITLE
mfc.sh: add --prebuilt-prefix for running against prebuilt binaries

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -102,9 +102,12 @@ if [ $code -ne 0 ]; then
     error "main.py finished with a $code exit code."
 fi
 
-# Deactivate the Python virtualenv in case the user "source"'d this script
-log "(venv) Exiting the$MAGENTA Python$COLOR_RESET virtual environment."
-deactivate
+# Deactivate the Python virtualenv in case the user "source"'d this script.
+# In prebuilt/spack mode the venv was never created, so there's nothing to deactivate.
+if type deactivate > /dev/null 2>&1; then
+    log "(venv) Exiting the$MAGENTA Python$COLOR_RESET virtual environment."
+    deactivate
+fi
 
 # Exit with proper exit code
 exit $code

--- a/toolchain/bootstrap/python.sh
+++ b/toolchain/bootstrap/python.sh
@@ -4,6 +4,12 @@ MFC_PYTHON_MIN_MAJOR=3
 MFC_PYTHON_MIN_MINOR=9
 MFC_PYTHON_MIN_STR="$MFC_PYTHON_MIN_MAJOR.$MFC_PYTHON_MIN_MINOR"
 
+# Prebuilt/spack mode: skip the venv entirely. The caller must already have
+# python3 + the MFC toolchain deps + the `mfc` package importable on PYTHONPATH.
+if [ -n "${MFC_PREBUILT_PREFIX:-}" ]; then
+    return 0
+fi
+
 is_python_compatible() {
     if ! ${1:-python3} -c "import sys; exit(int(not (sys.version_info[0]==$MFC_PYTHON_MIN_MAJOR and sys.version_info[1] >= $MFC_PYTHON_MIN_MINOR)))"; then
         return 1

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -14,7 +14,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 from rich.text import Text
 
 from .case import Case
-from .common import MFCException, create_directory, debug, delete_directory, format_list_to_string, system
+from .common import MFCException, create_directory, debug, delete_directory, format_list_to_string, get_prebuilt_prefix, system
 from .printer import cons
 from .run import input
 from .state import ARG, CFG, gpuConfigOptions
@@ -336,6 +336,9 @@ class MFCTarget:
         return os.sep.join([os.getcwd()])
 
     def get_install_binpath(self, case: Case) -> str:
+        prebuilt = get_prebuilt_prefix()
+        if prebuilt:
+            return os.sep.join([prebuilt, "bin", self.name])
         # <root>/install/<slug>/bin/<target>
         return os.sep.join([self.get_install_dirpath(case), "bin", self.name])
 
@@ -357,6 +360,9 @@ class MFCTarget:
 
     def is_buildable(self) -> bool:
         if ARG("no_build"):
+            return False
+
+        if get_prebuilt_prefix():
             return False
 
         if self.isDependency and ARG(f"sys_{self.name}", False):

--- a/toolchain/mfc/cli/commands.py
+++ b/toolchain/mfc/cli/commands.py
@@ -275,6 +275,14 @@ RUN_COMMAND = Command(
             dest="no_build",
         ),
         Argument(
+            name="prebuilt-prefix",
+            help="Use prebuilt MFC binaries from <PREFIX>/bin (e.g. a Spack install prefix). Implies --no-build. Also settable via MFC_PREBUILT_PREFIX.",
+            type=str,
+            default=None,
+            metavar="PREFIX",
+            dest="prebuilt_prefix",
+        ),
+        Argument(
             name="wait",
             help="(Batch) Wait for the job to finish.",
             action=ArgAction.STORE_TRUE,
@@ -436,6 +444,14 @@ TEST_COMMAND = Command(
             action=ArgAction.STORE_TRUE,
             default=False,
             dest="no_build",
+        ),
+        Argument(
+            name="prebuilt-prefix",
+            help="Use prebuilt MFC binaries from <PREFIX>/bin (e.g. a Spack install prefix). Implies --no-build. Also settable via MFC_PREBUILT_PREFIX.",
+            type=str,
+            default=None,
+            metavar="PREFIX",
+            dest="prebuilt_prefix",
         ),
         Argument(
             name="no-examples",

--- a/toolchain/mfc/common.py
+++ b/toolchain/mfc/common.py
@@ -42,6 +42,17 @@ MFC_TEMPLATE_DIR = abspath(join(MFC_TOOLCHAIN_DIR, "templates"))
 MFC_BENCH_FILEPATH = abspath(join(MFC_TOOLCHAIN_DIR, "bench.yaml"))
 MFC_MECHANISMS_DIR = abspath(join(MFC_TOOLCHAIN_DIR, "mechanisms"))
 
+
+def get_prebuilt_prefix() -> typing.Optional[str]:
+    # Returns the prebuilt install prefix when MFC is run against pre-built binaries
+    # (e.g. a Spack install). The CLI flag --prebuilt-prefix takes precedence over the
+    # MFC_PREBUILT_PREFIX environment variable. Returns None when running normally.
+    from .state import ARG
+
+    cli = ARG("prebuilt_prefix", "") or None
+    return cli or os.environ.get("MFC_PREBUILT_PREFIX") or None
+
+
 MFC_LOGO = """\
      .=++*:          -+*+=.
     :+   -*-        ==   =* .


### PR DESCRIPTION
Adds support for running `mfc.sh run` and `mfc.sh test` against an externally-installed MFC (e.g. a Spack install prefix) instead of rebuilding from source.

## Motivation

A separate Spack package for MFC is being prepared. Without first-class support in MFC for "use my prebuilt binaries from <prefix>/bin", the Spack recipe has to ship a ~100-line shell wrapper that fakes an MFC working tree via cache-dir symlinks and aspirational env vars (`MFC_PREBUILT_BIN_DIR` and friends) that no MFC code actually reads. Reviewers on the Spack side will (rightly) push back on that. This change moves the "find installed binaries + skip the build steps" logic where it belongs: inside MFC.

## Changes

- New CLI flag `--prebuilt-prefix=<PATH>` on `mfc.sh run` and `mfc.sh test`. Also settable via `MFC_PREBUILT_PREFIX` environment variable (CLI wins).
- When set:
  - `Target.is_buildable()` returns False for every target (implies `--no-build`).
  - `Target.get_install_binpath()` resolves to `<prefix>/bin/<target>` instead of `<cwd>/build/install/<slug>/bin/<target>`.
  - `toolchain/bootstrap/python.sh` skips venv creation; caller is responsible for putting `python3` + toolchain deps + the `mfc` package on `PYTHONPATH`.
  - `mfc.sh`'s trailing `deactivate` call is now guarded (no-op when there's no venv to deactivate).
- Zero behavior change when the env var is unset and the flag is absent.

## Testing

Local:
- `./mfc.sh format -j 8` clean
- `./mfc.sh precheck -j 8` 6/6 pass (formatting, spelling, toolchain lint, source lint, doc refs, parameter docs)
- `--prebuilt-prefix` shows in both `run --help` and `test --help`
- `get_prebuilt_prefix()` precedence verified: CLI > env > None, empty-string CLI falls back to env
- `MFC_PREBUILT_PREFIX=/tmp/fake ./mfc.sh run --help` runs cleanly, skips venv

End-to-end MFC build + test verification is what this PR's CI will cover (local build blocked by an unrelated apple-clang 21 + ncurses toolchain issue).

## Follow-up

After this merges, the planned spack-packages PR for `mfc` collapses from ~360 lines (with embedded shell wrapper) to ~120 lines and just sets `MFC_PREBUILT_PREFIX=<prefix>` in `setup_run_environment`.