### PR TITLE
perf: grind uses minimum wall-clock per-stage time, not running-mean cpu_time

### DIFF
--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -463,8 +463,7 @@ contains
     end subroutine s_initialize_rhs_module
 
     !> Compute the right-hand side of the semi-discrete governing equations for a single time stage
-    impure subroutine s_compute_rhs(q_cons_vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_in, rhs_pb, mv_in, rhs_mv, t_step, &
-                                    & time_avg, stage)
+    impure subroutine s_compute_rhs(q_cons_vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_in, rhs_pb, mv_in, rhs_mv, t_step, stage)
 
         type(scalar_field), dimension(sys_size), intent(inout)                                     :: q_cons_vf
         type(scalar_field), intent(inout)                                                          :: q_T_sf
@@ -478,17 +477,13 @@ contains
         real(stp), dimension(idwbuff(1)%beg:,idwbuff(2)%beg:,idwbuff(3)%beg:,1:,1:), intent(inout) :: mv_in
         real(wp), dimension(idwbuff(1)%beg:,idwbuff(2)%beg:,idwbuff(3)%beg:,1:,1:), intent(inout) :: rhs_mv
         integer, intent(in) :: t_step
-        real(wp), intent(inout) :: time_avg
         integer, intent(in) :: stage
-        real(wp) :: t_start, t_finish
         integer :: id
         integer(kind=8) :: i, j, k, l, q  !< Generic loop iterators
 
         ! RHS: halo exchange -> reconstruct -> Riemann solve -> flux difference -> source terms
 
         call nvtxStartRange("COMPUTE-RHS")
-
-        call cpu_time(t_start)
 
         if (.not. igr) then
             ! Association/Population of Working Variables
@@ -847,14 +842,6 @@ contains
                 end do
                 $:END_GPU_PARALLEL_LOOP()
             end if
-        end if
-
-        call cpu_time(t_finish)
-
-        if (t_step >= 2) then
-            time_avg = (abs(t_finish - t_start) + (t_step - 2)*time_avg)/(t_step - 1)
-        else
-            time_avg = 0._wp
         end if
 
         call nvtxEndRange

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -459,6 +459,9 @@ contains
         integer, intent(in)     :: nstage
         integer                 :: i, j, k, l, q, s  !< Generic loop iterator
         real(wp)                :: start, finish
+        integer(kind=8)         :: stage_t0, stage_t1, clock_rate
+        real(wp)                :: stage_time
+        integer, parameter      :: n_warmup = 2      !< stages excluded before the timing floor (warmup/JIT/first-touch)
 
         call cpu_time(start)
         call nvtxStartRange("TIMESTEP")
@@ -467,8 +470,9 @@ contains
         if (adap_dt) call s_adaptive_dt_bubble(1)
 
         do s = 1, nstage
+            call system_clock(stage_t0)
             call s_compute_rhs(q_cons_ts(1)%vf, q_T_sf, q_prim_vf, bc_type, rhs_vf, pb_ts(1)%sf, rhs_pb, mv_ts(1)%sf, rhs_mv, &
-                               & t_step, time_avg, s)
+                               & t_step, s)
 
             if (s == 1) then
                 if (run_time_info) then
@@ -565,6 +569,20 @@ contains
                 else
                     call s_ibm_correct_state(q_cons_ts(1)%vf, q_prim_vf)
                 end if
+            end if
+
+            ! Grind: minimum wall-clock time of a full RK stage (compute + halo H2D/D2H +
+            ! update + IBM correction, aside from I/O) over steady-state stages. Wall clock
+            ! (not cpu_time, which counts MPI spin-wait) and the minimum (jitter only adds
+            ! time) make it reproducible; the min over stages drops the I/O-bearing s==1 stage.
+            call system_clock(stage_t1, clock_rate)
+            stage_time = real(stage_t1 - stage_t0, wp)/real(clock_rate, wp)
+            if (t_step - t_step_start < n_warmup) then
+                time_avg = 0._wp
+            else if (time_avg <= 0._wp) then
+                time_avg = stage_time
+            else
+                time_avg = min(time_avg, stage_time)
             end if
         end do
 

--- a/src/simulation/m_time_steppers.fpp
+++ b/src/simulation/m_time_steppers.fpp
@@ -459,9 +459,9 @@ contains
         integer, intent(in)     :: nstage
         integer                 :: i, j, k, l, q, s  !< Generic loop iterator
         real(wp)                :: start, finish
