### PR TITLE
fix: correct internal spelling typos

### DIFF
--- a/src/common/include/ExtrusionHardcodedIC.fpp
+++ b/src/common/include/ExtrusionHardcodedIC.fpp
@@ -192,7 +192,7 @@
     end select
 #:enddef
 
-#:def HardcodedDellacation()
+#:def HardcodedDeallocation()
     if (allocated(stored_values)) then
         @:DEALLOCATE(stored_values)
         @:DEALLOCATE(x_coords)

--- a/src/common/m_boundary_common.fpp
+++ b/src/common/m_boundary_common.fpp
@@ -260,7 +260,7 @@ contains
                             call s_symmetry(q_prim_vf, 3, 1, k, l, pb_in, mv_in, q_T_sf)
                         case (BC_PERIODIC)
                             call s_periodic(q_prim_vf, 3, 1, k, l, pb_in, mv_in, q_T_sf)
-                        case (BC_SlIP_WALL)
+                        case (BC_SLIP_WALL)
                             call s_slip_wall(q_prim_vf, 3, 1, k, l, q_T_sf)
                         case (BC_NO_SLIP_WALL)
                             call s_no_slip_wall(q_prim_vf, 3, 1, k, l, q_T_sf)

--- a/src/common/m_finite_differences.fpp
+++ b/src/common/m_finite_differences.fpp
@@ -39,7 +39,7 @@ contains
 
 #ifdef MFC_POST_PROCESS
         if (allocated(fd_coeff_s)) deallocate (fd_coeff_s)
-        allocate (fd_coeff_s(-fd_number_in:fd_number_in,lb:lE))
+        allocate (fd_coeff_s(-fd_number_in:fd_number_in,lB:lE))
 #endif
 
         ! Computing the 1st order finite-difference coefficients

--- a/src/pre_process/m_icpp_patches.fpp
+++ b/src/pre_process/m_icpp_patches.fpp
@@ -208,7 +208,7 @@ contains
                 if (1._wp - eta < sgm_eps) patch_id_fp(i, 0, 0) = patch_id
             end if
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_line_segment
 
@@ -272,7 +272,7 @@ contains
                 end if
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_spiral
 
@@ -328,7 +328,7 @@ contains
                 end if
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_circle
 
@@ -385,7 +385,7 @@ contains
                 end if
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_varcircle
 
@@ -448,7 +448,7 @@ contains
                 end do
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_3dvarcircle
 
@@ -505,7 +505,7 @@ contains
                 end if
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_ellipse
 
@@ -576,7 +576,7 @@ contains
                 end do
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_ellipsoid
 
@@ -646,7 +646,7 @@ contains
                 end if
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_rectangle
 
@@ -705,7 +705,7 @@ contains
                 end if
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_sweep_line
 
@@ -774,7 +774,7 @@ contains
                 end if
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_2D_TaylorGreen_Vortex
 
@@ -828,7 +828,7 @@ contains
                 end if
             end if
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_1D_bubble_pulse
 
@@ -1016,7 +1016,7 @@ contains
                 end do
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_sphere
 
@@ -1086,7 +1086,7 @@ contains
                 end do
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_cuboid
 
@@ -1180,7 +1180,7 @@ contains
                 end do
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_cylinder
 
@@ -1251,7 +1251,7 @@ contains
                 end do
             end do
         end do
-        @:HardcodedDellacation()
+        @:HardcodedDeallocation()
 
     end subroutine s_icpp_sweep_plane
 

--- a/src/simulation/m_collisions.fpp
+++ b/src/simulation/m_collisions.fpp
@@ -81,7 +81,7 @@ contains
         integer :: i, encoded_pid1, encoded_pid2, xp1, xp2, yp1, yp2, zp1, zp2, pid1, pid2, l  ! iterators and patch IDs
         real(wp) :: overlap_distance
         real(wp), dimension(3) :: normal_vector, centroid_1, centroid_2
-        real(wp), dimension(3) :: normal_velocity, tangental_vector, normal_force, tangental_force, torque, radial_vector, &
+        real(wp), dimension(3) :: normal_velocity, tangential_vector, normal_force, tangential_force, torque, radial_vector, &
              & rotation_velocity, vel1, vel2
         real(wp) :: k, eta, effective_mass  ! the spring stiffness and damping coefficient and mass of a specific interaction
 
@@ -92,7 +92,7 @@ contains
         ! Iterate over all collisions detected
         $:GPU_PARALLEL_LOOP(private='[i, l, encoded_pid1, encoded_pid2, xp1, xp2, yp1, yp2, zp1, zp2, pid1, pid2, centroid_1, &
                             & centroid_2, normal_vector, overlap_distance, effective_mass, k, eta, normal_velocity, &
-                            & tangental_vector, normal_force, tangental_force, torque, radial_vector, rotation_velocity, vel1, &
+                            & tangential_vector, normal_force, tangential_force, torque, radial_vector, rotation_velocity, vel1, &
                             & vel2]', copy='[forces, torques]')
         do i = 1, num_considered_collisions
             encoded_pid1 = collision_lookup(i, 3)
@@ -132,25 +132,25 @@ contains
                     vel2 = patch_ib(pid2)%vel + rotation_velocity
 
                     normal_velocity = dot_product(vel1 - vel2, normal_vector)*normal_vector
-                    tangental_vector = (vel1 - vel2) - normal_velocity
-                    if (.not. f_approx_equal(norm2(tangental_vector), &
-                        & 0._wp)) tangental_vector = tangental_vector/norm2(tangental_vector)
+                    tangential_vector = (vel1 - vel2) - normal_velocity
+                    if (.not. f_approx_equal(norm2(tangential_vector), &
+                        & 0._wp)) tangential_vector = tangential_vector/norm2(tangential_vector)
 
                     ! compute force and torque
                     normal_force = -k*overlap_distance*normal_vector - eta*normal_velocity
