### PR TITLE
fix(coverage): exclude convergence tests from map build; harden refresh bot commit

### DIFF
--- a/.github/workflows/coverage-refresh.yml
+++ b/.github/workflows/coverage-refresh.yml
@@ -34,7 +34,10 @@ jobs:
             git config user.name  "mfc-bot"
             git config user.email "mfc-bot@users.noreply.github.com"
             git add tests/coverage_map.json.gz
-            git commit -m "test: refresh coverage map [skip ci]"
+            # --no-verify: this bot commit stages only the binary coverage map; it
+            # must not run the repo pre-commit hook (./mfc.sh precheck/spelling),
+            # which is for source changes and aborts the commit on the runner.
+            git commit --no-verify -m "test: refresh coverage map [skip ci]"
             # Push to protected master via CACHE_PUSH_TOKEN (a PAT/App token with
             # contents:write + branch-protection bypass), mirroring deploy-tap.yml's
             # x-access-token push. The default GITHUB_TOKEN is rejected by protection.

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -230,7 +230,18 @@ def test():
     if ARG("build_coverage_map"):
         from .coverage_build import build_coverage_map
 
-        all_cases = [b.to_case() for b in cases]
+        # Convergence tests are order-of-accuracy checks driven by convergence.py,
+        # which fills in grid resolution and patch geometry per refinement level at
+        # runtime. Their base params are skeletons (m=n=p=0, no geometry) that cannot
+        # run standalone, so the direct-invocation collector cannot map them. Exclude
+        # them: absent from the map, select_tests conservatively always-runs them
+        # (rung 5), which is the desired behavior for convergence checks anyway.
+        convergence = [b for b in cases if getattr(b, "kind", "golden") == "convergence"]
+        coverage_cases = [b for b in cases if getattr(b, "kind", "golden") != "convergence"]
+        if convergence:
+            cons.print(f"[yellow]Excluding {len(convergence)} convergence tests from the coverage map (always-run by design).[/yellow]")
+
+        all_cases = [b.to_case() for b in coverage_cases]
         unique = set()
         for case, code in itertools.product(all_cases, [PRE_PROCESS, SIMULATION, POST_PROCESS]):
             slug = code.get_slug(case.to_input_file())


### PR DESCRIPTION
## What

A manual run of the weekly `coverage-refresh` workflow (workflow_dispatch) surfaced two automation bugs. The SLURM gcov collector itself ran correctly in CI (`618 tests → 574 mapped`), but:

**1. The map builder ran convergence tests and they all failed (32/618).**
`--build-coverage-map` passed every case to the direct-invocation collector, including `kind=convergence` cases. Convergence tests are order-of-accuracy checks driven by `convergence.py`, which fills in grid resolution and patch geometry *per refinement level* at runtime — their base params are skeletons (`m=n=p=0`, no `patch_icpp%geometry`) that cannot run standalone. So all 32 errored in `pre_process` (`geometry must be set` / `nGlobal < min_cells`).
   - **Map impact: none harmful.** Failed tests are omitted → absent from the map → `select_tests` conservatively always-runs them (rung 5). That is the correct behavior for convergence checks anyway. This change just makes it explicit and removes 32 spurious failure warnings.

**2. The commit-back ran the pre-commit hook and aborted before pushing.**
`git commit` triggered the repo hook (`./mfc.sh precheck`/spelling) against the `clean: false` working tree (polluted with leftover SLURM coverage artifacts), which failed → commit aborted → the `git push` never ran. The bot commit stages only the binary map, so it should bypass source-code prechecks: `git commit --no-verify`.

## Changes
- `toolchain/mfc/test/test.py`: exclude `kind=='convergence'` cases from the coverage-map build; log how many are excluded (always-run by design).
- `.github/workflows/coverage-refresh.yml`: `git commit --no-verify` for the map-refresh bot commit.

## Verification
- `{'golden': 586, 'convergence': 32}` — filter excludes exactly the 32 tests that failed in CI.
- `./mfc.sh precheck` + `./mfc.sh lint` (273 unit tests) pass locally; spell check passes locally, confirming the CI hook failure was a runner-tree artifact, not a master regression.

## Still unverified
The `CACHE_PUSH_TOKEN` branch-protection bypass never executed (the commit aborted first). The next refresh run after this merges will exercise the push for the first time.