### PR TITLE
ci: wire CACHE_PUSH_TOKEN so the coverage-map refresh actually pushes

### DIFF
--- a/.github/workflows/coverage-refresh.yml
+++ b/.github/workflows/coverage-refresh.yml
@@ -27,18 +27,18 @@ jobs:
       - name: Build + collect coverage map (SLURM)
         run: bash .github/scripts/submit-slurm-job.sh .github/workflows/common/coverage-refresh.sh cpu none phoenix
       - name: Commit refreshed map
+        env:
+          CACHE_PUSH_TOKEN: ${{ secrets.CACHE_PUSH_TOKEN }}
         run: |
           if ! git diff --quiet tests/coverage_map.json.gz; then
             git config user.name  "mfc-bot"
             git config user.email "mfc-bot@users.noreply.github.com"
             git add tests/coverage_map.json.gz
             git commit -m "test: refresh coverage map [skip ci]"
-            # NOTE: pushing to a protected default branch requires a token or
-            # GitHub App with bypass-branch-protection permission.  The default
-            # GITHUB_TOKEN may be rejected by branch protection rules; if so,
-            # configure a PAT or App token with the `contents: write` scope and
-            # pass it as `GITHUB_TOKEN` in the environment for this step.
-            git push origin HEAD:master
+            # Push to protected master via CACHE_PUSH_TOKEN (a PAT/App token with
+            # contents:write + branch-protection bypass), mirroring deploy-tap.yml's
+            # x-access-token push. The default GITHUB_TOKEN is rejected by protection.
+            git push "https://x-access-token:${CACHE_PUSH_TOKEN}@github.com/MFlowCode/MFC.git" HEAD:master
           else
             echo "Coverage map unchanged."
           fi


### PR DESCRIPTION
Follow-up to #1461. The `coverage-refresh` workflow pushed to protected `master` with the default `GITHUB_TOKEN`, which branch protection rejects — so the auto-refresh (the anti-rot mechanism) would never update the committed map.

The repo already has a **`CACHE_PUSH_TOKEN`** secret (created when the original cache was built) that was wired *nowhere* — part of why the old committed cache never auto-refreshed. This uses it, via the same `x-access-token` push pattern `deploy-tap.yml` uses for the homebrew repo.

With this, the weekly (+ cases.py/src-fpp-triggered) refresh can commit the rebuilt map back to master, and `coverage-health` stays green instead of going red after ~10 days.

(Requires that `CACHE_PUSH_TOKEN` has `contents: write` and branch-protection bypass for MFlowCode/MFC — it was presumably created for exactly this.)