-                    tangental_force = -ib_coefficient_of_friction*norm2(normal_force)*tangental_vector
-                    call s_cross_product(normal_vector*patch_ib(pid1)%radius, tangental_force, torque)
+                    tangential_force = -ib_coefficient_of_friction*norm2(normal_force)*tangential_vector
+                    call s_cross_product(normal_vector*patch_ib(pid1)%radius, tangential_force, torque)
 
                     do l = 1, num_dims
                         ! update the first IB
                         $:GPU_ATOMIC(atomic='update')
-                        forces(pid1, l) = forces(pid1, l) + (normal_force(l) + tangental_force(l))
+                        forces(pid1, l) = forces(pid1, l) + (normal_force(l) + tangential_force(l))
                         $:GPU_ATOMIC(atomic='update')
                         torques(pid1, l) = torques(pid1, l) + torque(l)
 
                         ! apply equal and opposite force/torque to second IB
                         $:GPU_ATOMIC(atomic='update')
-                        forces(pid2, l) = forces(pid2, l) - (normal_force(l) + tangental_force(l))
+                        forces(pid2, l) = forces(pid2, l) - (normal_force(l) + tangential_force(l))
                         $:GPU_ATOMIC(atomic='update')
                         torques(pid2, l) = torques(pid2, l) + torque(l)*patch_ib(pid2)%radius/patch_ib(pid1)%radius
                     end do
@@ -166,12 +166,12 @@ contains
 
         real(wp), dimension(num_ibs, 3), intent(inout) :: forces, torques
         integer :: patch_id, i, l
-        real(wp), dimension(3) :: normal_force, tangental_force, normal_vector, normal_velocity, tangental_vector, &
+        real(wp), dimension(3) :: normal_force, tangential_force, normal_vector, normal_velocity, tangential_vector, &
              & collision_location, torque, radial_vector, rotation_velocity, velocity
         real(wp) :: k, eta  ! the spring stiffness and damping coefficient for a specific IB
 
         $:GPU_PARALLEL_LOOP(private='[patch_id, i, l, collision_location, normal_vector, k, eta, normal_velocity, &
-                            & tangental_vector, normal_force, tangental_force, torque, radial_vector, rotation_velocity, &
+                            & tangential_vector, normal_force, tangential_force, torque, radial_vector, rotation_velocity, &
                             & velocity]', copy='[forces, torques]', collapse=2)
         do patch_id = 1, num_ibs
             do i = 1, num_dims*2
@@ -208,16 +208,16 @@ contains
 
                     ! standard soft-sphere collision  with the wall
                     normal_velocity = dot_product(velocity, normal_vector)*normal_vector
-                    tangental_vector = velocity - normal_velocity
-                    if (.not. f_approx_equal(norm2(tangental_vector), &
-                        & 0._wp)) tangental_vector = tangental_vector/norm2(tangental_vector)
+                    tangential_vector = velocity - normal_velocity
+                    if (.not. f_approx_equal(norm2(tangential_vector), &
+                        & 0._wp)) tangential_vector = tangential_vector/norm2(tangential_vector)
                     normal_force = -k*wall_overlap_distances(patch_id, i)*normal_vector - eta*normal_velocity
-                    tangental_force = -ib_coefficient_of_friction*norm2(normal_force)*tangental_vector
-                    call s_cross_product(normal_vector*patch_ib(patch_id)%radius, tangental_force, torque)
+                    tangential_force = -ib_coefficient_of_friction*norm2(normal_force)*tangential_vector
+                    call s_cross_product(normal_vector*patch_ib(patch_id)%radius, tangential_force, torque)
 
                     do l = 1, num_dims
                         $:GPU_ATOMIC(atomic='update')
-                        forces(patch_id, l) = forces(patch_id, l) + (normal_force(l) + tangental_force(l))
+                        forces(patch_id, l) = forces(patch_id, l) + (normal_force(l) + tangential_force(l))
                         $:GPU_ATOMIC(atomic='update')
                         torques(patch_id, l) = torques(patch_id, l) + torque(l)
                     end do

--- a/toolchain/mfc/test/case.py
+++ b/toolchain/mfc/test/case.py
@@ -479,9 +479,9 @@ def create_input_lagrange(path_test):
 
 def copy_input_lagrange(path_example_input, path_test):
     folder_path_dest = path_test + "/input/"
-    fite_path_dest = folder_path_dest + "lag_bubbles.dat"
+    file_path_dest = folder_path_dest + "lag_bubbles.dat"
     file_path_src = common.MFC_EXAMPLE_DIRPATH + path_example_input + "/input/lag_bubbles.dat"
     if not os.path.exists(folder_path_dest):
         os.mkdir(folder_path_dest)
 
-    shutil.copyfile(file_path_src, fite_path_dest)
+    shutil.copyfile(file_path_src, file_path_dest)


### PR DESCRIPTION
## Description

Fixes the internal spelling typos listed in MFlowCode/MFC#1498:

- `HardcodedDellacation` -> `HardcodedDeallocation`
- `BC_SlIP_WALL` -> `BC_SLIP_WALL`
- `tangental_*` -> `tangential_*`
- `fite_path_dest` -> `file_path_dest`
- `lb:lE` -> `lB:lE`

These are naming/readability fixes only; the existing behavior is preserved.

## Related Issues

Fixes #1498

## Verification

- `rg "HardcodedDellacation|BC_SlIP_WALL|tangental|fite_path_dest|\blb:lE\b" -n src toolchain` returns no matches
- `python -m py_compile toolchain\mfc\test\case.py`
- `git diff --check`