### PR TITLE
Fix --debug/--reldebug GPU builds

### DIFF
--- a/src/common/m_variables_conversion.fpp
+++ b/src/common/m_variables_conversion.fpp
@@ -1332,7 +1332,11 @@ contains
 #ifdef MFC_DEBUG
         if (disc < 0._wp) then
             print *, 'rho, c, Bx, By, Bz, h, term, disc:', rho, c, B(1), B(2), B(3), h, term, disc
+            ! s_mpi_abort is a host routine and cannot be called from device code
+            ! (this is a GPU routine); on GPU builds, emit the diagnostic print only.
+#ifndef MFC_GPU
             call s_mpi_abort('Error: negative discriminant in s_compute_fast_magnetosonic_speed')
+#endif
         end if
 #endif
 


### PR DESCRIPTION
## Problem

`--debug` and `--reldebug` GPU builds (`--gpu acc`/`--gpu mp`) fail to compile with:

```
NVFORTRAN-S-1061-Procedures called in a compute region must have acc routine
information - s_mpi_abort
  (m_variables_conversion.fpp: 1335)
```

## Root cause

`s_compute_fast_magnetosonic_speed` is a GPU device routine (`$:GPU_ROUTINE(... parallelism='[seq]')`), but its `#ifdef MFC_DEBUG` diagnostic block calls the **host** routine `s_mpi_abort`. That call is only legal in Release because IPO/`-Minline` inlines it away — and `--debug`/`--reldebug` disable IPO. With IPO off, the device routine is left calling a host MPI routine, which is illegal in device code.

This is why the failure is debug-only: in Release the entire `#ifdef MFC_DEBUG` block is compiled out.

## Fix

Guard the host `s_mpi_abort` call with `#ifndef MFC_GPU`, keeping the device-legal diagnostic `print`:

```fortran
#ifdef MFC_DEBUG
        if (disc < 0._wp) then
            print *, 'rho, c, Bx, By, Bz, h, term, disc:', ...
#ifndef MFC_GPU
            call s_mpi_abort('Error: negative discriminant in s_compute_fast_magnetosonic_speed')
#endif
        end if
#endif
```

A full-tree scan confirms this is the only device-region `s_mpi_abort` site for NVHPC/Cray (the 6 NaN-check aborts in `m_mpi_common.fpp` are inside `#if defined(__INTEL_COMPILER)` and so are not compiled for these backends). CPU and Release builds are byte-for-byte unchanged: off-GPU the guarded call is identical, and in Release the block is compiled out.

## Verification

Built on NVHPC 24.5 (Quadro RTX 6000, `MFC_CUDA_CC=75`):

| Build | Result |
|---|---|
| `simulation --gpu acc --debug` | compiles, 0× `NVFORTRAN-S-1061` |
| `simulation --gpu acc --reldebug` | compiles, 0× `NVFORTRAN-S-1061` |
| `./mfc.sh precheck` | all 7 checks pass |
| `./mfc.sh format` | clean |

Verified on NVHPC only (the GPU compiler available on the test node); the fix is gated on `MFC_GPU` and is therefore compiler-agnostic (Cray/AMD untested here).
