### PR TITLE
fix: correct axis normalization in s_compute_moment_of_inertia

### DIFF
--- a/src/simulation/m_ibm.fpp
+++ b/src/simulation/m_ibm.fpp
@@ -1143,7 +1143,7 @@ contains
             patch_ib(ib_idx)%moment = 1._wp
             return
         else
-            normal_axis = axis/sqrt(sum(axis))
+            normal_axis = axis/sqrt(sum(axis**2))
         end if
 
         ! if the IB is in 2D or a 3D sphere, we can compute this exactly


### PR DESCRIPTION
## Description

Use sqrt(sum(axis**2)) instead of sqrt(sum(axis)) to compute the unit vector along the rotation axis. The incorrect norm produced a non-unit normal_axis, making the orthogonal projection and computed moment of inertia wrong for 3D moving IBs with non-analytic geometry.

Closes #1481

### Type of change (delete unused ones)

- Bug fix

## Testing

Ran ./mfc.sh test -j 4 locally on Ubuntu/WSL with GNU compiler and MPI. 578 tests passed, 0 failed.

## Checklist

__Check these like this `[x]` to indicate which of the below applies.__

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed

See the [developer guide](https://mflowcode.github.io/documentation/contributing.html) for full coding standards.

<details>
<summary><strong>GPU changes</strong> (expand if you modified <code>src/simulation/</code>)</summary>

- [ ] GPU results match CPU results
- [ ] Tested on NVIDIA GPU or AMD GPU

One line arithmetic fix. Runtime behavior unchanged for all unaffected paths. GPU correctness covered by CI.

</details>

## AI code reviews

Reviews are not retriggered automatically. To request a review, comment on the PR:
- `@claude full review` — Claude full review (also triggers on PR open/reopen/ready)
- Or add label `claude-full-review` — Claude full review via label
