### PR TITLE
Do not check for riemann_solver when running IGR

### DIFF
--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -668,6 +668,10 @@ class CaseValidator:
         low_Mach = self.get("low_Mach", 0)
         cyl_coord = self.get("cyl_coord", "F") == "T"
         viscous = self.get("viscous", "F") == "T"
+        igr = self.get("igr", "F") == "T"
+
+        if igr:
+            return
 
         self.prohibit(riemann_solver is None, "riemann_solver must be specified (1=HLL, 2=HLLC, 4=HLLD, 5=Lax-Friedrichs)")
         if riemann_solver is None:


### PR DESCRIPTION
## Description

When running IGR, the riemann_solver parameter has no functional code purpose as IGR is self contained entirely inside m_igr.fpp. Currently running IGR without writing the riemann_solver parameter results in a case validation error. 

### Type of change

- [X] Bug fix

## AI code reviews

Reviews are not triggered automatically. To request a review, comment on the PR:
- `@coderabbitai review` — incremental review (new changes only)
- `@coderabbitai full review` — full review from scratch
- `/review` — Qodo review
- `/improve` — Qodo code suggestions
- `@claude full review` — Claude full review (also triggers on PR open/reopen/ready)
- Add label `claude-full-review` — Claude full review via label