### PR TITLE
ci(coverage): make health check robust to un-loadable (chemistry/cantera) cases

### DIFF
--- a/.github/scripts/check_coverage_map_health.py
+++ b/.github/scripts/check_coverage_map_health.py
@@ -13,7 +13,22 @@ MIN_FRACTION = 0.80
 entries, meta = load_map(COVERAGE_MAP_PATH)
 if entries is None:
     sys.exit("Coverage map missing or corrupt.")
-current_keys = {b.to_case().coverage_key() for b in list_cases()}
+# Compute each current test's coverage key. Loading a case executes its case
+# file; some (e.g. chemistry examples) import optional deps like cantera that are
+# not installed in this lightweight job. Skip any case that fails to load instead
+# of crashing — map_health measures the fraction of *loadable* current tests that
+# are mapped, so a smaller current_keys cannot produce a false "stale" result.
+current_keys = set()
+unloadable = []
+for b in list_cases():
+    try:
+        current_keys.add(b.to_case().coverage_key())
+    except Exception as exc:  # noqa: BLE001 — a case file that won't import must not crash the health check
+        unloadable.append((getattr(b, "trace", repr(b)), str(exc).strip().splitlines()[-1][:140]))
+if unloadable:
+    print(f"Note: {len(unloadable)} case(s) could not be loaded in this lightweight job (excluded from the check):")
+    for trace, err in unloadable[:15]:
+        print(f"  - {trace}: {err}")
 ok, msg = map_health(
     meta=meta,
     current_keys=current_keys,


### PR DESCRIPTION
## Problem

The first scheduled run of the **Coverage Map Health** workflow (overnight) failed — but the map is fine; the *check* crashed:

```
File ".../examples/nD_perfect_reactor/case.py", line 7, in <module>
    import cantera as ct
ModuleNotFoundError: No module named 'cantera'
→ check_coverage_map_health.py:16  current_keys = {b.to_case().coverage_key() for b in list_cases()}
```

`coverage_key()` calls `to_case()`, which *executes* the case file. Chemistry examples import `cantera`, but the lightweight health job runs only `./mfc.sh init` (cantera is installed by `build`, not `init`). One un-loadable case aborted the whole check.

## Fix

Skip any case that fails to load and log it, instead of crashing. This is safe: `map_health` computes `len(current_keys & mapped_keys) / len(current_keys)` — the fraction of *loadable* current tests that are mapped — so a smaller `current_keys` cannot produce a false "stale". The age check (the primary anti-rot signal) is unaffected.

## Verified locally
(my env also lacks cantera, so it exercised the skip path)
```
Note: 8 case(s) could not be loaded in this lightweight job (excluded from the check):
  - nD -> Example -> perfect_reactor: ...
  - 1D -> Chemistry -> Inert Shocktube -> ...
Coverage map healthy: 0d old.   (exit 0)
```
273 unit tests pass.