### PR TITLE
build: support amdflang (LLVMFlang) CPU builds via non-PIE link

### DIFF
--- a/cmake/GPU.cmake
+++ b/cmake/GPU.cmake
@@ -115,6 +115,20 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")
     if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
         add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-O1> $<$<COMPILE_LANGUAGE:Fortran>:-g>)
     endif()
+elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    # AMD/LLVM flang (amdflang). These are CPU-build flags only; the OpenMP-offload GPU
+    # build sets its own flags (MFCTargets.cmake) and links via the offload wrapper, so
+    # it is left untouched here.
+    if (NOT (MFC_OpenMP OR MFC_OpenACC))
+        if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelDebug")
+            # Ordinary (non-LTO) objects plus static deps built without -fPIC
+            # (e.g. libfftw3) hit ld.lld's default-PIE "relocation R_X86_64_32
+            # against local symbol". Link a non-PIE executable to accept them.
+            # Release links fine via LTO's link-time PIC codegen, so it is left alone.
+            add_link_options(-no-pie)
+            add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-O1> $<$<COMPILE_LANGUAGE:Fortran>:-g>)
+        endif()
+    endif()
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-free>)
 


### PR DESCRIPTION
## Summary

Adds an `LLVMFlang` branch to the compiler dispatch in `cmake/GPU.cmake` so **amdflang** (AMD's LLVM-based `flang`, which CMake identifies as `LLVMFlang`, distinct from classic `Flang`) can build the CPU targets.

Previously amdflang matched no branch in `GPU.cmake`, so a CPU build received no compiler-appropriate flags and **Debug/RelDebug failed to link**:

```
ld.lld: error: relocation R_X86_64_32 cannot be used against local symbol; recompile with -fPIC
```

`ld.lld` defaults to producing a PIE, but the static dependencies (e.g. `libfftw3`) are not built `-fPIC`. The new branch links a **non-PIE** executable for the non-LTO build types, which accepts those objects.

## Scope / safety

- Gated on `NOT (MFC_OpenMP OR MFC_OpenACC)`, so the merged **OpenMP-offload GPU** path (#1632) is untouched — it sets its own flags in `MFCTargets.cmake` and links via the offload wrapper.
- Only affects `Debug`/`RelDebug`. **Release is unchanged** — it already linked, via LTO's link-time PIC codegen.
- Verified on AMD HPCFund (MI250X node, amdflang from `rocm/7.2.0`): `simulation` CPU **Debug and Release both build clean**.

## Caveats

- **No default behavior changes.** `-c amdfund` still defaults CPU builds to gfortran (from #1632); this only unblocks amdflang when a user selects it as the CPU compiler.
- **No CI lane currently builds amdflang on CPU**, so this path is not CI-gated. Adding such a lane would be a separate, larger change.
