### PR TITLE
toolchain: bump ffmt 0.4.0 -> 0.4.1

### DIFF
--- a/toolchain/pyproject.toml
+++ b/toolchain/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # Code Health
     "typos",
     "ruff",
-    "ffmt==0.4.0",
+    "ffmt==0.4.1",
     "ansi2txt",
 
     # Profiling


### PR DESCRIPTION
## Summary

- Bumps `ffmt` from 0.4.0 to 0.4.1
- The new release publishes `manylinux_2_17` wheels (glibc ≥ 2.17), so HPC systems with older glibc (e.g. Tuolumne at 2.28, RHEL 7/8 clusters) no longer fall back to compiling ffmt from source
- Previously, source compilation on Cray systems failed because Cray's `cc` wrapper injects plugin options incompatible with `rust-lld`; the new wheel eliminates this entirely
- Also adds `ppc64le` and `aarch64` Linux wheels and a `universal2` macOS wheel

## Test plan

- [x] Clean install verified on Tuolumne (glibc 2.28, Cray PE loaded) — ffmt downloaded as binary wheel, no source compilation