### PR TITLE
Fix acoustic-source NaN for unfocused 2D sources (undefined negative-base pow)

### DIFF
--- a/src/simulation/m_acoustic_src.fpp
+++ b/src/simulation/m_acoustic_src.fpp
@@ -350,9 +350,9 @@ contains
         ! compilers (e.g. nvhpc <= 24.3) in 2D, and 1/foc_length = wrong-sign or Inf in 3D/cylindrical.
         if (n == 0 .or. foc_length(ai) <= 0._wp) then
             foc_length_factor = 1._wp
-        else if (p == 0 .and. (.not. cyl_coord)) then  ! 2D axisymmetric case is physically 3D
-            foc_length_factor = foc_length(ai)**(-0.85_wp)  ! Empirical correction
-        else
+        else if (p == 0 .and. (.not. cyl_coord)) then  ! 2D Cartesian: cylindrical (line-source) spreading
+            foc_length_factor = foc_length(ai)**(-0.85_wp)  ! Empirical correction to 1/sqrt(r)
+        else  ! 3D or axisymmetric: spherical spreading
             foc_length_factor = 1._wp/foc_length(ai)
         end if
 

--- a/src/simulation/m_acoustic_src.fpp
+++ b/src/simulation/m_acoustic_src.fpp
@@ -344,12 +344,16 @@ contains
         ! i.e. Spherical support -> 1/r scaling; Cylindrical support -> 1/sqrt(r) [empirical correction: ^-0.5 -> ^-0.85]
         integer, parameter :: mass_label = 1
 
-        if (n == 0) then
+        ! An unfocused source leaves foc_length at its unset default (dflt_real < 0, or 0): apply no
+        ! radial amplitude scaling. This guards every branch against the silent-corruption the default
+        ! would otherwise cause - foc_length(ai)**(-0.85) = pow(negative, non-integer) = NaN on some
+        ! compilers (e.g. nvhpc <= 24.3) in 2D, and 1/foc_length = wrong-sign or Inf in 3D/cylindrical.
+        if (n == 0 .or. foc_length(ai) <= 0._wp) then
             foc_length_factor = 1._wp
         else if (p == 0 .and. (.not. cyl_coord)) then  ! 2D axisymmetric case is physically 3D
             foc_length_factor = foc_length(ai)**(-0.85_wp)  ! Empirical correction
         else
-            foc_length_factor = 1/foc_length(ai)
+            foc_length_factor = 1._wp/foc_length(ai)
         end if
 
         source = 0._wp


### PR DESCRIPTION
## Problem

`s_source_temporal` (`src/simulation/m_acoustic_src.fpp`) computes, for a 2D non-cylindrical source:

```fortran
foc_length_factor = foc_length(ai)**(-0.85_wp)
```

An **unfocused** acoustic source never sets `foc_length`, so it keeps the default sentinel `dflt_real = -1e6`. Then `(-1e6)**(-0.85)` is `pow(negative_base, non-integer_exponent)`, which Fortran leaves **undefined**. Compilers disagree: many mask it, but some (e.g. NVHPC ≤ 24.3) return `NaN`, which flows through the acoustic **mass** source term into the density field.

## Symptom

CI test `2D -> Lagrange Bubbles -> Two-way Coupling -> AMR` (`4B08E9B7`) fails with a post-process NaN on the **NVHPC 24.1 (cpu)** and **NVHPC 24.3 (cpu)** lanes, while 24.5→26.3 pass. That case enables `acoustic_source` with `support = 2` and no `foc_length`, so it hits the sentinel.

## Fix

Guard the power: an unfocused source (`foc_length ≤ 0`) uses `foc_length_factor = 1` (no radial scaling — the correct behavior when there is no focal length). Focused sources are unchanged.

## Verification

Reproduced and fixed in an `nvcr.io/nvidia/nvhpc:24.1` container built with CI's flags (`-tp=px -Kieee`):

- `-O0 -Ktrap=fp` traps at exactly `m_acoustic_src.fpp` line 358 on time step 1 (`pow` → invalid). This is the origin.
- With the guard, the trapping build runs to completion — no FP exception.
- A clean **release** build + golden compare **passes `4B08E9B7`**, so no golden regeneration is needed and lanes that currently pass are unaffected (they now compute `factor = 1` deterministically instead of relying on undefined-pow behavior).

Independent, single-hunk change. Opening as **draft**.
