### PR TITLE
fix(runners): prevent and clean up duplicate runner listeners

### DIFF
--- a/misc/runners/common/README.md
+++ b/misc/runners/common/README.md
@@ -13,7 +13,7 @@ bash misc/runners/runner.sh <site> <command> [args...]
 
 | Script | Purpose |
 |---|---|
-| `runner-lib.sh` | Shared library: GitHub API helpers, EXE-based process discovery, parallel node sweep, start/stop primitives. Sourced by site `config.sh` files. |
+| `runner-lib.sh` | Shared library: GitHub API helpers, EXE-based process discovery, parallel node sweep, start/stop primitives. Sourced by site `config.sh` files. Process discovery distinguishes an unreachable node (SSH failure) from "no runner here" so callers can fail safe instead of restarting a runner that is actually still running elsewhere. |
 | `check-runners.sh` | Per-node health check: Runner.Listener processes with name, idle/BUSY, slurm PATH, RSS. Optional cgroup memory footer. |
 | `list-runners.sh` | Full table: GitHub API status × parallel node sweep. Shows slurm status, flags stale `runner.node`. |
 | `rebalance-runners.sh` | Compute optimal distribution and move runners across nodes. Handles offline runners. Writes `runner.node`. Dry run by default. |
@@ -21,5 +21,6 @@ bash misc/runners/runner.sh <site> <command> [args...]
 | `restart-all.sh` | Restart all runners in place. Skips busy unless `FORCE=1`. Dry run by default. |
 | `move-runner.sh` | Move a runner to a different login node by name. Stops on current node, starts on target. Writes `runner.node`. |
 | `stop-runner.sh` | Stop a runner process and remove its GitHub registration. |
+| `dedupe-runners.sh` | Find runners listening on more than one node (a duplicate created by a botched move/restart) and stop the extra listeners, keeping one. Prefers the busy listener, then the `runner.node` one. Dry run by default. |
 | `rerun-failed.sh` | Rerun failed GitHub Actions workflows on open non-draft PRs and master. Dry run by default. |
 | `create-runner.sh` | Download, register, and start a new runner. Requires `runner_install_dir()` and `TARBALL_CACHE_DIR` from site config. Usage: `create-runner <name> <node> [install-dir]` |

