### PR TITLE
ci(coverage): guard health-check skip against empty exception message

### DIFF
--- a/.github/scripts/check_coverage_map_health.py
+++ b/.github/scripts/check_coverage_map_health.py
@@ -24,7 +24,8 @@ for b in list_cases():
     try:
         current_keys.add(b.to_case().coverage_key())
     except Exception as exc:  # noqa: BLE001 — a case file that won't import must not crash the health check
-        unloadable.append((getattr(b, "trace", repr(b)), str(exc).strip().splitlines()[-1][:140]))
+        last_line = (str(exc).strip().splitlines() or ["(no message)"])[-1][:140]
+        unloadable.append((getattr(b, "trace", repr(b)), last_line))
 if unloadable:
     print(f"Note: {len(unloadable)} case(s) could not be loaded in this lightweight job (excluded from the check):")
     for trace, err in unloadable[:15]:


### PR DESCRIPTION
Follow-up to #1471. Addresses a Claude Code Review finding: in the skip handler,

```python
str(exc).strip().splitlines()[-1]
```

raises `IndexError` if the exception's message is empty (`"".splitlines()` → `[]`), and that secondary error is *inside* the `except` handler so it propagates and crashes the very graceful-skip path the change added. Low-probability (our cases raise `MFCException` with messages) but a real latent crash.

Fix: `(str(exc).strip().splitlines() or ["(no message)"])[-1][:140]`.

Verified locally: still skips the 8 chemistry cases and reports healthy; the empty-`ImportError()` case now yields `'(no message)'` instead of raising.