### PR TITLE
ci(coverage): use app token for push (persist-credentials: false)

### DIFF
--- a/.github/workflows/coverage-refresh.yml
+++ b/.github/workflows/coverage-refresh.yml
@@ -22,8 +22,14 @@ jobs:
       group:  phoenix
       labels: gt
     steps:
+      # persist-credentials: false stops actions/checkout from configuring the
+      # default GITHUB_TOKEN as an http.extraheader, which otherwise OVERRIDES the
+      # app-token credentials embedded in the push URL below — making the push
+      # authenticate as github-actions[bot] (not a ruleset bypass actor) and get
+      # rejected by the require-PR rule. With it off, the app token is used and the
+      # mfc-map-bot bypass applies.
       - uses: actions/checkout@v4
-        with: { clean: false }
+        with: { clean: false, persist-credentials: false }
       - name: Build + collect coverage map (SLURM)
         run: bash .github/scripts/submit-slurm-job.sh .github/workflows/common/coverage-refresh.sh cpu none phoenix
       # Mint a short-lived GitHub App installation token. The app is on the master


### PR DESCRIPTION
## Root cause

The previous run minted the `mfc-map-bot` app token correctly, but the push still hit `GH013 ... Changes must be made through a pull request` even with the app on the ruleset bypass list.

Reason: **`actions/checkout` persists the default `GITHUB_TOKEN` as an `http.https://github.com/.extraheader` auth header**, which **overrides** the app-token credentials embedded in the push URL. So the push authenticated as `github-actions[bot]` (not a bypass actor) and was rejected by the require-PR rule. The bypass config was correct all along; the push just never used the app identity.

Refs: [community #136531](https://github.com/orgs/community/discussions/136531), [community #72173](https://github.com/orgs/community/discussions/72173), [create-github-app-token #81](https://github.com/actions/create-github-app-token/issues/81).

## Fix

`persist-credentials: false` on the checkout step, so the push uses the app-token URL. The SLURM build/collect needs no persisted git credentials (it only reads via `git rev-parse`/`git diff` and installs public deps), so this is safe.

## Follow-up (restores protection)

With this merged, the `pull_request` (require-PR) rule can be **re-added** to the master ruleset: humans still need PRs, and only the `mfc-map-bot` app bypasses it. I'll restore the rule and dispatch a verification run once this lands.