### PR TITLE
Feature/only case insensitive

### DIFF
--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -66,7 +66,6 @@ def _filter_only(cases, skipped_cases):
         check = set(case.trace.split(" -> "))
         check.add(case.get_uuid())
 
-        #label_ok = all(label in check for label in labels) if labels else True
         label_ok = all(label.lower() in {c.lower() for c in check} for label in labels) if labels else True
         uuid_ok = any(u in check for u in uuids) if uuids else True
 

--- a/toolchain/mfc/test/test.py
+++ b/toolchain/mfc/test/test.py
@@ -66,7 +66,8 @@ def _filter_only(cases, skipped_cases):
         check = set(case.trace.split(" -> "))
         check.add(case.get_uuid())
 
-        label_ok = all(label in check for label in labels) if labels else True
+        #label_ok = all(label in check for label in labels) if labels else True
+        label_ok = all(label.lower() in {c.lower() for c in check} for label in labels) if labels else True
         uuid_ok = any(u in check for u in uuids) if uuids else True
 
         if labels and uuids:


### PR DESCRIPTION
## Description
The `--only` flag in `./mfc.sh test --only <label>` performed a case-sensitive 
string comparison against test labels. Since MFC's test labels follow no 
consistent capitalization convention (e.g. `STL`, `slip`, `Sphere`), users had 
to remember the exact casing of every label to filter tests correctly. This PR 
normalizes the label comparison to lowercase so any casing works.

Closes #1533.

### Type of change (delete unused ones)
- Bug fix

## Testing
Manually verified the fix by running the following before and after the change:
- `./mfc.sh test --only stl -j 1` → previously failed with "matched zero test 
  cases", now passes
- `./mfc.sh test --only STL -j 1` → passes (unchanged)
- `./mfc.sh test --only Stl -j 1` → previously failed, now passes
- `ruff check toolchain/mfc/test/test.py` → all style checks passed

## Checklist
- [ ] I added or updated tests for new behavior
- [x] I updated documentation if user-facing behavior changed