### PR TITLE
Reject chemistry with num_fluids > 1 in case validator

### DIFF
--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -1323,6 +1323,15 @@ class CaseValidator:
         # Fetch global chemistry and diffusion flags
         chemistry = self.get("chemistry", "F") == "T"
         diffusion = self.get("chem_params%diffusion", "F") == "T"
+        num_fluids = self.get("num_fluids")
+
+        # Chemistry assumes a single reacting gas phase: the temperature/pressure
+        # inversion recovers T from the total internal energy via Cantera's ideal-gas
+        # EOS (ignoring pi_inf), and the cons->prim conversion collapses all partial
+        # densities onto the species-summed total density. Both are only correct for
+        # num_fluids = 1; with a second (e.g. stiffened-gas) fluid the state is
+        # inconsistent and the simulation NaNs. See MFlowCode/MFC#1470.
+        self.prohibit(chemistry and num_fluids is not None and num_fluids != 1, "chemistry is only supported for single-component flows (num_fluids = 1)")
 
         # Define what constitutes a wall (-15 for slip, -16 for no-slip)
         wall_bcs = [-15, -16]


### PR DESCRIPTION
## Description

Closes #1470.

Chemistry in MFC assumes a **single reacting gas phase** and is not coupled to the multi-fluid (5-equation) model. When `chemistry = T` is combined with `num_fluids > 1`, the simulation silently produces `NaN` rather than erroring out. Two paths in `src/common/m_variables_conversion.fpp` are responsible:

1. The chemistry branch of `s_convert_conservative_to_primitive_variables` overwrites **all** partial densities (`qK_prim_vf(1:num_fluids)`) with the species-summed total density — correct for `num_fluids = 1`, destructive otherwise.
2. `s_compute_pressure` recovers temperature from the **total** internal energy via Cantera's **ideal-gas** EOS, ignoring `pi_inf`. With a second stiffened-gas fluid present (e.g. a water droplet, `pi_inf ~ 4e8`), the inversion diverges and `NaN` propagates.

Full multi-fluid + chemistry coupling is a larger, research-level effort. This PR is the short-term fix: a case-validator guard that rejects the unsupported combination with a clear message instead of leaving users to debug `NaN`s. Both `chemistry` and `num_fluids` are known at case-definition time, so the guard lives in Python (`case_validator.py`); no Fortran-side check is needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Scope

- Adds one `prohibit` to `CaseValidator.check_chemistry`, mirroring the existing `mhd and num_fluids != 1` guard.

## How Has This Been Tested?

Validator unit-checked directly:
- `chemistry='T', num_fluids=2` -> rejected with "chemistry is only supported for single-component flows (num_fluids = 1)"
- `chemistry='T', num_fluids=1` -> passes (no regression for existing chemistry examples, all of which use `num_fluids = 1`)
- `num_fluids=2` without chemistry -> passes (unaffected)
- `chemistry='T'` with `num_fluids` unset -> passes (deferred to existing model_eqns/num_fluids check)

`ruff check` and `ruff format --check` pass on the changed file.

## Checklist

- [x] I have added a concise diagnostic message
- [x] My change is a single logical commit
- [x] `ruff` lint/format pass