### PR TITLE
Add AMD HPCFund (amdfund) amdflang OpenMP-offload build/run support

### DIFF
--- a/cmake/MFCTargets.cmake
+++ b/cmake/MFCTargets.cmake
@@ -106,6 +106,10 @@ exit 0
                 set(_flang_mpi_lib "$ENV{CRAY_MPICH_LIB}")
             endif()
             if(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang" AND NOT "${_flang_mpi_inc}" STREQUAL "")
+                if("${_flang_mpi_lib}" STREQUAL "")
+                    message(FATAL_ERROR "amdflang MPI include path is set but its link libraries are not. "
+                        "Set both MFC_FLANG_MPI_INC and MFC_FLANG_MPI_LIB (or both CRAY_MPICH_INC and CRAY_MPICH_LIB).")
+                endif()
                 target_compile_options(${a_target} PRIVATE "${_flang_mpi_inc}")
                 target_link_libraries(${a_target} PRIVATE ${_flang_mpi_lib})
             else()

--- a/cmake/MFCTargets.cmake
+++ b/cmake/MFCTargets.cmake
@@ -96,10 +96,18 @@ exit 0
             find_package(MPI COMPONENTS Fortran REQUIRED)
 
             target_compile_definitions(${a_target} PRIVATE MFC_MPI)
-            if(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang" AND
-               DEFINED ENV{CRAY_MPICH_INC} AND NOT "$ENV{CRAY_MPICH_INC}" STREQUAL "")
-                target_compile_options(${a_target} PRIVATE "$ENV{CRAY_MPICH_INC}")
-                target_link_libraries(${a_target} PRIVATE $ENV{CRAY_MPICH_LIB})
+            # amdflang (LLVMFlang) needs MPI include/link paths passed explicitly, as
+            # its mpi.mod must match the compiler ABI. Prefer the compiler-neutral
+            # MFC_FLANG_MPI_* vars; fall back to the legacy CRAY_MPICH_* names (Frontier).
+            set(_flang_mpi_inc "$ENV{MFC_FLANG_MPI_INC}")
+            set(_flang_mpi_lib "$ENV{MFC_FLANG_MPI_LIB}")
+            if("${_flang_mpi_inc}" STREQUAL "")
+                set(_flang_mpi_inc "$ENV{CRAY_MPICH_INC}")
+                set(_flang_mpi_lib "$ENV{CRAY_MPICH_LIB}")
+            endif()
+            if(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang" AND NOT "${_flang_mpi_inc}" STREQUAL "")
+                target_compile_options(${a_target} PRIVATE "${_flang_mpi_inc}")
+                target_link_libraries(${a_target} PRIVATE ${_flang_mpi_lib})
             else()
                 target_link_libraries(${a_target} PRIVATE MPI::MPI_Fortran)
             endif()
@@ -121,8 +129,13 @@ exit 0
                     find_package(CUDAToolkit REQUIRED)
                     target_link_libraries(${a_target} PRIVATE CUDA::cudart CUDA::cufft)
                 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
-                    if(DEFINED ENV{CRAY_HIPFORT_LIB} AND NOT "$ENV{CRAY_HIPFORT_LIB}" STREQUAL "")
-                        target_link_libraries(${a_target} PRIVATE $ENV{CRAY_HIPFORT_LIB})
+                    # Prefer the neutral MFC_FLANG_HIPFORT_LIB; fall back to CRAY_HIPFORT_LIB (Frontier).
+                    set(_flang_hipfort_lib "$ENV{MFC_FLANG_HIPFORT_LIB}")
+                    if("${_flang_hipfort_lib}" STREQUAL "")
+                        set(_flang_hipfort_lib "$ENV{CRAY_HIPFORT_LIB}")
+                    endif()
+                    if(NOT "${_flang_hipfort_lib}" STREQUAL "")
+                        target_link_libraries(${a_target} PRIVATE ${_flang_hipfort_lib})
                     else()
                         find_library(HIPFFT_LIB hipfft
                             HINTS "$ENV{OLCF_AFAR_ROOT}/lib" REQUIRED)
@@ -244,11 +257,14 @@ exit 0
                 endif()
 
 		        find_library(HIP_LIB amdhip64
-                    HINTS "$ENV{OLCF_AFAR_ROOT}/lib" REQUIRED)
+                    HINTS "$ENV{OLCF_AFAR_ROOT}/lib" "$ENV{OLCF_AFAR_ROOT}/lib/llvm/lib" REQUIRED)
                 find_library(HIPFORT_AMDGCN_LIB hipfort-amdgcn
-                    HINTS "$ENV{OLCF_AFAR_ROOT}/lib" REQUIRED)
+                    HINTS "$ENV{OLCF_AFAR_ROOT}/lib" "$ENV{OLCF_AFAR_ROOT}/lib/llvm/lib" REQUIRED)
+                # The hipfort module dir moved to lib/llvm/include in newer AFAR
+                # (therock) drops; keep the classic path for Frontier's layout.
                 target_include_directories(${a_target} PRIVATE
-                    "$ENV{OLCF_AFAR_ROOT}/include/hipfort/amdgcn")
+                    "$ENV{OLCF_AFAR_ROOT}/include/hipfort/amdgcn"
+                    "$ENV{OLCF_AFAR_ROOT}/lib/llvm/include/hipfort/amdgcn")
                 target_link_libraries(${a_target} PRIVATE
                     ${HIP_LIB} ${HIPFORT_AMDGCN_LIB})
 

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -9,6 +9,7 @@ show_help() {
   echo "  -h, --help                  Display this help message and exit."
   echo "  -c, --computer COMPUTER     Configures for COMPUTER environment."
   echo "                 Options:     Ascent (a) | Frontier (f) | Frontier_amd (famd) | Summit (s) | Wombat (w)"
+  echo "                              AMD HPCFund (amdfund)"
   echo "                              Bridges2 (b) | Expanse (e) | Delta (d) | DeltaAI (dai)"
   echo "                              Phoenix (p) | Richardson (r) | Oscar (o)"
   echo "                              Carpenter Cray (cc) | Carpenter GNU (c) |  Nautilus (n)"
@@ -48,6 +49,7 @@ if [ -v $u_c ]; then
     log   "$B""DoD$W:     Carpenter Cray (cc) | Carpenter GNU (c) |  Nautilus (n)"
     log   "$OR""Florida$W: HiPerGator (h)"
     log   "$C""WPI $W:   Turing   (t)"
+    log   "$R""AMD$W:     HPCFund  (amdfund)"
     log_n "($G""a$W/$G""f$W/$G""s$W/$G""w$W/$B""tuo$W/$C""b$W/$C""e$CR/$C""d/$C""dai$CR/$Y""p$CR/$R""r$CR/$B""cc$CR/$B""c$CR/$B""n$CR/$BR""o$CR/$BR""pa"$CR"/$OR""h"$CR/$C""t""$CR"): "
     read u_c
     log
@@ -157,6 +159,28 @@ if [ "$u_c" '==' 'famd' ]; then
     export FC="${OLCF_AFAR_ROOT}/bin/amdflang"
 
     unset MPICH_GPU_SUPPORT_ENABLED
+fi
+
+# AMD HPCFund: AFAR LLVM Flang (amdflang) + system GNU-built OpenMPI, gfx90a.
+# The stock mpi.mod is GNU-built and binary-incompatible with amdflang, so we
+# point at a pre-generated flang-compatible one under $OLCF_AFAR_ROOT/include/mpi.
+if [ "$u_c" '==' 'amdfund' ]; then
+    # Direct WORK-filesystem path (mounted at the same /work1 point on login and
+    # compute nodes); override OLCF_AFAR_ROOT before loading to use another drop.
+    export OLCF_AFAR_ROOT="${OLCF_AFAR_ROOT:-/work1/spencerbryngelson/sbryngelson/software/therock-afar-23.2.1-gfx90a-7.13.0-7357b5084b}"
+    _mfc_mpi_lib="/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.8/lib"
+
+    export PATH="${OLCF_AFAR_ROOT}/lib/llvm/bin:${OLCF_AFAR_ROOT}/bin:${PATH}"
+    export LD_LIBRARY_PATH="${OLCF_AFAR_ROOT}/lib:${OLCF_AFAR_ROOT}/lib/llvm/lib:${_mfc_mpi_lib}:${LD_LIBRARY_PATH}"
+    export CMAKE_PREFIX_PATH="${OLCF_AFAR_ROOT}:${CMAKE_PREFIX_PATH}"
+
+    export MFC_FLANG_MPI_INC="-I${OLCF_AFAR_ROOT}/include/mpi"
+    export MFC_FLANG_MPI_LIB="${_mfc_mpi_lib}/libmpi.so;${_mfc_mpi_lib}/libmpi_mpifh.so"
+    export MFC_FLANG_HIPFORT_LIB="${OLCF_AFAR_ROOT}/lib/llvm/lib/libhipfort-amdgcn.a;${OLCF_AFAR_ROOT}/lib/libhipfft.so"
+
+    export FC="${OLCF_AFAR_ROOT}/bin/amdflang"
+
+    unset _mfc_mpi_lib
 fi
 
 ok 'All modules and environment variables have been loaded.'

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -164,7 +164,9 @@ fi
 # AMD HPCFund: AFAR LLVM Flang (amdflang) + system GNU-built OpenMPI, gfx90a.
 # The stock mpi.mod is GNU-built and binary-incompatible with amdflang, so we
 # point at a pre-generated flang-compatible one under $OLCF_AFAR_ROOT/include/mpi.
-if [ "$u_c" '==' 'amdfund' ]; then
+# amdflang is only supported for OpenMP-offload GPU builds; CPU-mode (-m c) builds
+# use the gfortran + OpenMPI provided by the amdfund-all modules, so gate on GPU.
+if [ "$u_c" '==' 'amdfund' ] && [ "$cg" '==' 'gpu' ]; then
     # Direct WORK-filesystem path (mounted at the same /work1 point on login and
     # compute nodes); override OLCF_AFAR_ROOT before loading to use another drop.
     export OLCF_AFAR_ROOT="${OLCF_AFAR_ROOT:-/work1/spencerbryngelson/sbryngelson/software/therock-afar-23.2.1-gfx90a-7.13.0-7357b5084b}"

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -168,7 +168,9 @@ if [ "$u_c" '==' 'amdfund' ]; then
     # Direct WORK-filesystem path (mounted at the same /work1 point on login and
     # compute nodes); override OLCF_AFAR_ROOT before loading to use another drop.
     export OLCF_AFAR_ROOT="${OLCF_AFAR_ROOT:-/work1/spencerbryngelson/sbryngelson/software/therock-afar-23.2.1-gfx90a-7.13.0-7357b5084b}"
-    _mfc_mpi_lib="/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.8/lib"
+    # Track the loaded openmpi4 module's prefix (OpenHPC sets MPI_DIR) instead of
+    # pinning a path that can drift from the module.
+    _mfc_mpi_lib="${MPI_DIR:-/opt/ohpc/pub/mpi/openmpi4-gnu12/4.1.8}/lib"
 
     export PATH="${OLCF_AFAR_ROOT}/lib/llvm/bin:${OLCF_AFAR_ROOT}/bin:${PATH}"
     export LD_LIBRARY_PATH="${OLCF_AFAR_ROOT}/lib:${OLCF_AFAR_ROOT}/lib/llvm/lib:${_mfc_mpi_lib}:${LD_LIBRARY_PATH}"
@@ -181,6 +183,13 @@ if [ "$u_c" '==' 'amdfund' ]; then
     export FC="${OLCF_AFAR_ROOT}/bin/amdflang"
 
     unset _mfc_mpi_lib
+
+    if [ ! -x "$FC" ]; then
+        error "amdfund: amdflang not found at $M$FC$CR."
+        error "Set $M\$OLCF_AFAR_ROOT$CR to your AFAR drop, then reload, e.g.:"
+        error "  export OLCF_AFAR_ROOT=/path/to/therock-afar-<ver>-gfx90a-...; source ./mfc.sh load -c amdfund -m g"
+        return
+    fi
 fi
 
 ok 'All modules and environment variables have been loaded.'

--- a/toolchain/modules
+++ b/toolchain/modules
@@ -52,6 +52,9 @@ famd-all cpe/25.09
 famd-all PrgEnv-amd
 famd-all amd/7.2.0 rocm/7.2.0
 
+amdfund    AMD HPCFund
+amdfund-all gnu12 openmpi4/4.1.8 cmake rocm/7.2.0
+
 tuo     OLCF Tuolumne
 tuo-all cpe/25.03 rocm/6.3.1
 tuo-all cray-fftw/3.3.10.9 cray-hdf5 python/3.12.2 cmake

--- a/toolchain/templates/amdfund.mako
+++ b/toolchain/templates/amdfund.mako
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+<%namespace name="helpers" file="helpers.mako"/>
+
+% if engine == 'batch':
+#SBATCH --nodes=${nodes}
+#SBATCH --ntasks-per-node=${tasks_per_node}
+#SBATCH --job-name="${name}"
+#SBATCH --output="${name}.out"
+#SBATCH --error="${name}.err"
+#SBATCH --time=${walltime}
+## hpcfund does not track GPUs through Slurm (GresTypes=null): the MI250X nodes
+## hand out every GCD with the node, so there is no --gres / --gpu-bind to set.
+#SBATCH --partition=${partition or 'mi2508x'}
+% if account:
+#SBATCH --account="${account}"
+% endif
+% if quality_of_service:
+#SBATCH --qos=${quality_of_service}
+% endif
+% if email:
+#SBATCH --mail-user=${email}
+#SBATCH --mail-type="BEGIN, END, FAIL"
+% endif
+% endif
+
+${helpers.template_prologue()}
+
+ok ":) Loading modules:\n"
+cd "${MFC_ROOT_DIR}"
+. ./mfc.sh load -c amdfund -m ${'g' if gpu_enabled else 'c'}
+cd - > /dev/null
+echo
+
+% if gpu_enabled:
+# Abort loudly if OpenMP offload cannot reach a GPU (e.g. run on a login node).
+export OMP_TARGET_OFFLOAD=MANDATORY
+% endif
+
+% for target in targets:
+    ${helpers.run_prologue(target)}
+
+    % if not mpi:
+        (set -x; ${profiler} "${target.get_install_binpath(case)}")
+    % else:
+        (set -x; ${profiler}                              \
+            mpirun -np ${nodes*tasks_per_node}            \
+                   "${target.get_install_binpath(case)}")
+    % endif
+
+    ${helpers.run_epilogue(target)}
+
+    echo
+% endfor
+
+${helpers.template_epilogue()}


### PR DESCRIPTION
## Description

Adds first-class support for building and running MFC on **AMD HPCFund** (`hpcfund`,
MI250X / gfx90a) with the AMD AFAR **LLVM Flang** (`amdflang`) compiler using OpenMP
`target` offload against the system GNU-built OpenMPI.

- **New `amdfund` load slug** (`toolchain/modules`, `toolchain/bootstrap/modules.sh`):
  loads `gnu12 openmpi4/4.1.8 cmake rocm/7.2.0` and sets `FC=amdflang` plus the MPI and
  hipfort paths. `OLCF_AFAR_ROOT` uses the direct WORK-filesystem path (mounted at the
  same point on login and compute nodes) and is overridable — `export OLCF_AFAR_ROOT=...`
  before loading to select a different AFAR drop.
- **New `amdfund.mako` run template**: SLURM, interactive + batch. hpcfund's Slurm has
  `GresTypes=null`, so no `--gres`/`--gpu-bind` is emitted (the MI250X nodes hand out
  every GCD with the node); default partition `mi2508x`.
- **`cmake/MFCTargets.cmake`** (refactor):
  - Resolve `hipfort-amdgcn` (library + Fortran module include) under the newer AFAR
    *therock* `lib/llvm/` layout in addition to Frontier's `lib/` layout.
  - Feed the amdflang (`LLVMFlang`) path its MPI/hipfort locations through compiler-neutral
    `MFC_FLANG_MPI_INC/LIB` and `MFC_FLANG_HIPFORT_LIB` env vars, **falling back to the
    legacy `CRAY_*` names** when the neutral ones are unset. These hooks are consumed only
    by the `LLVMFlang` branch (never the Cray CCE compiler), so the naming was misleading;
    the fallback keeps the existing Frontier `famd` (amdflang + Cray MPICH) build working
    unchanged.

**Note on the default `OLCF_AFAR_ROOT`:** hpcfund has no shared, writable software
location, so the committed default points at a concrete AFAR install path; it is
overridable per the above. This mirrors how the existing Frontier `famd` slug hard-codes
its AFAR path.

No solver source (`src/`) changes — this is toolchain and build-configuration only.

### Type of change

- New feature
- Refactor

## Testing

On hpcfund (MI250X, gfx90a, AFAR drop 23.2.1, flang 23.0.0git):

- `source ./mfc.sh load -c amdfund -m g && ./mfc.sh build -t simulation --gpu mp -j 8`
  configures, builds, and installs the `simulation` target (exit 0, ~23 MB binary).
- Verified both env paths resolve correctly: the legacy `CRAY_*` fallback and the neutral
  `MFC_FLANG_*` vars. Confirmed the `simulation` link line carries `libhipfort-amdgcn.a`,
  `libhipfft.so`, `libmpi.so`, and `libmpi_mpifh.so`.
- `./mfc.sh precheck` passes all checks.
- Frontier `famd` is preserved by construction (its `CRAY_*` block is untouched and the
  CMake fallback reads it); not re-run on Frontier hardware in this change.

## Checklist

- [ ] I added or updated tests for new behavior — N/A (build-config/toolchain only)
- [x] I updated documentation if user-facing behavior changed — `./mfc.sh load` help text
  and system menu updated with the new `amdfund` slug
