### PR TITLE
revert: remove --prebuilt-prefix  (spack-only feature)

### DIFF
--- a/mfc.sh
+++ b/mfc.sh
@@ -103,7 +103,7 @@ if [ $code -ne 0 ]; then
 fi
 
 # Deactivate the Python virtualenv in case the user "source"'d this script.
-# In prebuilt/spack mode the venv was never created, so there's nothing to deactivate.
+# Guard against the case where no venv was activated (e.g. system Python).
 if type deactivate > /dev/null 2>&1; then
     log "(venv) Exiting the$MAGENTA Python$COLOR_RESET virtual environment."
     deactivate

--- a/toolchain/bootstrap/python.sh
+++ b/toolchain/bootstrap/python.sh
@@ -4,12 +4,6 @@ MFC_PYTHON_MIN_MAJOR=3
 MFC_PYTHON_MIN_MINOR=9
 MFC_PYTHON_MIN_STR="$MFC_PYTHON_MIN_MAJOR.$MFC_PYTHON_MIN_MINOR"
 
-# Prebuilt/spack mode: skip the venv entirely. The caller must already have
-# python3 + the MFC toolchain deps + the `mfc` package importable on PYTHONPATH.
-if [ -n "${MFC_PREBUILT_PREFIX:-}" ]; then
-    return 0
-fi
-
 is_python_compatible() {
     if ! ${1:-python3} -c "import sys; exit(int(not (sys.version_info[0]==$MFC_PYTHON_MIN_MAJOR and sys.version_info[1] >= $MFC_PYTHON_MIN_MINOR)))"; then
         return 1

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -14,7 +14,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 from rich.text import Text
 
 from .case import Case
-from .common import MFCException, create_directory, debug, delete_directory, format_list_to_string, get_prebuilt_prefix, system
+from .common import MFCException, create_directory, debug, delete_directory, format_list_to_string, system
 from .printer import cons
 from .run import input
 from .state import ARG, CFG, gpuConfigOptions
@@ -336,9 +336,6 @@ class MFCTarget:
         return os.sep.join([os.getcwd()])
 
     def get_install_binpath(self, case: Case) -> str:
-        prebuilt = get_prebuilt_prefix()
-        if prebuilt:
-            return os.sep.join([prebuilt, "bin", self.name])
         # <root>/install/<slug>/bin/<target>
         return os.sep.join([self.get_install_dirpath(case), "bin", self.name])
 
@@ -360,9 +357,6 @@ class MFCTarget:
 
     def is_buildable(self) -> bool:
         if ARG("no_build"):
-            return False
-
-        if get_prebuilt_prefix():
             return False
 
         if self.isDependency and ARG(f"sys_{self.name}", False):

--- a/toolchain/mfc/cli/commands.py
+++ b/toolchain/mfc/cli/commands.py
@@ -275,14 +275,6 @@ RUN_COMMAND = Command(
             dest="no_build",
         ),
         Argument(
-            name="prebuilt-prefix",
-            help="Use prebuilt MFC binaries from <PREFIX>/bin (e.g. a Spack install prefix). Implies --no-build. Also settable via MFC_PREBUILT_PREFIX.",
-            type=str,
-            default=None,
-            metavar="PREFIX",
-            dest="prebuilt_prefix",
-        ),
-        Argument(
             name="wait",
             help="(Batch) Wait for the job to finish.",
             action=ArgAction.STORE_TRUE,
@@ -444,14 +436,6 @@ TEST_COMMAND = Command(
             action=ArgAction.STORE_TRUE,
             default=False,
             dest="no_build",
-        ),
-        Argument(
-            name="prebuilt-prefix",
-            help="Use prebuilt MFC binaries from <PREFIX>/bin (e.g. a Spack install prefix). Implies --no-build. Also settable via MFC_PREBUILT_PREFIX.",
-            type=str,
-            default=None,
-            metavar="PREFIX",
-            dest="prebuilt_prefix",
         ),
         Argument(
             name="no-examples",

--- a/toolchain/mfc/common.py
+++ b/toolchain/mfc/common.py
@@ -42,17 +42,6 @@ MFC_TEMPLATE_DIR = abspath(join(MFC_TOOLCHAIN_DIR, "templates"))
 MFC_BENCH_FILEPATH = abspath(join(MFC_TOOLCHAIN_DIR, "bench.yaml"))
 MFC_MECHANISMS_DIR = abspath(join(MFC_TOOLCHAIN_DIR, "mechanisms"))
 
-
-def get_prebuilt_prefix() -> typing.Optional[str]:
-    # Returns the prebuilt install prefix when MFC is run against pre-built binaries
-    # (e.g. a Spack install). The CLI flag --prebuilt-prefix takes precedence over the
-    # MFC_PREBUILT_PREFIX environment variable. Returns None when running normally.
-    from .state import ARG
-
-    cli = ARG("prebuilt_prefix", "") or None
-    return cli or os.environ.get("MFC_PREBUILT_PREFIX") or None
-
-
 MFC_LOGO = """\
      .=++*:          -+*+=.
     :+   -*-        ==   =* .


### PR DESCRIPTION
Reverts the spack-specific additions from #1444, keeping only the defensive `deactivate` guard in `mfc.sh` which is useful regardless.

## What's removed
- `--prebuilt-prefix` CLI flag from `mfc.sh run` and `mfc.sh test`
- `MFC_PREBUILT_PREFIX` environment variable support
- `get_prebuilt_prefix()` in `toolchain/mfc/common.py`
- Prebuilt prefix logic in `toolchain/mfc/build.py`
- Venv skip in `toolchain/bootstrap/python.sh`

## Why
The spack package for MFC is being parked — the upstream `spack/spack-packages` PR has unclear ROI given MFC already has `install.sh` and full CI on Frontier and Phoenix. These toolchain changes only exist to support that spack workflow.

## What's kept
The `if type deactivate` guard in `mfc.sh` — defensive and independently useful.