### PR TITLE
build: bump ffmt pin to 0.4.4

### DIFF
--- a/toolchain/pyproject.toml
+++ b/toolchain/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     # Code Health
     "typos",
     "ruff==0.6.5",
-    "ffmt==0.4.3",
+    "ffmt==0.4.4",
     "ansi2txt",
     "pytest",
 


### PR DESCRIPTION
Bumps the `ffmt` pin in `toolchain/pyproject.toml` from `0.4.3` to `0.4.4`.

ffmt 0.4.4 fixes an indentation bug ([sbryngelson/ffmt#5](https://github.com/sbryngelson/ffmt/issues/5)): a self-contained single-line construct like `do d = 1, n; s = s + d; end do` leaked an indent level onto every following line, and the wrong output was idempotent — so it silently persisted in format-clean files and turned any later edit in the enclosing scope into a large re-indentation cascade.

**Impact on this repo:** ffmt 0.4.4 produces **zero formatting changes** on the current `master` source tree (verified: the fix only affects code parked in the buggy over-indented fixed point, which `master` has none of). So `ffmt --check` should stay green. The benefit is that when the AMR module (which contains such a construct) lands, its indentation will be correct instead of leaked.

Released: https://github.com/sbryngelson/ffmt/releases/tag/v0.4.4