### PR TITLE
[smoke test] confirm coverage selection prunes in shadow (comment-only .fpp change)

### DIFF
--- a/src/simulation/m_bubbles_EE.fpp
+++ b/src/simulation/m_bubbles_EE.fpp
@@ -1,6 +1,6 @@
 !>
 !! @file
-!! @brief Contains module @ref m_bubbles_ee "m_bubbles_EE"
+!! @brief Contains module @ref m_bubbles_ee "m_bubbles_EE" (Euler--Euler bubble model)
 
 #:include 'macros.fpp'
 


### PR DESCRIPTION
**Throwaway draft** to validate coverage-based test selection in shadow mode on a real Fortran-only PR (the first one since #1461 merged). It changes only a doc comment in `m_bubbles_EE.fpp` — no behavioral change, golden files unaffected.

Expectation: the github shadow-selection line should report a **pruned subset** (~`ran 101/610`, the bubble-covering tests) rather than run-all, confirming the selector works end-to-end on a real PR. Draft so the heavy self-hosted matrix doesn't run.

Will be closed (not merged) once the shadow line is observed.