### PR TITLE
cleanup: remove orphaned comments referencing invisible context

### DIFF
--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -11,7 +11,6 @@ Based on the constraints enforced in:
 - src/simulation/m_checker.fpp
 - src/post_process/m_checker.fpp
 """
-# Justification: Comprehensive validator covering all MFC parameter constraints
 
 import re
 from functools import lru_cache

--- a/toolchain/mfc/params/definitions.py
+++ b/toolchain/mfc/params/definitions.py
@@ -1,8 +1,6 @@
-"""
-MFC Parameter Definitions (Compact).
+"""MFC Parameter Definitions (Compact).
 
 Single file containing all ~3,300 parameter definitions using loops.
-This replaces the definitions/ directory.
 """
 
 import re


### PR DESCRIPTION
## What
Removes two stale comments that reference context no longer visible in the repository:

1. **`case_validator.py`**: Dangling `# Justification: Comprehensive validator covering all MFC parameter constraints` comment after the module docstring — a leftover review note.
2. **`params/definitions.py`**: `"This replaces the definitions/ directory."` — documents a past migration; that directory was already removed from the repo, so the note refers to invisible history.

## Why
Dead comments create noise for new readers and suggest maintenance that is no longer happening.

## Testing
Comment-only changes — no behavior impact. Python imports and module behavior are unaffected.

Fixes #1500.