### PR TITLE
ci: exclude Microsoft Store & VS Code links from lychee link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -29,6 +29,6 @@ exclude = [
     "https://sc22\\.supercomputing\\.org",              # Returns 415 to automated requests
     "https://strawberryperl\\.com",                    # Frequently times out
     "https://www\\.olcf\\.ornl\\.gov/summit",            # Returns 503 to automated requests
-    "https://apps\\.microsoft\\.com",                 # Microsoft Store returns 403 to automated requests
-    "https://code\\.visualstudio\\.com",              # Returns 403 to automated requests
+    "https://apps\\.microsoft\\.com/store/detail/",  # Microsoft Store detail pages return 403 to automated requests
+    "https://code\\.visualstudio\\.com/?$",           # Root page returns 403 to automated requests
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -29,4 +29,6 @@ exclude = [
     "https://sc22\\.supercomputing\\.org",              # Returns 415 to automated requests
     "https://strawberryperl\\.com",                    # Frequently times out
     "https://www\\.olcf\\.ornl\\.gov/summit",            # Returns 503 to automated requests
+    "https://apps\\.microsoft\\.com",                 # Microsoft Store returns 403 to automated requests
+    "https://code\\.visualstudio\\.com",              # Returns 403 to automated requests
 ]


### PR DESCRIPTION
## Problem

The `Build & Verify` job's **Lychee link check** (`docs.yml` → `.lychee.toml`) fails on three external links in `documentation/getting-started.html` that return **403 Forbidden** to automated requests:

- `https://apps.microsoft.com/store/detail/ubuntu/9PDXGNCFSCZV`
- `https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701`
- `https://code.visualstudio.com/`

These are live, correct links — the Microsoft Store and VS Code sites simply bot-block the checker (a common link-checker false positive). The failure is unrelated to the doc content and recurs on every run.

## Fix

Add the two hosts to the existing `exclude` list in `.lychee.toml`, following the file's established pattern of host-specific excludes with an explanatory comment (as already done for `olcf.ornl.gov` → 503, `sc22.supercomputing.org` → 415, etc.).

Targeted host excludes are preferred over globally accepting `403` (which would mask genuinely dead links elsewhere in the docs).