### PR TITLE
ci: enable --stepmgr for Frontier jobs to relieve slurmctld pressure

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -52,7 +52,10 @@ case "$cluster" in
         account="CFD154"
         job_prefix="MFC"
         qos="hackathon"
-        extra_sbatch=""
+        # Let each job's slurmstepd broker its own steps instead of routing
+        # every srun through slurmctld. The in-job test suite launches ~1700+
+        # srun steps per allocation, which congests the Frontier controller.
+        extra_sbatch="#SBATCH --stepmgr"
         test_time="01:59:00"
         bench_time="01:59:00"
         gpu_partition_dynamic=false
@@ -62,7 +65,7 @@ case "$cluster" in
         account="CFD154"
         job_prefix="MFC"
         qos="hackathon"
-        extra_sbatch=""
+        extra_sbatch="#SBATCH --stepmgr"
         test_time="01:59:00"
         bench_time="01:59:00"
         gpu_partition_dynamic=false


### PR DESCRIPTION
## What

Add `#SBATCH --stepmgr` to Frontier and Frontier-AMD CI job submissions, via the existing `extra_sbatch` hook in `.github/scripts/submit-slurm-job.sh`. Phoenix is unaffected.

## Why

Each Frontier CI test/bench job is a **single-node** (`-N 1`) allocation that runs the full regression suite *inside* the allocation via `./mfc.sh test -a -j 32`. Each of the ~560 test cases launches a separate `srun` per target (pre_process / simulation / post_process), with restart-roundtrip cases adding more — on the order of **1,700+ `srun` step-creates per job, up to 32 concurrent**, all brokered by `slurmctld`. Across the test + bench + AMD matrix this reaches ~3,000 step-creates and congests the Frontier Slurm controller.

OLCF flagged this and temporarily limited the maintainer account to one running job. `--stepmgr` is the mechanism OLCF recommended: it delegates step management to each job's own `slurmstepd` instead of routing every `srun` through the central controller, which is the appropriate model for many-step single-allocation workloads.

## Scope

- One file changed; behavior identical except for the added SBATCH directive on Frontier.
- No change to the number of `srun` calls or to test logic — this only changes *who brokers the steps*.

## Validation

- [x] Confirm `enable_stepmgr` is active on the Frontier controller (coordinating with OLCF).
- [ ] Run the Frontier test + bench jobs on this branch and confirm reduced controller load.

If `--stepmgr` proves insufficient, follow-ups in reserve: lower in-job concurrency (`-j`), or coalesce the three executables into a single `srun` per case.