### PR TITLE
Fix incorrect and misleading comments across src/

### DIFF
--- a/src/common/m_derived_types.fpp
+++ b/src/common/m_derived_types.fpp
@@ -303,8 +303,8 @@ module m_derived_types
         real(wp), dimension(6) :: tau_e  !< Elastic stresses added to primitive variables if hypoelasticity = True
         real(wp) :: R0  !< Bubble size
         real(wp) :: V0  !< Bubble velocity
-        real(wp) :: p0  !< Bubble size
-        real(wp) :: m0  !< Bubble velocity
+        real(wp) :: p0  !< Bubble pressure
+        real(wp) :: m0  !< Bubble mass
         integer :: hcid  !< Hardcoded initial condition ID
         real(wp) :: cf_val  !< Color function value
         real(wp) :: Y(1:num_species)  !< Species mass fractions

--- a/src/common/m_helper.fpp
+++ b/src/common/m_helper.fpp
@@ -521,7 +521,7 @@ contains
     elemental function double_factorial(n_in) result(R_result)
 
         integer, intent(in)      :: n_in
-        integer, parameter       :: int64_kind = selected_int_kind(18)  !< 18 bytes for 64-bit integer
+        integer, parameter       :: int64_kind = selected_int_kind(18)  !< kind holding >= 18 decimal digits (64-bit integer)
         integer(kind=int64_kind) :: R_result
         integer                  :: i
 
@@ -533,7 +533,7 @@ contains
     elemental function factorial(n_in) result(R_result)
 
         integer, intent(in)      :: n_in
-        integer, parameter       :: int64_kind = selected_int_kind(18)  !< 18 bytes for 64-bit integer
+        integer, parameter       :: int64_kind = selected_int_kind(18)  !< kind holding >= 18 decimal digits (64-bit integer)
         integer(kind=int64_kind) :: R_result
         integer                  :: i
 

--- a/src/common/m_mpi_common.fpp
+++ b/src/common/m_mpi_common.fpp
@@ -39,7 +39,7 @@ contains
     impure subroutine s_initialize_mpi_common_module
 
 #ifdef MFC_MPI
-        ! Allocating buff_send/recv and. Please note that for the sake of simplicity, both variables are provided sufficient storage
+        ! Allocating buff_send/recv. Please note that for the sake of simplicity, both variables are provided sufficient storage
         ! to hold the largest buffer in the computational domain.
 
         if (qbmm .and. .not. polytropic) then
@@ -426,7 +426,6 @@ contains
     end subroutine s_mpi_reduce_min
 
     !> Reduce a 2-element variable to its global maximum value with the owning processor rank (MPI_MAXLOC).
-    !> Reduce a local value to its global maximum with location (rank) across all ranks
     impure subroutine s_mpi_reduce_maxloc(var_loc)
 
         real(wp), dimension(2), intent(inout) :: var_loc

--- a/src/common/m_precision_select.f90
+++ b/src/common/m_precision_select.f90
@@ -13,7 +13,7 @@ module m_precision_select
     implicit none
 
     ! Define the available precision types
-    integer, parameter :: half_precision = 2  !< selected_real_kind(3, 4)
+    integer, parameter :: half_precision = 2  !< hardcoded half-precision kind (approx. selected_real_kind(3, 4))
     integer, parameter :: single_precision = selected_real_kind(6, 37)
     integer, parameter :: double_precision = selected_real_kind(15, 307)
     integer, parameter :: hp = half_precision

--- a/src/simulation/m_collisions.fpp
+++ b/src/simulation/m_collisions.fpp
@@ -4,8 +4,8 @@
 
 #:include 'macros.fpp'
 
-!> @brief Ghost-node immersed boundary method: locates ghost/image points, computes interpolation coefficients, and corrects the
-!! flow state
+!> @brief Immersed-boundary collision handling: detects IB-IB and IB-wall contacts and applies soft-sphere collision forces and
+!! torques
 module m_collisions
 
     use m_derived_types      !< Definitions of the derived types

--- a/src/simulation/m_data_output.fpp
+++ b/src/simulation/m_data_output.fpp
@@ -45,7 +45,7 @@ module m_data_output
     !> @{
     real(wp) :: icfl_max  !< ICFL criterion maximum
     real(wp) :: vcfl_max  !< VCFL criterion maximum
-    real(wp) :: Rc_min    !< Rc criterion maximum
+    real(wp) :: Rc_min    !< Rc criterion minimum
     !> @}
 
     type(scalar_field), allocatable, dimension(:) :: q_cons_temp_ds

--- a/src/simulation/m_riemann_solver_hllc.fpp
+++ b/src/simulation/m_riemann_solver_hllc.fpp
@@ -136,7 +136,7 @@ contains
             #:set SV = STENCIL_VAR
             #:set SF = lambda offs: COORDS.format(STENCIL_IDX = SV + offs)
             if (norm_dir == ${NORM_DIR}$) then
-                ! 6-EQUATION MODEL WITH HLLC HLLC star-state flux with contact wave speed s_S
+                ! 6-EQUATION MODEL WITH HLLC star-state flux with contact wave speed s_S
                 if (model_eqns == model_eqns_6eq) then
                     ! 6-equation model (model_eqns=3): separate phasic internal energies
                     $:GPU_PARALLEL_LOOP(collapse=3, private='[i, j, k, l, q, vel_L, vel_R, Re_L, Re_R, alpha_L, alpha_R, Ys_L, &


### PR DESCRIPTION
## Description

Fixes seven incorrect or misleading comments across `src/`, as listed in #1497. All changes are comment-only — no executable code, logic, or formatting was touched.

1. `m_helper.fpp` (double_factorial, factorial): `selected_int_kind(18)` requests 18 decimal digits, not 18 bytes — corrected both.
2. `m_collisions.fpp`: module `@brief` was copy-pasted from an IBM module; rewrote it to describe the module's actual collision-force handling.
3. `m_data_output.fpp`: `Rc_min` tracks a minimum (`minval`, `Rc_min_glb < Rc_min`), so "maximum" → "minimum".
4. `m_derived_types.fpp`: `p0`/`m0` are bubble pressure/mass; comments said size/velocity (copied from `R0`/`V0`).
5. `m_riemann_solver_hllc.fpp`: removed a duplicate "HLLC".
6. `m_precision_select.f90`: clarified `half_precision` is a hardcoded kind (its siblings are computed via `selected_real_kind`).
7. `m_mpi_common.fpp`: fixed a dangling "and."; removed a duplicate `s_mpi_reduce_maxloc` summary line.

Note: the issue cited `m_riemann_solvers.fpp:1779` for item 5, but that module was split into per-scheme files after the issue was filed, so the fix lands in `m_riemann_solver_hllc.fpp`. A few other line numbers had also drifted and were re-verified against current `master`.

Closes #1497.

### Type of change (delete unused ones)

- Documentation

## Testing

Comment-only change with no runtime behavior, so there's nothing to unit-test. Validated that the diff is comment-only and the project's checks pass: `./mfc.sh format` (no reformatting), `./mfc.sh lint` (ruff + 349 toolchain tests passed), and the pre-commit precheck (same as the CI lint-gate) passed all seven gates (formatting, spell check, toolchain lint, source lint, doc references, parameter docs, example cases).

## Checklist

- [ ] I added or updated tests for new behavior  *(N/A — comment-only, no behavior change)*
- [x] I updated documentation if user-facing behavior changed  *(these fixes are the documentation)*