### PR TITLE
ci(coverage): push refreshed map via classic PAT (CACHE_PUSH_TOKEN)

### DIFF
--- a/.github/workflows/coverage-refresh.yml
+++ b/.github/workflows/coverage-refresh.yml
@@ -24,38 +24,31 @@ jobs:
     steps:
       # persist-credentials: false stops actions/checkout from configuring the
       # default GITHUB_TOKEN as an http.extraheader, which otherwise OVERRIDES the
-      # app-token credentials embedded in the push URL below — making the push
-      # authenticate as github-actions[bot] (not a ruleset bypass actor) and get
-      # rejected by the require-PR rule. With it off, the app token is used and the
-      # mfc-map-bot bypass applies.
+      # token embedded in the push URL below — making the push authenticate as
+      # github-actions[bot] (which cannot bypass the require-PR rule) instead of
+      # the CACHE_PUSH_TOKEN identity.
       - uses: actions/checkout@v4
         with: { clean: false, persist-credentials: false }
       - name: Build + collect coverage map (SLURM)
         run: bash .github/scripts/submit-slurm-job.sh .github/workflows/common/coverage-refresh.sh cpu none phoenix
-      # Mint a short-lived GitHub App installation token. The app is on the master
-      # ruleset's bypass list (Integration actor), so its push satisfies the
-      # "require pull request" rule that rejects the default GITHUB_TOKEN.
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.MAP_BOT_APP_ID }}
-          private-key: ${{ secrets.MAP_BOT_APP_PRIVATE_KEY }}
       - name: Commit refreshed map
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CACHE_PUSH_TOKEN: ${{ secrets.CACHE_PUSH_TOKEN }}
         run: |
           if ! git diff --quiet tests/coverage_map.json.gz; then
-            git config user.name  "mfc-map-bot[bot]"
-            git config user.email "mfc-map-bot[bot]@users.noreply.github.com"
+            git config user.name  "mfc-bot"
+            git config user.email "mfc-bot@users.noreply.github.com"
             git add tests/coverage_map.json.gz
             # --no-verify: this bot commit stages only the binary coverage map; it
             # must not run the repo pre-commit hook (./mfc.sh precheck/spelling),
             # which is for source changes and aborts the commit on the runner.
             git commit --no-verify -m "test: refresh coverage map [skip ci]"
-            # Push to master via the app installation token. The app is a bypass
-            # actor on the master ruleset, so the require-PR rule does not reject it.
-            git push "https://x-access-token:${GH_TOKEN}@github.com/MFlowCode/MFC.git" HEAD:master
+            # Push to master with CACHE_PUSH_TOKEN, a classic PAT from an org-owner
+            # account. GitHub Apps cannot bypass the require-PR ruleset rule for
+            # direct pushes, but a PAT authenticates as the user (OrganizationAdmin),
+            # which IS an honored bypass actor. persist-credentials:false above
+            # ensures this token is actually used for the push.
+            git push "https://x-access-token:${CACHE_PUSH_TOKEN}@github.com/MFlowCode/MFC.git" HEAD:master
           else
             echo "Coverage map unchanged."
           fi


### PR DESCRIPTION
## Why

The coverage-refresh push to master needs to bypass the `master` ruleset's require-PR rule. We tried a GitHub App (`mfc-map-bot`), but **GitHub Apps cannot bypass the require-PR rule for direct pushes** — a [documented limitation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets) ([discussion #136531](https://github.com/orgs/community/discussions/136531)). A **classic PAT** authenticates as a *user*; an org-owner user is an `OrganizationAdmin`, which **is** an honored bypass actor.

## Change

Push with `CACHE_PUSH_TOKEN` (now a classic org-owner PAT, `repo` scope) instead of the app token. The `persist-credentials: false` fix from #1466 is retained — it ensures the PAT is the identity used for the push rather than the hijacking `GITHUB_TOKEN` extraheader (the real reason every earlier attempt failed).

## Verified

A throwaway smoke-test workflow pushed a commit to **protected master with require-PR active** using exactly this mechanism — it landed (`mfc-bot test: pat-push smoketest`), then was cleaned up. So the full chain (SLURM collect → `--no-verify` commit → PAT push) is proven end-to-end.

## Follow-up cleanup
- Remove the now-unused `Integration` bypass actor (`mfc-map-bot`) from the master ruleset.
- The `mfc-map-bot` App and its secrets (`MAP_BOT_APP_ID`, `MAP_BOT_APP_PRIVATE_KEY`) can be deleted.