### PR TITLE
cmake: replace -fopenmp-target-fast with -O3 for LLVMFlang AMD GPU builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,7 +643,7 @@ exit 0
                     target_compile_options(${a_target} PRIVATE -fopenmp)
                     target_link_options(${a_target} PRIVATE -fopenmp)
                 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
-                    target_compile_options(${a_target} PRIVATE -fopenmp --offload-arch=gfx90a -fopenmp-target-fast -fopenmp-assume-threads-oversubscription -fopenmp-assume-teams-oversubscription)
+                    target_compile_options(${a_target} PRIVATE -fopenmp --offload-arch=gfx90a -O3 -fopenmp-assume-threads-oversubscription -fopenmp-assume-teams-oversubscription)
                     target_link_options(${a_target} PRIVATE -fopenmp --offload-arch=gfx90a -flto-partitions=${MFC_BUILD_JOBS})
                 endif()
             endif()


### PR DESCRIPTION
## Summary

Replaces `-fopenmp-target-fast` with `-O3` in the LLVMFlang OpenMP target offload compile flags.

`-fopenmp-target-fast` is present in the minimal reproducer for the array constructor corruption bug reported in #1449. Replacing it with explicit `-O3` preserves optimization level while avoiding the flag combination that triggers silent wrong values in `GPU_PARALLEL_LOOP` regions on AMD MI250X (gfx90a).

Closes #1449

## Test plan

- [x] Build with `./mfc.sh build --gpu mp -j 8` on Frontier using AMD flang
- [x] Run IBM test cases (`./mfc.sh test --only IBM -j 8`) and confirm ghost point corrections are correct
- [ ] Run full test suite on Frontier to check for regressions