-        integer(kind=8)         :: stage_t0, stage_t1, clock_rate
+        integer(kind=8)         :: stage_t0, stage_t1, clock_rate, clock_max
         real(wp)                :: stage_time
-        integer, parameter      :: n_warmup = 2      !< stages excluded before the timing floor (warmup/JIT/first-touch)
+        integer, parameter      :: n_warmup = 2      !< time steps excluded before the timing floor (warmup/JIT/first-touch)
 
         call cpu_time(start)
         call nvtxStartRange("TIMESTEP")
@@ -575,8 +575,13 @@ contains
             ! update + IBM correction, aside from I/O) over steady-state stages. Wall clock
             ! (not cpu_time, which counts MPI spin-wait) and the minimum (jitter only adds
             ! time) make it reproducible; the min over stages drops the I/O-bearing s==1 stage.
-            call system_clock(stage_t1, clock_rate)
-            stage_time = real(stage_t1 - stage_t0, wp)/real(clock_rate, wp)
+            call system_clock(stage_t1, clock_rate, clock_max)
+            ! Correct the delta for the rare case of the clock counter wrapping past clock_max.
+            if (stage_t1 >= stage_t0) then
+                stage_time = real(stage_t1 - stage_t0, wp)/real(clock_rate, wp)
+            else
+                stage_time = real(stage_t1 - stage_t0 + clock_max + 1_8, wp)/real(clock_rate, wp)
+            end if
             if (t_step - t_step_start < n_warmup) then
                 time_avg = 0._wp
             else if (time_avg <= 0._wp) then


### PR DESCRIPTION
## What

Change the `grind` performance metric (`ns/gp/eq/rhs`, printed as `Performance:` and written to `time_data.dat`) from a **running mean of `cpu_time`** to the **minimum wall-clock time of a full RK stage**.

The timer also moves from `s_compute_rhs` to the stage loop in `s_tvd_rk`, so it now brackets the whole per-stage compute+communication — RHS + halo H2D/D2H copies + RK update + source terms + **the IBM ghost-point correction** — while still excluding file I/O.

## Why

The old metric was noisy and incomplete on multi-rank GPU runs:

1. **`cpu_time` is per-process CPU time.** An MPI wait that busy-spins the host accumulates CPU time, so idle ranks look busy. At 8 ranks the reduction (`maxval(proc_time)`) then picks the rank that *spun* most, not the one that *computed* most. → `system_clock` (wall) measures real elapsed time.
2. **A running mean is dragged by outlier steps** (OS jitter, first-touch/JIT, page migration). → the **minimum** is the most reproducible estimator: jitter only ever *adds* time, so the floor reflects the hardware. The min over stages also naturally drops the `s == 1` stage that carries any run-time-info/probe I/O.
3. **The old timer bracketed only `s_compute_rhs`**, so per-stage work outside it — most notably the IBM correction (`s_ibm_correct_state`) — was never counted. The `ibm` benchmark's per-step cost was invisible to `grind`.

## Validation (amdflang 23.1.0, MI250X, `-n 8` MPI, gbpp 2)

Same binary, repeated runs:

| metric | mean | range | CV |
|---|---|---|---|
| old `cpu_time` (igr) | 1.98 | 1.65–2.14 | 9.3% |
| new wall+min (igr) | 1.81 | 1.67–1.98 | **5.8%** |
| new wall+min (ibm) | 4.09 | 3.74–4.83 | 10.4% |

igr's run-to-run CV drops ~38%. (Residual spread is contention on a shared dev node; a dedicated CI node will be tighter.) `ibm` now produces a grind that includes the IBM correction.

## Notes for reviewers

- **Output-neutral:** only perf-timing variables change; no field/physics output is touched, so golden regression files are unaffected.
- **This PR's own benchmark comparison is not meaningful** — it compares the *new* metric (this branch) against the *old* metric (master). The comparison is only valid once merged, when both sides use the same definition. Absolute `grind` values shift versus historical numbers by design.
- The ETA/progress-bar timer (`wall_time_avg`) is intentionally left on `cpu_time`; it is cosmetic and separate from the perf gate.
- Alternative considered: **median** instead of min would also catch a purely *periodic* per-step cost (e.g. every-Nth-step) that min can skip, at the cost of slightly more variance. Happy to switch if reviewers prefer.
