### PR TITLE
refactor(fp-stability): extract _empty_result helper

### DIFF
--- a/toolchain/mfc/fp_stability.py
+++ b/toolchain/mfc/fp_stability.py
@@ -98,6 +98,24 @@ _CONTROL_FLOW_RE = re.compile(
 )
 
 
+def _empty_result(name: str, threshold: float) -> dict:
+    """Build a default empty result dict with all fields initialised."""
+    return {
+        "name": name,
+        "passed": False,
+        "max_dev": float("inf"),
+        "threshold": threshold,
+        "float_proxy": None,
+        "vprec": [],
+        "dd_sym_syms": [],
+        "dd_line_locs": [],
+        "cancellation_locs": [],
+        "mca_dev": None,
+        "mca_sigbits": None,
+        "float_max_locs": [],
+    }
+
+
 def _read_source_line(fname: str, lineno: int) -> str:
     """Return the raw source line at lineno (1-based), or '' if unavailable."""
     if os.path.isabs(fname) and os.path.isfile(fname):
@@ -967,20 +985,7 @@ def _run_case(
     cons.print(f"  threshold: {threshold:.0e}")
 
     work_dir = tempfile.mkdtemp(prefix=f"mfc-fps-{name}-")
-    result = {
-        "name": name,
-        "passed": False,
-        "max_dev": float("inf"),
-        "threshold": threshold,
-        "float_proxy": None,
-        "vprec": [],
-        "dd_sym_syms": [],
-        "dd_line_locs": [],
-        "cancellation_locs": [],
-        "mca_dev": None,
-        "mca_sigbits": None,
-        "float_max_locs": [],
-    }
+    result = _empty_result(name, threshold)
     try:
         cons.print("  [dim]running pre_process...[/dim]")
         _write_inp(case["sim"], "simulation", work_dir)
@@ -1319,20 +1324,7 @@ def fp_stability():
             )
         except MFCException as exc:
             cons.print(f"  [bold red]ERROR[/bold red]: {exc}")
-            r = {
-                "name": case["name"],
-                "passed": False,
-                "max_dev": float("inf"),
-                "threshold": case["threshold"],
-                "float_proxy": None,
-                "vprec": [],
-                "dd_sym_syms": [],
-                "dd_line_locs": [],
-                "cancellation_locs": [],
-                "mca_dev": None,
-                "mca_sigbits": None,
-                "float_max_locs": [],
-            }
+            r = _empty_result(case["name"], case["threshold"])
         results.append(r)
 
     elapsed = time.time() - start


### PR DESCRIPTION
## What
Extracts the identical 13-key empty result dict into a reusable `_empty_result(name, threshold)` helper function, replacing both manual dict literals with a single call.

## Why
The default result dict `{name, passed, max_dev, threshold, float_proxy, vprec, dd_sym_syms, dd_line_locs, cancellation_locs, mca_dev, mca_sigbits, float_max_locs}` appeared at:
- `toolchain/mfc/fp_stability.py:970-983` (in `_run_case`)
- `toolchain/mfc/fp_stability.py:1322-1335` (error handler in `_run_stability_checks`)

Any future field addition or default change must be edited in lockstep. The helper keeps this in one place.

## Testing
Pure extraction — identical constants, identical control flow. No behavior change. The existing FP-stability CI paths exercise both call sites.

Fixes part (a) of #1512.