### PR TITLE
fix: correct internal spelling typos

### DIFF
--- a/src/common/m_boundary_common.fpp
+++ b/src/common/m_boundary_common.fpp
@@ -260,7 +260,7 @@ contains
                             call s_symmetry(q_prim_vf, 3, 1, k, l, pb_in, mv_in, q_T_sf)
                         case (BC_PERIODIC)
                             call s_periodic(q_prim_vf, 3, 1, k, l, pb_in, mv_in, q_T_sf)
-                        case (BC_SlIP_WALL)
+                        case (BC_SLIP_WALL)
                             call s_slip_wall(q_prim_vf, 3, 1, k, l, q_T_sf)
                         case (BC_NO_SLIP_WALL)
                             call s_no_slip_wall(q_prim_vf, 3, 1, k, l, q_T_sf)

--- a/src/common/m_finite_differences.fpp
+++ b/src/common/m_finite_differences.fpp
@@ -39,7 +39,7 @@ contains
 
 #ifdef MFC_POST_PROCESS
         if (allocated(fd_coeff_s)) deallocate (fd_coeff_s)
-        allocate (fd_coeff_s(-fd_number_in:fd_number_in,lb:lE))
+        allocate (fd_coeff_s(-fd_number_in:fd_number_in,lB:lE))
 #endif
 
         ! Computing the 1st order finite-difference coefficients

--- a/toolchain/mfc/test/case.py
+++ b/toolchain/mfc/test/case.py
@@ -479,9 +479,9 @@ def create_input_lagrange(path_test):
 
 def copy_input_lagrange(path_example_input, path_test):
     folder_path_dest = path_test + "/input/"
-    fite_path_dest = folder_path_dest + "lag_bubbles.dat"
+    file_path_dest = folder_path_dest + "lag_bubbles.dat"
     file_path_src = common.MFC_EXAMPLE_DIRPATH + path_example_input + "/input/lag_bubbles.dat"
     if not os.path.exists(folder_path_dest):
         os.mkdir(folder_path_dest)
 
-    shutil.copyfile(file_path_src, fite_path_dest)
+    shutil.copyfile(file_path_src, file_path_dest)


### PR DESCRIPTION
## What
Fixes three spelling typos in the codebase:

1. **`BC_SlIP_WALL` → `BC_SLIP_WALL`** in `src/common/m_boundary_common.fpp:263` — lowercase `l` instead of `L` in `SlIP`. Fortran is case-insensitive so it compiled, but a grep for `BC_SLIP_WALL` would miss this site.
2. **`lb` → `lB`** in `src/common/m_finite_differences.fpp:42` — declared everywhere else as `lB`; this single site used lowercase.
3. **`fite_path_dest` → `file_path_dest`** in `toolchain/mfc/test/case.py:482,487` — clear naming typo in variable name.

## Why
Spelling errors in identifiers degrade grep-ability and code readability even when they compile (Fortran case-insensitivity).

## Testing
All changes are cosmetic identifier renames. No behavior change.

Fixes #1498 (items 2, 4, 5).