### PR TITLE
homebrew: fix brew style failure, sync formula to v5.5.0, preserve tap bottles

### DIFF
--- a/.github/workflows/deploy-tap.yml
+++ b/.github/workflows/deploy-tap.yml
@@ -13,8 +13,7 @@ on:
     paths:
       - 'packaging/homebrew/mfc.rb'
       - 'packaging/homebrew/README.md'
-  # Deploy to tap when a tag is created (no paths filter on tag creation)
-  create:
+  # Note: tag releases are deployed to the tap by homebrew-release.yml, not here.
   workflow_dispatch:
 
 permissions:
@@ -24,7 +23,6 @@ jobs:
   deploy-tap:
     name: Audit and deploy formula
     runs-on: macos-14
-    if: github.event_name != 'create' || github.event.ref_type == 'tag'
     permissions:
       contents: write
       pull-requests: write
@@ -44,12 +42,8 @@ jobs:
           EVENT_NAME="${{ github.event_name }}"
           REF_NAME="${{ github.ref_name }}"
           
-          if [[ "${EVENT_NAME}" == "create" ]]; then
-            # Tag creation event
-            VERSION="${REF_NAME#v}"
-            URL="https://github.com/${{ github.repository }}/archive/refs/tags/v${VERSION}.tar.gz"
-          elif [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
-            # Tag push event
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            # Manual dispatch from a tag ref
             VERSION="${REF_NAME#v}"
             URL="https://github.com/${{ github.repository }}/archive/refs/tags/v${VERSION}.tar.gz"
           else
@@ -71,7 +65,7 @@ jobs:
           fi
 
       - name: Update formula (for tag events)
-        if: github.event_name == 'create' || github.ref_type == 'tag'
+        if: github.ref_type == 'tag'
         run: |
           /usr/bin/sed -i '' "s@^  url \".*\"@  url \"${{ steps.meta.outputs.url }}\"@" packaging/homebrew/mfc.rb
           /usr/bin/sed -i '' "s@^  sha256 \".*\"@  sha256 \"${{ steps.meta.outputs.sha256 }}\"@" packaging/homebrew/mfc.rb
@@ -110,22 +104,41 @@ jobs:
           fi
 
       - name: Copy formula and README into tap
+        id: merge
         if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           mkdir -p tap-repo/Formula
-          # If the release URL is unchanged, keep the tap's existing bottle block so a
-          # formula-only push to master doesn't delete bottles already built for this version.
-          NEW_URL="$(grep -E '^  url ' packaging/homebrew/mfc.rb || true)"
-          OLD_URL="$(grep -E '^  url ' tap-repo/Formula/mfc.rb 2>/dev/null || true)"
-          if [[ -n "${NEW_URL}" && "${NEW_URL}" == "${OLD_URL}" ]] && grep -q '^  bottle do' tap-repo/Formula/mfc.rb; then
-            awk '/^  bottle do/,/^  end$/' tap-repo/Formula/mfc.rb > /tmp/bottle.block
-            awk '{ print } /^  head / { print ""; while ((getline line < "/tmp/bottle.block") > 0) print line }' \
-              packaging/homebrew/mfc.rb > tap-repo/Formula/mfc.rb
-          else
-            cp packaging/homebrew/mfc.rb tap-repo/Formula/mfc.rb
+          SRC=packaging/homebrew/mfc.rb
+          TAP=tap-repo/Formula/mfc.rb
+          get_ver() { grep -Eo '/archive/refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' "$1" | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'; }
+          MERGED="$(mktemp)"
+          cp "${SRC}" "${MERGED}"
+          if [[ -f "${TAP}" ]]; then
+            SRC_VER="$(get_ver "${SRC}" || true)"
+            TAP_VER="$(get_ver "${TAP}" || true)"
+            # homebrew-release.yml bumps the tap directly on releases, so the in-repo
+            # formula can lag behind. Never downgrade: if the tap pins a newer release,
+            # keep the tap's url/sha256 while still syncing the rest of the formula.
+            if [[ -n "${SRC_VER}" && -n "${TAP_VER}" && "${SRC_VER}" != "${TAP_VER}" ]] \
+               && [[ "$(printf '%s\n%s\n' "${SRC_VER}" "${TAP_VER}" | sort -V | tail -n 1)" == "${TAP_VER}" ]]; then
+              TAP_URL_LINE="$(grep -E '^  url ' "${TAP}")"
+              TAP_SHA_LINE="$(grep -E '^  sha256 "' "${TAP}" | head -n 1)"
+              awk -v url="${TAP_URL_LINE}" -v sha="${TAP_SHA_LINE}" \
+                '/^  url / { print url; next } /^  sha256 "/ { print sha; next } { print }' \
+                "${SRC}" > "${MERGED}"
+            fi
+            # If the pinned release is unchanged, keep the tap's existing bottle block so a
+            # formula-only push to master doesn't delete bottles already built for this version.
+            if [[ "$(grep -E '^  url ' "${MERGED}")" == "$(grep -E '^  url ' "${TAP}")" ]] && grep -q '^  bottle do' "${TAP}"; then
+              awk '/^  bottle do/,/^  end$/' "${TAP}" > /tmp/bottle.block
+              awk '{ print } /^  head / { print ""; while ((getline line < "/tmp/bottle.block") > 0) print line }' \
+                "${MERGED}" > "${MERGED}.tmp" && mv "${MERGED}.tmp" "${MERGED}"
+            fi
           fi
+          mv "${MERGED}" "${TAP}"
           cp packaging/homebrew/README.md tap-repo/README.md
+          echo "version=$(get_ver "${TAP}" || true)" >> "$GITHUB_OUTPUT"
 
       - name: Commit & push if changed
         if: github.event_name != 'pull_request'
@@ -139,6 +152,6 @@ jobs:
             exit 0
           fi
           git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" \
-            commit -m "mfc: v${{ steps.meta.outputs.version }}"
+            commit -m "mfc: v${{ steps.merge.outputs.version || steps.meta.outputs.version }}"
           git push origin HEAD:main
 

--- a/.github/workflows/deploy-tap.yml
+++ b/.github/workflows/deploy-tap.yml
@@ -112,8 +112,19 @@ jobs:
       - name: Copy formula and README into tap
         if: github.event_name != 'pull_request'
         run: |
+          set -euo pipefail
           mkdir -p tap-repo/Formula
-          cp packaging/homebrew/mfc.rb tap-repo/Formula/mfc.rb
+          # If the release URL is unchanged, keep the tap's existing bottle block so a
+          # formula-only push to master doesn't delete bottles already built for this version.
+          NEW_URL="$(grep -E '^  url ' packaging/homebrew/mfc.rb || true)"
+          OLD_URL="$(grep -E '^  url ' tap-repo/Formula/mfc.rb 2>/dev/null || true)"
+          if [[ -n "${NEW_URL}" && "${NEW_URL}" == "${OLD_URL}" ]] && grep -q '^  bottle do' tap-repo/Formula/mfc.rb; then
+            awk '/^  bottle do/,/^  end$/' tap-repo/Formula/mfc.rb > /tmp/bottle.block
+            awk '{ print } /^  head / { print ""; while ((getline line < "/tmp/bottle.block") > 0) print line }' \
+              packaging/homebrew/mfc.rb > tap-repo/Formula/mfc.rb
+          else
+            cp packaging/homebrew/mfc.rb tap-repo/Formula/mfc.rb
+          fi
           cp packaging/homebrew/README.md tap-repo/README.md
 
       - name: Commit & push if changed

--- a/packaging/homebrew/mfc.rb
+++ b/packaging/homebrew/mfc.rb
@@ -6,8 +6,8 @@
 class Mfc < Formula
   desc "Exascale multiphase/multiphysics compressible flow solver"
   homepage "https://mflowcode.github.io/"
-  url "https://github.com/MFlowCode/MFC/archive/refs/tags/v5.2.0.tar.gz"
-  sha256 "aaee855302950cb6bd8497170a6737214ed9a47ad3d109258f5b27ee2b78fe3d"
+  url "https://github.com/MFlowCode/MFC/archive/refs/tags/v5.5.0.tar.gz"
+  sha256 "05499f28291654ee5cc7f4344c85b5b12707e43e8408e7a28b96e43020e42959"
   license "MIT"
   head "https://github.com/MFlowCode/MFC.git", branch: "master"
 
@@ -28,7 +28,7 @@ class Mfc < Formula
   def install
     # Create Python virtual environment inside libexec (inside Cellar for proper bottling)
     venv = libexec/"venv"
-    system Formula["python@3.12"].opt_bin/"python3.12", "-m", "venv", venv
+    system formula_opt_bin("python@3.12")/"python3.12", "-m", "venv", venv
     system venv/"bin/pip", "install", "--upgrade",
            "pip", "setuptools", "wheel",
            "setuptools-scm",


### PR DESCRIPTION
## Description

The v5.5.0 release runs of **Deploy Homebrew Tap** and **Homebrew Formula Test** both failed on the same `brew style` offense: Homebrew added a new RuboCop cop, `Homebrew/FormulaPathMethods` ([Homebrew/brew, 2026-06-22](https://github.com/Homebrew/brew/commits/main/Library/Homebrew/rubocops/formula_path_methods.rb)), and both workflows install latest brew via `setup-homebrew@master`. The formula itself hadn't changed since February. Note the release still shipped: `homebrew-release.yml` succeeded and the tap already serves v5.5.0 with bottles.

### Commit 1 — formula fixes
1. **The lint offense** — `Formula["python@3.12"].opt_bin` → `formula_opt_bin("python@3.12")` in `packaging/homebrew/mfc.rb`. The helper is defined in `Utils::Path` and included in `Formula`, so it is equivalent at install time.
2. **Stale in-repo formula version** — the repo copy still pointed at v5.2.0 while the tap is at v5.5.0. Bumped `url`/`sha256` to v5.5.0 (sha256 computed independently from the release tarball; matches the tap).

### Commit 2 — deploy-tap.yml hardening
3. **Never downgrade the tap** — push-to-master deploys copied the repo formula verbatim into the tap. Since `homebrew-release.yml` bumps the tap directly on releases, the repo copy lags behind, and a formula-only push would have downgraded the tap and deleted its bottles. The copy step now adopts the tap's `url`/`sha256` whenever the tap pins a newer release, and preserves the tap's `bottle do` block whenever the pinned release is unchanged. Genuine version bumps still drop the stale bottle block as before.
4. **Drop the redundant `create:` (tag) trigger** — `homebrew-release.yml` already owns tag releases, so both workflows raced to push the tap on every tag, and this one put a strict `brew audit` on the release critical path (exactly what turned red for v5.5.0). Tag handling is kept for manual `workflow_dispatch` from a tag ref.

### Type of change

- Bug fix

## Testing

- `brew style packaging/homebrew/mfc.rb` (Homebrew 6.0.6, includes the new cop): old formula reproduces the CI failure, fixed formula passes.
- Ran the copy-step script (extracted verbatim from the workflow YAML) locally against the real current tap formula in three scenarios:
  - repo == tap version → tap bottle block preserved;
  - repo v5.2.0 / tap v5.5.0 → tap's url+sha adopted, bottles preserved (no downgrade);
  - repo v5.6.0 / tap v5.5.0 → repo pin wins, stale bottle dropped.
  All merged outputs pass `brew style` and `ruby -c`.
- `deploy-tap.yml` parses as valid YAML; PR checks on this branch exercise both previously-failing workflows in audit mode.

## Checklist

- [x] I added or updated tests for new behavior (local `brew style`/merge-script scenario runs above; no test-suite surface for packaging CI)
- [ ] I updated documentation if user-facing behavior changed (n/a)

## AI code reviews

Reviews are not retriggered automatically. To request a review, comment on the PR:
- `@claude full review` — Claude full review (also triggers on PR open/reopen/ready)
- Or add label `claude-full-review` — Claude full review via label