### PR TITLE
Fixes #1656: preserve MHD calculations with case optimization

### DIFF
--- a/src/simulation/m_riemann_solver_hll.fpp
+++ b/src/simulation/m_riemann_solver_hll.fpp
@@ -258,7 +258,7 @@ contains
                             else if (mhd .and. relativity) then
                                 Ga%L = 1._wp/sqrt(1._wp - vel_L_rms)
                                 Ga%R = 1._wp/sqrt(1._wp - vel_R_rms)
-                                #:if not MFC_CASE_OPTIMIZATION or num_dims > 2
+                                #:if not MFC_CASE_OPTIMIZATION or num_vels > 2
                                     vdotB%L = vel_L(1)*B%L(1) + vel_L(2)*B%L(2) + vel_L(3)*B%L(3)
                                     vdotB%R = vel_R(1)*B%R(1) + vel_R(2)*B%R(2) + vel_R(3)*B%R(3)
 
@@ -274,7 +274,7 @@ contains
                                 ! Hard-coded EOS
                                 H_L = 1._wp + (gamma_L + 1)*pres_L/rho_L
                                 H_R = 1._wp + (gamma_R + 1)*pres_R/rho_R
-                                #:if not MFC_CASE_OPTIMIZATION or num_dims > 2
+                                #:if not MFC_CASE_OPTIMIZATION or num_vels > 2
                                     cm%L(1:3) = (rho_L*H_L*Ga%L**2 + B2%L)*vel_L(1:3) - vdotB%L*B%L(1:3)
                                     cm%R(1:3) = (rho_R*H_R*Ga%R**2 + B2%R)*vel_R(1:3) - vdotB%R*B%R(1:3)
                                 #:endif
@@ -282,7 +282,7 @@ contains
                                 E_L = rho_L*H_L*Ga%L**2 - pres_L + 0.5_wp*(B2%L + vel_L_rms*B2%L - vdotB%L**2._wp) - rho_L*Ga%L
                                 E_R = rho_R*H_R*Ga%R**2 - pres_R + 0.5_wp*(B2%R + vel_R_rms*B2%R - vdotB%R**2._wp) - rho_R*Ga%R
                             else if (mhd .and. .not. relativity) then
-                                #:if not MFC_CASE_OPTIMIZATION or num_dims > 2
+                                #:if not MFC_CASE_OPTIMIZATION or num_vels > 2
                                     pres_mag%L = 0.5_wp*(B%L(1)**2._wp + B%L(2)**2._wp + B%L(3)**2._wp)
                                     pres_mag%R = 0.5_wp*(B%R(1)**2._wp + B%R(2)**2._wp + B%R(3)**2._wp)
                                 #:endif
@@ -490,7 +490,7 @@ contains
                             ! Energy
                             if (mhd .and. (.not. relativity)) then
                                 ! energy flux = (E + p + p_mag) * v_${XYZ}$ - B_${XYZ}$ * (v_x*B_x + v_y*B_y + v_z*B_z)
