### PR TITLE
ci: retry NVHPC image pull on transient nvcr.io timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,9 +156,19 @@ jobs:
       # Replaces the container: directive so we can free disk space first.
       # Uses "docker run -d ... sleep infinity" + "docker exec" to preserve
       # installed packages and env vars across steps.
+      # Retry the pull: nvcr.io intermittently times out ("context deadline
+      # exceeded") under load, and ~30 matrix jobs hit it at once. Pulls
+      # resume completed layers, so retries are cheap.
       - name: Pull NVHPC container
         if:   matrix.nvhpc
-        run:  docker pull "$NVHPC_IMAGE"
+        run: |
+          for attempt in 1 2 3 4 5; do
+            docker pull "$NVHPC_IMAGE" && exit 0
+            echo "docker pull failed (attempt $attempt/5); retrying in $((attempt * 30))s..."
+            sleep $((attempt * 30))
+          done
+          echo "::error::Failed to pull $NVHPC_IMAGE after 5 attempts"
+          exit 1
 
       - name: Start NVHPC container
         if:   matrix.nvhpc


### PR DESCRIPTION
## Problem

NVHPC matrix jobs sporadically fail at the **Pull NVHPC container** step with:

```
Error response from daemon: Get "https://nvcr.io/v2/": context deadline exceeded
```

Example: [NVHPC 25.7 (cpu) in run 27312594672](https://github.com/MFlowCode/MFC/actions/runs/27312594672/job/80691100992), where 1 of 30 NVHPC jobs hit the timeout while the other 29 pulled the same registry fine — a transient nvcr.io flake, likely aggravated by ~30 concurrent pulls per run.

## Fix

Retry `docker pull` up to 5 times with linear backoff (30s, 60s, ...). Docker resumes already-downloaded layers, so retries are cheap. Worst case adds ~5 min before failing with an explicit error annotation.