--- a/misc/runners/common/dedupe-runners.sh
+++ b/misc/runners/common/dedupe-runners.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Detect and remove duplicate GitHub Actions runner listeners.
+#
+# Sourced by site wrappers (frontier/dedupe-runners.sh via the dispatcher)
+# after config.sh is loaded.
+#
+# Because runner binaries live on shared storage, a botched move/restart can
+# leave the SAME runner listening on two login nodes at once. The two processes
+# then fight over the single GitHub registration and share one _diag/ directory,
+# which cancels in-progress jobs and produces "file already exists" errors in
+# job setup. This sweeps every node, groups listeners by runner directory, and
+# for any runner found on more than one node keeps a single listener (preferring
+# the busy one, then the node recorded in runner.node) and stops the rest.
+#
+# Usage: bash dedupe-runners.sh              # dry run
+#        APPLY=1 bash dedupe-runners.sh      # execute
+set -euo pipefail
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "=== Sweeping all nodes for runner listeners ==="
+mapfile -t lines < <(sweep_all_listeners "$tmpdir")
+
+# Group listeners by directory: dir -> "node:pid:busy node:pid:busy ..."
+declare -A locs
+for line in "${lines[@]}"; do
+    read -r _tag node pid dir busy <<< "$line"
+    locs["$dir"]="${locs["$dir"]:-} $node:$pid:$busy"
+done
+
+dupes=0
+declare -a kill_nodes=() kill_pids=() kill_names=()
+for dir in "${!locs[@]}"; do
+    entries=(${locs["$dir"]})
+    [ "${#entries[@]}" -le 1 ] && continue
+    dupes=$((dupes + 1))
+    name=$(get_runner_name "$dir" 2>/dev/null || basename "$dir")
+
+    recorded=""
+    [ -f "$dir/runner.node" ] && recorded=$(cat "$dir/runner.node" 2>/dev/null || echo "")
+
+    echo ""
+    echo "DUPLICATE: $name on ${#entries[@]} nodes"
+    for e in "${entries[@]}"; do
+        IFS=: read -r n p b <<< "$e"
+        tag=""
+        [ "$n" = "$recorded" ] && tag=" (runner.node)"
+        echo "  $n pid=$p $b$tag"
+    done
+
+    # Choose the keeper: first busy listener (never kill a running job if we
+    # can avoid it), else the one matching runner.node, else the first.
+    keeper=""
+    for e in "${entries[@]}"; do
+        IFS=: read -r n p b <<< "$e"
+        [ "$b" = "busy" ] && keeper="$e" && break
+    done
+    if [ -z "$keeper" ] && [ -n "$recorded" ]; then
+        for e in "${entries[@]}"; do
+            IFS=: read -r n p b <<< "$e"
+            [ "$n" = "$recorded" ] && keeper="$e" && break
+        done
+    fi
+    [ -z "$keeper" ] && keeper="${entries[0]}"
+
+    IFS=: read -r kn kp kb <<< "$keeper"
+    echo "  -> keep $kn pid=$kp ($kb); stop the rest"
+    for e in "${entries[@]}"; do
+        [ "$e" = "$keeper" ] && continue
+        IFS=: read -r n p _b <<< "$e"
+        kill_nodes+=("$n"); kill_pids+=("$p"); kill_names+=("$name")
+    done
+done
+
+if [ "$dupes" -eq 0 ]; then
+    echo ""
+    echo "No duplicate runners found."
+    exit 0
+fi
+
+echo ""
+echo "${#kill_pids[@]} extra listener(s) to stop across $dupes runner(s)."
+if [ "${APPLY:-0}" != "1" ]; then
+    echo "Dry run — set APPLY=1 to execute."
+    exit 0
+fi
+
+echo ""
+echo "=== Stopping extra listeners ==="
+for i in "${!kill_pids[@]}"; do
+    n="${kill_nodes[$i]}"; p="${kill_pids[$i]}"; nm="${kill_names[$i]}"
+    echo "Stopping duplicate $nm: $n pid=$p"
+    ssh $SSH_OPTS "$n" "kill $p" 2>/dev/null || true
+    sleep 2
+    if ssh $SSH_OPTS "$n" "kill -0 $p" 2>/dev/null; then
+        ssh $SSH_OPTS "$n" "kill -9 $p" 2>/dev/null || true
+    fi
+done
+
+echo ""
+echo "Done. Re-run without APPLY to confirm no duplicates remain."

--- a/misc/runners/common/list-runners.sh
+++ b/misc/runners/common/list-runners.sh
@@ -21,13 +21,16 @@ trap 'rm -rf "$tmpdir"' EXIT
 sweep_all_nodes "$tmpdir"
 
 # Parse sweep results into associative arrays
-declare -A runner_node runner_rss runner_slurm
+declare -A runner_node runner_rss runner_slurm runner_dupcount
 for node in "${NODES[@]}"; do
     while IFS= read -r line; do
         read -r _s sweep_node dir rss slurm_ok <<< "$line"
         runner_node["$dir"]="$sweep_node"
         runner_rss["$dir"]="$rss"
         runner_slurm["$dir"]="$slurm_ok"
+        # Count how many nodes report this runner. >1 means a duplicate
+        # listener, which the last-wins assignment above would otherwise hide.
+        runner_dupcount["$dir"]=$(( ${runner_dupcount["$dir"]:-0} + 1 ))
     done < <(grep '^RUNNER ' "$tmpdir/$node.out" 2>/dev/null || true)
 done
 
@@ -63,6 +66,10 @@ while IFS= read -r dir; do
         recorded=$(cat "$dir/runner.node")
         [ "$actual_node" != "$recorded" ] && node_col="${actual_node} *(stale: ${recorded})"
     fi
