### PR TITLE
fix(run): validate job options before generating job script

### DIFF
--- a/toolchain/mfc/run/run.py
+++ b/toolchain/mfc/run/run.py
@@ -196,8 +196,8 @@ def run(targets=None, case=None):
         if ARG("nodes") > 1 or ARG("tasks_per_node") > 1:
             cons.print(f"  [dim]MPI: {ARG('nodes')} nodes × {ARG('tasks_per_node')} tasks/node = {ARG('nodes') * ARG('tasks_per_node')} total ranks[/dim]")
 
-    __generate_job_script(targets, case)
     __validate_job_options()
+    __generate_job_script(targets, case)
     __generate_input_files(targets, case)
 
     if verbosity >= 2:


### PR DESCRIPTION
## What
Moves `__validate_job_options()` before `__generate_job_script()` in `run()` so that invalid invocations (e.g. `--no-mpi` with >1 rank, `nodes <= 0`, malformed `--email`) are rejected **before** a stale `.sh` file is written to disk.

## Why
Previously the call order was:
1. `__generate_job_script(...)` — writes the job `.sh` to disk
2. `__validate_job_options()` — may raise `MFCException`

An invalid invocation would leave a confusing stale job script on disk while aborting the run.

## Testing
This is a pure reorder of two function calls — `__validate_job_options()` has no side effects (it reads `ARG()` and may raise). Existing callers of `run()` exercise both paths.

Fixes part (b) of #1511.