### PR TITLE
ci: bump GitHub Actions to Node24-compatible versions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,10 +21,10 @@ jobs:
       checkall: ${{ steps.changes.outputs.checkall }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect Changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: ".github/file-filter.yml"
@@ -95,13 +95,13 @@ jobs:
         run: rm -f *.out
 
       - name: Clone - PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: pr
           clean: false
 
       - name: Clone - Master
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: MFlowCode/MFC
           ref: master
@@ -174,7 +174,7 @@ jobs:
       # All other runners (non-Phoenix) just run without special env
       - name: Archive Logs (Frontier)
         if: always() && matrix.cluster != 'phoenix'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.cluster }}-${{ matrix.device }}-${{ matrix.interface }}
           path: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,7 +64,7 @@ jobs:
           echo "pr_head_ref=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -18,10 +18,10 @@ jobs:
       checkall: ${{ steps.changes.outputs.checkall }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect Changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with: 
           filters: ".github/file-filter.yml"
@@ -36,11 +36,11 @@ jobs:
           master_everything: 0
       steps:
           - name: Clone - PR
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
               path: pr
           - name: Clone - Master
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
               repository: MFlowCode/MFC
               ref: master

--- a/.github/workflows/convergence.yml
+++ b/.github/workflows/convergence.yml
@@ -18,10 +18,10 @@ jobs:
       checkall: ${{ steps.changes.outputs.checkall }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect Changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: ".github/file-filter.yml"
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 240
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Ubuntu
         run: |
@@ -46,7 +46,7 @@ jobs:
                    openmpi-bin libopenmpi-dev
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/coverage-health.yml
+++ b/.github/workflows/coverage-health.yml
@@ -9,8 +9,8 @@ jobs:
     if: github.repository == 'MFlowCode/MFC'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with: { python-version: '3.12' }
       - name: Initialize MFC
         run: ./mfc.sh init

--- a/.github/workflows/coverage-refresh.yml
+++ b/.github/workflows/coverage-refresh.yml
@@ -27,7 +27,7 @@ jobs:
       # token embedded in the push URL below — making the push authenticate as
       # github-actions[bot] (which cannot bypass the require-PR rule) instead of
       # the CACHE_PUSH_TOKEN identity.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: { clean: false, persist-credentials: false }
       - name: Build + collect coverage map (SLURM)
         run: bash .github/scripts/submit-slurm-job.sh .github/workflows/common/coverage-refresh.sh cpu none phoenix

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,10 +19,10 @@ jobs:
       checkall: ${{ steps.changes.outputs.checkall }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect Changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with: 
           filters: ".github/file-filter.yml"
@@ -34,7 +34,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkouts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get system info for cache key
         id: sys-info
@@ -48,7 +48,7 @@ jobs:
           echo "sys-hash=$(cat /tmp/sys-hash)" >> "$GITHUB_OUTPUT"
 
       - name: Restore Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build
           key: mfc-coverage-${{ steps.sys-info.outputs.sys-hash }}-${{ hashFiles('CMakeLists.txt', 'toolchain/dependencies/**', 'toolchain/cmake/**', 'src/**/*.fpp', 'src/**/*.f90') }}
@@ -67,7 +67,7 @@ jobs:
         run: /bin/bash mfc.sh test -v -a -j $(nproc)
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/deploy-tap.yml
+++ b/.github/workflows/deploy-tap.yml
@@ -31,7 +31,7 @@ jobs:
       url: https://github.com/MFlowCode/homebrew-mfc
     steps:
       - name: Checkout MFC repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,20 +44,20 @@ jobs:
           swap-storage: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Clone
         id: clone
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build and push image (cpu)
         if: ${{ matrix.config.name == 'cpu' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: /mnt/share
           file: /mnt/share/Dockerfile
@@ -114,7 +114,7 @@ jobs:
 
       - name: Build and push image (gpu)
         if: ${{ matrix.config.name == 'gpu' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           builder: default
           context: /mnt/share
@@ -142,20 +142,20 @@ jobs:
       url: https://hub.docker.com/r/sbryngelson/mfc
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set GHCR registry (lowercase)
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0  # Full history for per-page last-updated dates
 
@@ -44,7 +44,7 @@ jobs:
         done
 
     - name: Upload Built Documentation Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mfc-docs
         path: build/install/docs/mfc
@@ -83,10 +83,10 @@ jobs:
       url: https://mflowcode.github.io/
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download Built Documentation Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: mfc-docs
         path: build/install/docs/mfc

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: MFC Python setup
       run: ./mfc.sh init

--- a/.github/workflows/fp-stability.yml
+++ b/.github/workflows/fp-stability.yml
@@ -43,10 +43,10 @@ jobs:
       checkall: ${{ steps.changes.outputs.checkall }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect Changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: ".github/file-filter.yml"
@@ -62,11 +62,11 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache Verrou
         id: cache-verrou
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/verrou
           # Key off the installer's content so any version bump (or other edit) in
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload FP stability logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fp-stability-logs
           path: fp-stability-logs/

--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Checkout homebrew-mfc tap
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: MFlowCode/homebrew-mfc
           token: ${{ secrets.TAP_REPO_TOKEN }}

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -121,7 +121,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Set up Homebrew
         run: |
@@ -197,7 +197,7 @@ jobs:
       
       - name: Upload Homebrew logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: homebrew-logs
           path: |

--- a/.github/workflows/line-count.yml
+++ b/.github/workflows/line-count.yml
@@ -14,10 +14,10 @@ jobs:
       checkall: ${{ steps.changes.outputs.checkall }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect Changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with: 
           filters: ".github/file-filter.yml"
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: pr
 
       - name: Checkout code from MFC master
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.event.pull_request.repository }}
           ref:        ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/lint-toolchain.yml
+++ b/.github/workflows/lint-toolchain.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Initialize MFC
       run: ./mfc.sh init

--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -14,10 +14,10 @@ jobs:
           pr_everything: 0
       steps:
           - name: Clone - PR
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
 
           - name: Set up Java
-            uses: actions/setup-java@v4
+            uses: actions/setup-java@v5
             with:
               distribution: temurin
               java-version: '17'

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: MFC Python Setup
       run:  ./mfc.sh init

--- a/.github/workflows/test-toolchain-compat.yml
+++ b/.github/workflows/test-toolchain-compat.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Initialize MFC

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -56,10 +56,10 @@ jobs:
       changed_files: ${{ steps.changes.outputs.checkall_files }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect Changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: ".github/file-filter.yml"
@@ -150,7 +150,7 @@ jobs:
           df -h /
 
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # ── NVHPC: pull image and start a long-lived container ──────────────
       # Replaces the container: directive so we can free disk space first.
@@ -416,7 +416,7 @@ jobs:
       NODE_OPTIONS: ${{ matrix.cluster == 'phoenix' && '--max-old-space-size=2048' || '' }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # clean: false preserves .slurm_job_id files across reruns so
           # submit-slurm-job.sh can detect and cancel stale SLURM jobs on retry.
@@ -465,7 +465,7 @@ jobs:
           done
 
       - name: Archive Logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if:   matrix.cluster != 'phoenix'
         with:
           name: logs-${{ strategy.job-index }}-${{ steps.log.outputs.test_slug }}
@@ -513,7 +513,7 @@ jobs:
       labels: ${{ matrix.runner }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: false
 
@@ -575,7 +575,7 @@ jobs:
           done
 
       - name: Archive Logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if:   always()
         with:
           name: case-opt-${{ strategy.job-index }}-${{ matrix.cluster }}-${{ matrix.interface }}

--- a/src/simulation/m_bubbles.fpp
+++ b/src/simulation/m_bubbles.fpp
@@ -4,7 +4,7 @@
 
 #:include 'macros.fpp'
 
-!> @brief Bubble-dynamics procedures for ensemble- and volume-averaged models
+!> @brief Bubble-dynamics procedures for ensemble- and volume-averaged model
 module m_bubbles
 
     use m_derived_types


### PR DESCRIPTION
## What

GitHub is deprecating the **Node20** action runtime. This bumps every JS action pinned in `.github/workflows` to its first major release that defaults to Node24 (`runs.using: node24`).

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v5** |
| `actions/setup-python` | v5 | **v6** |
| `actions/setup-java` | v4 | **v5** |
| `actions/cache` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v6** |
| `actions/download-artifact` | v4 | **v7** |
| `dorny/paths-filter` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/build-push-action` | v5 & v6 | **v7** |
| `codecov/codecov-action` | v4 | **v5** |

20 workflow files touched, no behavioral changes to CI logic.

## Left as-is

`lycheeverse/lychee-action@v2`, `cicirello/generate-sitemap@v1`, `anthropics/claude-code-action@v1`, `Homebrew/actions/setup-homebrew@master`, and `jlumbroso/free-disk-space@main` are composite/docker actions with no Node runtime, so they are unaffected by the Node20 deprecation.

## Self-hosted runner note

`upload-artifact@v6+` and `download-artifact@v7+` require a self-hosted runner agent >= `2.327.1` (the version that bundles Node 24). The GT/Phoenix and ORNL/Frontier runners auto-update, so the `checkout`/`upload-artifact` steps on those jobs are bumped too. If a self-hosted runner is ever pinned to an old agent, those specific steps would need to stay on the Node20 majors until the agent is updated.

## Version choice

Conservative Node24 targets were chosen for the artifact actions (`upload-artifact@v6`, `download-artifact@v7`) — the first majors that default to Node24 — to avoid `upload-artifact@v7`'s new direct-upload behavior and `download-artifact@v8`'s enforced hash-mismatch error.

## Notes

- codecov step only uses `fail_ci_if_error`/`verbose`, so the v4->v5 CLI-wrapper migration is a clean drop-in (no deprecated `file`/`plugin` args).
- docs' `download-artifact` pulls a single named artifact, unaffected by v5+ path/behavior changes.