+
+    # Flag duplicate listeners (same runner on more than one node)
+    [ "${runner_dupcount[$dir]:-1}" -gt 1 ] && \
+        node_col="${actual_node} !!DUPLICATE on ${runner_dupcount[$dir]} nodes — run dedupe-runners!!"
 
     printf "%-25s %-8s %-20s %-8s %sMB\n" "$name" "$gh_col" "$node_col" "$slurm" "$rss"
 done < <(find_runner_dirs)

--- a/misc/runners/common/move-runner.sh
+++ b/misc/runners/common/move-runner.sh
@@ -44,6 +44,12 @@ declare -f sync_runner_nodes > /dev/null 2>&1 && {
 echo "==> Locating $RUNNER_NAME..."
 current_node=$(find_node "$runner_dir")
 
+if [ "$current_node" = "unknown" ]; then
+    echo "ERROR: could not determine where $RUNNER_NAME is running (SSH failures to" >&2
+    echo "       one or more nodes). Moving now risks a duplicate listener. Try again." >&2
+    exit 1
+fi
+
 if [ "$current_node" = "$TARGET_NODE" ]; then
     echo "==> $RUNNER_NAME is already running on $TARGET_NODE. Nothing to do."
     exit 0

--- a/misc/runners/common/rebalance-runners.sh
+++ b/misc/runners/common/rebalance-runners.sh
@@ -45,12 +45,25 @@ for node in "${NODES[@]}"; do node_runners[$node]=""; done
 for i in "${!dirs[@]}"; do
     node=$(find_node "${dirs[$i]}")
     runner_node[$i]="$node"
+    runner_busy[$i]=0
+    # Location could not be confirmed (SSH failures). Acting on a guess here
+    # is exactly what creates duplicate listeners, so skip this runner and
+    # leave it out of both the per-node counts and the offline placement list.
+    if [ "$node" = "unknown" ]; then
+        echo "  WARNING: ${names[$i]} location unknown (SSH failures); skipping this cycle" >&2
+        continue
+    fi
     if [ "$node" != "offline" ]; then
         node_runners[$node]="${node_runners[$node]:-} $i"
-        worker=$(ssh $SSH_OPTS "$node" "ps aux | grep Runner.Worker | grep '${dirs[$i]}/' | grep -v grep" 2>/dev/null || true)
-        [ -n "$worker" ] && runner_busy[$i]=1 || runner_busy[$i]=0
-    else
-        runner_busy[$i]=0
+        worker=$(ssh $SSH_OPTS "$node" "ps aux | grep Runner.Worker | grep '${dirs[$i]}/' | grep -v grep" 2>/dev/null)
+        wrc=$?
+        if [ "$wrc" -eq 255 ]; then
+            # Could not reach the node to check — assume busy so we do not move
+            # a runner that might be mid-job (which would create a duplicate).
+            runner_busy[$i]=1
+        elif [ -n "$worker" ]; then
+            runner_busy[$i]=1
+        fi
     fi
 done
 

--- a/misc/runners/common/restart-all.sh
+++ b/misc/runners/common/restart-all.sh
@@ -28,6 +28,11 @@ while IFS= read -r dir; do
         continue
     fi
 
+    if [ "$node" = "unknown" ]; then
+        echo "  $name: UNKNOWN location (SSH failures); skipping"
+        continue
+    fi
+
     worker=$(ssh $SSH_OPTS "$node" "ps aux | grep Runner.Worker | grep '$dir/' | grep -v grep" 2>/dev/null || true)
     if [ -n "$worker" ]; then
         echo "  $name: BUSY on $node"

--- a/misc/runners/common/runner-lib.sh
+++ b/misc/runners/common/runner-lib.sh
@@ -61,24 +61,48 @@ print(d.get('agentName', ''))
 # Output is filtered to numeric lines only to strip SSH MOTD noise.
 # Args: $1 = node, $2 = runner directory
 # Prints: space-separated PIDs, or empty.
+# Returns: 0 normally; 2 if the SSH connection itself failed (so callers can
+#          fail safe rather than mistake an unreachable node for "no runner").
 find_pids() {
-    ssh $SSH_OPTS "$1" '
+    local out rc
+    out=$(ssh $SSH_OPTS "$1" '
         for p in $(ps aux | grep Runner.Listener | grep -v grep | awk "{print \$2}"); do
             exe=$(readlink -f /proc/$p/exe 2>/dev/null || true)
             exe=${exe% (deleted)}
             [ "$exe" = "'"$2"'/bin/Runner.Listener" ] && echo "$p"
         done
-    ' 2>/dev/null | grep -E '^[0-9]+$' | tr '\n' ' ' || true
+    ' 2>/dev/null)
+    rc=$?
+    # ssh exits 255 when the connection itself fails (timeout, refused, or
+    # throttled during a connection storm). Distinguish that from a clean
+    # "no matching process": treating an unreachable node as empty is what
+    # lets a busy runner be declared offline and restarted elsewhere,
+    # producing a duplicate listener.
+    [ "$rc" -eq 255 ] && return 2
+    printf '%s\n' "$out" | grep -E '^[0-9]+$' | tr '\n' ' '
+    return 0
 }
 
 # Find which login node a runner is on.
 # Args: $1 = runner directory
-# Prints: node hostname, or "offline".
+# Prints: node hostname if found; "offline" if confirmed nowhere; "unknown"
+#         if one or more nodes could not be reached (so the location cannot be
+#         confirmed and the caller should not act on it).
 find_node() {
+    local node pids rc unreachable=0
     for node in "${NODES[@]}"; do
-        [ -n "$(find_pids "$node" "$1")" ] && echo "$node" && return
+        pids=$(find_pids "$node" "$1")
+        rc=$?
+        if [ "$rc" -eq 2 ]; then
+            unreachable=1
+            continue
+        fi
+        if [ -n "$pids" ]; then
+            echo "$node"
+            return 0
+        fi
     done
-    echo "offline"
+    [ "$unreachable" -eq 1 ] && echo "unknown" || echo "offline"
 }
 
 # Check if a runner process has a slurm directory in its PATH.
@@ -144,10 +168,18 @@ start_runner() {
 # still alive (e.g. SSH kill failed, wrong UID, kernel stuck), emits a warning
 # to stderr and returns 1 so callers can react. Returns 0 if the runner is
 # confirmed stopped or was never running.
+# If the node is unreachable at any check, returns 1 (state unknown) rather
+# than 0: a caller that then starts the runner elsewhere would create a
+# duplicate listener, so "could not confirm stopped" must not read as stopped.
 # Args: $1 = node, $2 = runner directory
 stop_runner() {
-    local node="$1" dir="$2" pids
+    local node="$1" dir="$2" pids rc
     pids=$(find_pids "$node" "$dir")
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        echo "WARNING: could not reach $node to stop runner; assuming it is still running" >&2
+        return 1
+    fi
     [ -z "$pids" ] && return 0
     for pid in $pids; do
         ssh $SSH_OPTS "$node" "kill $pid" 2>/dev/null || true
@@ -159,8 +191,43 @@ stop_runner() {
     done
     sleep 1
     pids=$(find_pids "$node" "$dir")
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        echo "WARNING: lost contact with $node while stopping runner; state unknown" >&2
+        return 1
+    fi
     if [ -n "$pids" ]; then
         echo "WARNING: process(es) $pids on $node survived SIGKILL; runner may still be running" >&2
         return 1
     fi
+}
+
+# Sweep all nodes in parallel for Runner.Listener processes, emitting one line
+# per live listener with its PID, directory, and busy state. Unlike
+# sweep_all_nodes (which keys results by directory and so collapses a runner
+# that is wrongly listening on two nodes down to one), this preserves every
+# (node, pid) pair so callers can detect duplicates.
+# Each output line: LISTENER <node> <pid> <dir> <busy>
+#   busy = "busy" if a Runner.Worker child is present for that dir, else "idle"
+# Args: $1 = tmpdir (caller creates and cleans up)
+sweep_all_listeners() {
+    local tmpdir="$1" node
+    for node in "${NODES[@]}"; do
+        ssh $SSH_OPTS "$node" '
+            for p in $(ps aux | grep Runner.Listener | grep -v grep | awk "{print \$2}"); do
+                exe=$(readlink -f /proc/$p/exe 2>/dev/null || true)
+                exe=${exe% (deleted)}
+                [ -z "$exe" ] && continue
+                dir=$(dirname "$(dirname "$exe")")
+                if ps aux | grep Runner.Worker | grep -v grep | grep -q "$dir/"; then
+                    busy=busy
+                else
+                    busy=idle
+                fi
+                echo "LISTENER '"$node"' $p $dir $busy"
+            done
+        ' 2>/dev/null > "$tmpdir/$node.dup" &
+    done
+    wait
+    cat "$tmpdir"/*.dup 2>/dev/null | grep '^LISTENER ' || true
 }

--- a/misc/runners/common/stop-runner.sh
+++ b/misc/runners/common/stop-runner.sh
@@ -28,7 +28,10 @@ fi
 echo "==> Locating $RUNNER_NAME..."
 node=$(find_node "$runner_dir")
 
-if [ "$node" != "offline" ]; then
+if [ "$node" = "unknown" ]; then
+    echo "WARNING: could not confirm where $RUNNER_NAME is running (SSH failures)." >&2
+    echo "         Skipping process stop; still attempting GitHub deregistration." >&2
+elif [ "$node" != "offline" ]; then
     echo "==> Stopping $RUNNER_NAME on $node..."
     stop_runner "$node" "$runner_dir"
     echo "==> Process stopped."

--- a/misc/runners/frontier/README.md
+++ b/misc/runners/frontier/README.md
@@ -51,6 +51,10 @@ APPLY=1 FORCE=1 $R rebalance-runners  # move busy runners too
 # Restart all runners in place (e.g. after a node reboot)
 APPLY=1 $R restart-all
 
+# Find and remove duplicate listeners (same runner on two nodes)
+$R dedupe-runners                # dry run
+APPLY=1 $R dedupe-runners       # execute
+
 # Restart one specific runner
 $R restart-runner login01 /path/to/runner-dir
 
@@ -95,3 +99,16 @@ to GitHub. Run `rebalance-runners` to recover and redistribute all at once.
 lag. `rebalance-runners` uses EXE-based process discovery first: if a
 process is found running, it will stop it before restarting, preventing
 duplicate runner processes.
+
+**Jobs fail with `The file '.../_diag/pages/....log' already exists` or get
+cancelled seconds after starting** — the same runner is listening on two login
+nodes at once (a duplicate). Because binaries live on shared storage, the two
+processes share one `_diag/` directory and fight over the single GitHub
+registration, which cancels in-progress jobs. This can happen if a move/restart
+runs while SSH to the login nodes is being throttled. Fix it with:
+```bash
+APPLY=1 bash misc/runners/runner.sh frontier dedupe-runners
+```
+`list-runners` also flags duplicates in the NODE column. Under normal SSH
+conditions the tooling avoids creating them: a runner whose location cannot be
+confirmed (SSH failure) is skipped rather than restarted elsewhere.

--- a/misc/runners/frontier/config.sh
+++ b/misc/runners/frontier/config.sh
@@ -45,7 +45,6 @@ find_runner_dirs() {
 sync_runner_nodes() {
     local tmpdir node
     tmpdir=$(mktemp -d)
-    trap 'rm -rf "$tmpdir"' RETURN
 
     sweep_all_nodes "$tmpdir"
 
@@ -62,4 +61,10 @@ sync_runner_nodes() {
             fi
         done < <(grep '^RUNNER ' "$tmpdir/$node.out" 2>/dev/null || true)
     done
+
+    # Clean up explicitly rather than via a RETURN trap: this function is
+    # sourced into the calling script, and a RETURN trap referencing the local
+    # tmpdir would fire again when the sourced script returns — by then tmpdir
+    # is out of scope, which aborts with "tmpdir: unbound variable" under set -u.
+    rm -rf "$tmpdir"
 }

--- a/misc/runners/runner.sh
+++ b/misc/runners/runner.sh
@@ -10,7 +10,7 @@
 #
 # Sites:    frontier  phoenix
 # Common:   check-runners  list-runners  move-runner  rebalance-runners
-#           restart-all  restart-runner  stop-runner  rerun-failed
+#           restart-all  restart-runner  stop-runner  dedupe-runners  rerun-failed
 # Frontier: make-runner  deploy-runners
 # Phoenix:  create-runner
 #
@@ -49,7 +49,7 @@ if [ -f "$MISC_DIR/common/$CMD.sh" ]; then
 fi
 
 echo "ERROR: Unknown command '$CMD' for site '$SITE'." >&2
-echo "Common:   check-runners list-runners move-runner rebalance-runners restart-all restart-runner stop-runner rerun-failed" >&2
+echo "Common:   check-runners list-runners move-runner rebalance-runners restart-all restart-runner stop-runner dedupe-runners rerun-failed" >&2
 echo "Frontier: make-runner deploy-runners" >&2
 echo "Phoenix:  create-runner" >&2
 exit 1


### PR DESCRIPTION
## Description

Under SSH throttling on Frontier's login nodes, a runner move/restart could leave the **same** self-hosted runner listening on two login nodes at once. Because runner binaries live on shared Lustre storage, the two processes share one `_diag/` directory and fight over the single GitHub registration — this cancels in-progress CI jobs (`The operation was canceled`) and produces `Error: The file '.../_diag/pages/....log' already exists` in job setup.

Root cause: fail-open process discovery. `find_pids` treated an unreachable node (SSH failure) the same as "no runner here", so a busy runner could be declared offline/idle and restarted on another node, creating a duplicate listener.

Changes (all under `misc/runners/`, no solver/toolchain impact):

- **`runner-lib.sh`** — `find_pids` now signals an SSH failure (rc=2) distinctly from "no match"; `find_node` returns `unknown` (not `offline`) when a node is unreachable; `stop_runner` fails safe (won't report "stopped" if it couldn't confirm). Adds `sweep_all_listeners`, which preserves every (node, pid) pair so duplicates are visible.
- **`rebalance-runners.sh`** — busy-check and location now fail safe: an unconfirmed runner is skipped rather than moved/placed elsewhere.
- **`restart-all.sh` / `move-runner.sh` / `stop-runner.sh`** — handle the new `unknown` location safely.
- **`dedupe-runners.sh`** (new command) — sweeps all nodes, finds runners listening on more than one node, and stops the extras (keeping the busy one, else the `runner.node` one). Dry run by default; `APPLY=1` executes.
- **`list-runners.sh`** — flags duplicate listeners in the NODE column.
- **`config.sh`** — fixes a leaked `RETURN` trap in `sync_runner_nodes` that aborted with `tmpdir: unbound variable`.
- READMEs (common + frontier) document the new command and the `_diag already exists` symptom.

### Type of change

- Bug fix

## Testing

Exercised live against the Frontier runner fleet (login01–login11):

- Reproduced and cleaned 3 real duplicates (`frontier-10`, `-21`, `-22`) with `dedupe-runners`; re-check reported no duplicates; fleet returned to 22/22 online.
- `bash -n` on all modified scripts.
- Full `rebalance-runners` dry run completed cleanly (exit 0, discovers 22 across 11 nodes, no `tmpdir` crash).
- `list-runners` runs clean (no false duplicate flags).
- Verified the `set -e` safety of the reworked busy-check (failing command-substitution assignment does not abort the script).

## Checklist

- [ ] I added or updated tests for new behavior (N/A — ops shell scripts, no test harness)
- [x] I updated documentation if user-facing behavior changed
