### PR TITLE
fix(post): exchange chemistry temperature seam ghosts for chemistry

### DIFF
--- a/src/common/m_mpi_common.fpp
+++ b/src/common/m_mpi_common.fpp
@@ -571,7 +571,14 @@ contains
             v_size = nVar + 2*nb*nnode
             buffer_counts = (/buff_size*v_size*(n + 1)*(p + 1), buff_size*v_size*(m + 2*buff_size + 1)*(p + 1), &
                              & buff_size*v_size*(m + 2*buff_size + 1)*(n + 2*buff_size + 1)/)
+#ifdef MFC_SIMULATION
         else if (present(q_T_sf) .and. chemistry .and. chem_params%diffusion) then
+#else
+        else if (present(q_T_sf) .and. chemistry) then
+            ! post_process converts cons->prim over the ghost-inclusive bounds, so the temperature
+            ! Newton guess must be valid at rank seams for EVERY chemistry run (not only diffusion):
+            ! an unexchanged seam ghost is an uninitialized guess -> NaN T/pres/c in the output
+#endif
             chem_diff_comm = .true.
             v_size = nVar + 1
             buffer_counts = (/buff_size*v_size*(n + 1)*(p + 1), buff_size*v_size*(m + 2*buff_size + 1)*(p + 1), &

--- a/src/post_process/m_start_up.fpp
+++ b/src/post_process/m_start_up.fpp
@@ -155,7 +155,11 @@ contains
 
         call s_read_data_files(t_step)
 
-        if (chemistry) call s_compute_q_T_sf(q_T_sf, q_cons_vf, idwbuff)
+        ! seed the chemistry temperature over the INTERIOR only (mirrors the simulation,
+        ! m_start_up): the ghost q_cons is unread at this point, so a ghost-inclusive sweep
+        ! would Newton-iterate on garbage (NaN under NaN-init builds) at rank seams and
+        ! physical boundaries; s_populate_variables_buffers below extends q_T into the ghosts
+        if (chemistry) call s_compute_q_T_sf(q_T_sf, q_cons_vf, idwint)
 
         if (buff_size > 0) then
             call s_populate_grid_variables_buffers()


### PR DESCRIPTION
`post_process` converts conservative → primitive variables over the **ghost-inclusive** bounds, so the temperature Newton guess must be valid at rank seams for **every** chemistry run. Previously the temperature seam ghost was exchanged only when `chem_params%diffusion` was set, so a multi-rank **non-diffusion** chemistry run left the rank-seam Newton guess uninitialized → `NaN` temperature / pressure / sound-speed in the output.

**Fix:**
- `m_mpi_common`: exchange the temperature seam ghost for any chemistry run in `post_process` (simulation keeps the diffusion-only condition, since it does not convert over the ghost shell) via an `#ifdef MFC_SIMULATION` split.
- `post_process/m_start_up`: seed `q_T` over the interior (`idwint`) rather than the ghost-inclusive bounds (`idwbuff`) — the ghost `q_cons` is unread at that point, so a ghost-inclusive Newton sweep iterates on uninitialized data; `s_populate_variables_buffers` extends `q_T` into the ghosts afterward.

Extracted as a standalone fix from the AMR/scaling work (`up/mega`); the AMR-specific coupling in the original change was dropped for this general fix. CI runs the full matrix as the gate.