-                                #:if not MFC_CASE_OPTIMIZATION or num_dims > 2
+                                #:if not MFC_CASE_OPTIMIZATION or num_vels > 2
                                     flux_rsx_vf(${SF('')}$, &
                                                 & eqn_idx%E) = (s_M*(vel_R(norm_dir)*(E_R + pres_R + pres_mag%R) - B%R(norm_dir) &
                                                 & *(vel_R(1)*B%R(1) + vel_R(2)*B%R(2) + vel_R(3)*B%R(3))) - s_P*(vel_L(norm_dir) &

--- a/src/simulation/m_riemann_solver_lf.fpp
+++ b/src/simulation/m_riemann_solver_lf.fpp
@@ -251,7 +251,7 @@ contains
                                 H_L = (E_L + pres_L)/rho_L
                                 H_R = (E_R + pres_R)/rho_R
                             else if (mhd .and. relativity) then
-                                #:if not MFC_CASE_OPTIMIZATION or num_dims > 2
+                                #:if not MFC_CASE_OPTIMIZATION or num_vels > 2
                                     Ga%L = 1._wp/sqrt(1._wp - vel_L_rms)
                                     Ga%R = 1._wp/sqrt(1._wp - vel_R_rms)
                                     vdotB%L = vel_L(1)*B%L(1) + vel_L(2)*B%L(2) + vel_L(3)*B%L(3)
@@ -392,7 +392,7 @@ contains
                             ! Energy
                             if (mhd .and. (.not. relativity)) then
                                 ! energy flux = (E + p + p_mag) * v_${XYZ}$ - B_${XYZ}$ * (v_x*B_x + v_y*B_y + v_z*B_z)
-                                #:if not MFC_CASE_OPTIMIZATION or num_dims > 1
+                                #:if not MFC_CASE_OPTIMIZATION or num_vels > 2
                                     flux_rsx_vf(${SF('')}$, &
                                                 & eqn_idx%E) = (s_M*(vel_R(norm_dir)*(E_R + pres_R + pres_mag%R) - B%R(norm_dir) &
                                                 & *(vel_R(1)*B%R(1) + vel_R(2)*B%R(2) + vel_R(3)*B%R(3))) - s_P*(vel_L(norm_dir) &


### PR DESCRIPTION
## Description

Replace case-optimization guards based on `num_dims` with guards based on `num_vels` for three-component MHD calculations in the HLL and LF Riemann solvers.

MFC retains three velocity and magnetic-field components in 1D and 2D MHD cases. The previous dimensional guards compiled out required magnetic-pressure, relativistic-state, and energy-flux calculations in case-optimized lower-dimensional builds, causing the standard 2D MHD rotor example to produce NaNs.

The revised guards continue pruning three-component expressions from optimized lower-dimensional non-MHD builds while retaining them when `num_vels=3`.

Closes #1656.

## Type of change

- Bug fix

## Testing

Tested with GNU Fortran 13.3.0 and Open MPI 4.1.6 on CPU with the following case-optimized HLL MHD cases:

- 2D ideal-MHD rotor:
```bash
./mfc.sh run examples/2D_mhd_rotor/case.py \
  -t pre_process simulation -n 1 -j 1 \
  --no-debug --no-gpu --case-optimization
```
- 1D ideal-MHD Brio–Wu:
```
./mfc.sh run examples/1D_brio_wu/case.py \
  -t pre_process simulation -n 1 -j 1 \
  --no-debug --no-gpu --case-optimization
```
- 1D ideal-MHD Dai–Woodward:
```
./mfc.sh run examples/1D_dai_woodward/case.py \
  -t pre_process simulation -n 1 -j 1 \
  --no-debug --no-gpu --case-optimization
```
- 2D ideal-MHD Orszag–Tang:
```
./mfc.sh run examples/2D_orszag_tang/case.py \
  -t pre_process simulation -n 1 -j 1 \
  --no-debug --no-gpu --case-optimization
```
- Reduced 1D relativistic-MHD case:
```
./mfc.sh run tests/E0015186/case.py \
  -t pre_process simulation -n 1 -j 1 \
  --no-debug --no-gpu --case-optimization
```
- Reduced 2D relativistic-MHD case:
```
./mfc.sh run tests/33FA33BE/case.py \
  -t pre_process simulation -n 1 -j 1 \
  --no-debug --no-gpu --case-optimization
```
All cases completed successfully with exit code 0. These runs cover the corrected HLL paths for ideal and relativistic MHD in both 1D and 2D.

## Checklist

__Check these like this `[x]` to indicate which of the below applies.__

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed

See the [developer guide](https://mflowcode.github.io/documentation/contributing.html) for full coding standards.

<details>
<summary><strong>GPU changes</strong> (expand if you modified <code>src/simulation/</code>)</summary>

- [ ] GPU results match CPU results
- [ ] Tested on NVIDIA GPU or AMD GPU

</details>

## AI code reviews

Reviews are not retriggered automatically. To request a review, comment on the PR:
- `@claude full review` — Claude full review (also triggers on PR open/reopen/ready)
- Or add label `claude-full-review` — Claude full review via label

