### PR TITLE
Explicit per-fluid equation-of-state selector

### DIFF
--- a/docs/documentation/case.md
+++ b/docs/documentation/case.md
@@ -450,6 +450,8 @@ The parameters define material's property of compressible fluids that are used i
 
 - `fluid_pp(i)%%gamma` and `fluid_pp(i)%%pi_inf` define \f$\Gamma\f$ and \f$\Pi\f$ as parameters of $i$-th fluid that are used in stiffened gas equation of state.
 
+- `fluid_pp(i)%%eos` selects the equation of state of the $i$-th fluid. Only `stiffened_gas` (the default) and `ideal_gas_mixture` (requires a chemistry build, backed by Pyrometheus) are currently supported; the enumeration reserves `mie_gruneisen`, `jwl`, and `table` for future backends. Every fluid in a run must use the same family.
+
 - `fluid_pp(i)%%Re(1)` and `fluid_pp(i)%%Re(2)` define the shear and volume viscosities of $i$-th fluid, respectively.
 
 When these parameters are undefined, fluids are treated as inviscid.

--- a/src/common/m_checker_common.fpp
+++ b/src/common/m_checker_common.fpp
@@ -25,11 +25,29 @@ contains
 #ifndef MFC_SIMULATION
         call s_check_total_cells
 #endif
+        call s_check_eos
         #:if USING_AMD
             call s_check_amd
         #:endif
 
     end subroutine s_check_inputs_common
+
+    !> Restrict the per-fluid EOS selector to the currently supported adapters. Only stiffened_gas (non-chemistry) and
+    !! ideal_gas_mixture (chemistry) are backed by a thermodynamics backend, and a single run uses one family for every fluid, so
+    !! the unimplemented values and any intra-cell EOS mixing are both rejected here.
+    impure subroutine s_check_eos
+
+        integer :: i
+
+        do i = 1, num_fluids
+            @:PROHIBIT(chemistry .and. fluid_pp(i)%eos /= eos_ideal_gas_mixture, &
+                       & "fluid_pp(:)%eos must be 'ideal_gas_mixture' for every fluid when chemistry is enabled")
+            @:PROHIBIT(.not. chemistry .and. fluid_pp(i)%eos /= eos_stiffened_gas, &
+                       & "fluid_pp(:)%eos selector is not supported; only 'stiffened_gas' is available " &
+                       & // "(or 'ideal_gas_mixture' with a chemistry build)")
+        end do
+
+    end subroutine s_check_eos
 
 #ifndef MFC_SIMULATION
     !> Verify that the total number of grid cells meets the minimum required by the number of dimensions and MPI ranks.

--- a/src/common/m_constants.fpp
+++ b/src/common/m_constants.fpp
@@ -114,6 +114,15 @@ module m_constants
     integer, parameter :: BC_NO_SLIP_WALL = -16
     integer, parameter :: BC_DIRICHLET = -17
 
+    ! Equation-of-state selector (fluid_pp(:)%eos). Values must match _EOS_NAMES in
+    ! toolchain/mfc/params/definitions.py. Only stiffened_gas and ideal_gas_mixture
+    ! are currently backed by a thermodynamics adapter.
+    integer, parameter :: eos_stiffened_gas = 1
+    integer, parameter :: eos_ideal_gas_mixture = 2
+    integer, parameter :: eos_mie_gruneisen = 3
+    integer, parameter :: eos_jwl = 4
+    integer, parameter :: eos_table = 5
+
     ! Synthetic turbulence array size limits
     integer, parameter :: num_synth_shells_max = 50  !< Max energy shells for synthetic turbulence
     integer, parameter :: num_turb_sources_max = 10  !< Max Gaussian forcing zones for synthetic turbulence

--- a/src/common/m_derived_types.fpp
+++ b/src/common/m_derived_types.fpp
@@ -379,6 +379,7 @@ module m_derived_types
     !> Derived type annexing the physical parameters (PP) of the fluids. These include the specific heat ratio function and liquid
     !! stiffness function.
     type physical_parameters
+        integer                :: eos            !< Equation of state selector (eos_* in m_constants)
         real(wp)               :: gamma          !< Sp. heat ratio
         real(wp)               :: pi_inf         !< Liquid stiffness
         real(wp), dimension(2) :: Re             !< Reynolds number

--- a/src/common/m_global_parameters_common.fpp
+++ b/src/common/m_global_parameters_common.fpp
@@ -16,7 +16,7 @@ module m_global_parameters_common
     use m_derived_types
     use m_thermochem, only: num_species
     use m_constants, only: model_eqns_gamma_law, model_eqns_5eq, model_eqns_6eq, model_eqns_4eq, recon_type_weno, &
-        & recon_type_muscl, name_len, dflt_int, dflt_real
+        & recon_type_muscl, name_len, dflt_int, dflt_real, eos_stiffened_gas, eos_ideal_gas_mixture
 
     implicit none
 

--- a/src/post_process/m_global_parameters.fpp
+++ b/src/post_process/m_global_parameters.fpp
@@ -211,6 +211,7 @@ contains
             fluid_pp(i)%cv = 0._wp
             fluid_pp(i)%qv = 0._wp
             fluid_pp(i)%qvp = 0._wp
+            fluid_pp(i)%eos = merge(eos_ideal_gas_mixture, eos_stiffened_gas, chemistry)
             fluid_pp(i)%G = dflt_real
             fluid_pp(i)%non_newtonian = .false.
             fluid_pp(i)%K = dflt_real

--- a/src/pre_process/m_global_parameters.fpp
+++ b/src/pre_process/m_global_parameters.fpp
@@ -392,6 +392,7 @@ contains
             fluid_pp(i)%cv = 0._wp
             fluid_pp(i)%qv = 0._wp
             fluid_pp(i)%qvp = 0._wp
+            fluid_pp(i)%eos = merge(eos_ideal_gas_mixture, eos_stiffened_gas, chemistry)
             fluid_pp(i)%G = 0._wp
             fluid_pp(i)%non_newtonian = .false.
             fluid_pp(i)%K = dflt_real

--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -430,6 +430,7 @@ contains
             fluid_pp(i)%cv = 0._wp
             fluid_pp(i)%qv = 0._wp
             fluid_pp(i)%qvp = 0._wp
+            fluid_pp(i)%eos = merge(eos_ideal_gas_mixture, eos_stiffened_gas, chemistry)
             fluid_pp(i)%Re(:) = dflt_real
             fluid_pp(i)%G = 0._wp
             fluid_pp(i)%non_newtonian = .false.

--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -42,6 +42,16 @@ PHYSICS_DOCS = {
         "explanation": ("MFC uses the transformed stiffened gas parameter. A common mistake is entering the physical gamma (e.g., 1.4 for air) instead of the transformed value 1/(gamma-1) = 2.5."),
         "references": ["Wilfong26", "Allaire02"],
     },
+    "check_eos": {
+        "title": "Equation of State Selection",
+        "category": "Thermodynamic Constraints",
+        "explanation": (
+            "The per-fluid eos selector exposes only the backends with a thermodynamics adapter: "
+            "'stiffened_gas' (default) and 'ideal_gas_mixture' (chemistry, Pyrometheus). A single run "
+            "uses one family for every fluid; unimplemented values and intra-cell EOS mixing are rejected."
+        ),
+        "references": ["Wilfong26"],
+    },
     "check_patch_physics": {
         "title": "Patch Initial Condition Constraints",
         "category": "Thermodynamic Constraints",
@@ -729,6 +739,27 @@ class CaseValidator:
             if model_eqns == 1:
                 self.prohibit(gamma is not None, f"model_eqns = 1 does not support fluid_pp({i})%gamma")
                 self.prohibit(pi_inf is not None, f"model_eqns = 1 does not support fluid_pp({i})%pi_inf")
+
+    def check_eos(self):
+        """Restricts the per-fluid EOS selector to the currently supported adapters"""
+        num_fluids = self.get("num_fluids")
+        chemistry = self.get("chemistry", "F") == "T"
+
+        if num_fluids is None:
+            return
+
+        eos_stiffened_gas, eos_ideal_gas_mixture = 1, 2
+
+        for i in range(1, num_fluids + 1):
+            eos = self.get(f"fluid_pp({i})%eos")
+            if eos is None:
+                continue
+            self.prohibit(
+                eos not in (eos_stiffened_gas, eos_ideal_gas_mixture),
+                f"fluid_pp({i})%eos selects an equation of state that is not yet implemented; " "only 'stiffened_gas' and 'ideal_gas_mixture' are available",
+            )
+            self.prohibit(chemistry and eos != eos_ideal_gas_mixture, f"fluid_pp({i})%eos must be 'ideal_gas_mixture' when chemistry is enabled")
+            self.prohibit(not chemistry and eos == eos_ideal_gas_mixture, f"fluid_pp({i})%eos = 'ideal_gas_mixture' requires a chemistry build")
 
     def check_surface_tension(self):
         """Checks constraints on surface tension"""
@@ -2277,6 +2308,7 @@ class CaseValidator:
         self.check_phase_change()
         self.check_ibm()
         self.check_stiffened_eos()
+        self.check_eos()
         self.check_eos_parameter_sanity()
         self.check_surface_tension()
         self.check_mhd()

--- a/toolchain/mfc/params/definitions.py
+++ b/toolchain/mfc/params/definitions.py
@@ -113,6 +113,7 @@ HINTS = {
         "cv": "Specific heat at constant volume",
         "qv": "Heat of formation",
         "qvp": "Heat of formation derivative",
+        "eos": "Equation of state selector",
     },
 }
 
@@ -385,6 +386,17 @@ CONSTRAINTS = {
     "n": {"min": 0},
     "p": {"min": 0},
 }
+
+# Per-fluid equation-of-state selector. The enumeration is stable (its integer
+# values must match the eos_* constants hand-written in src/common/m_constants.fpp);
+# only stiffened_gas and ideal_gas_mixture are currently backed by a thermodynamics
+# adapter, so the remaining values are rejected explicitly in the checkers. The
+# constants are NOT auto-generated from here: generate_constants_fpp skips compound
+# keys, so these entries only drive readable-name resolution and validation.
+_EOS_VALUE_LABELS = {1: "stiffened-gas", 2: "ideal-gas mixture", 3: "Mie-Grueneisen", 4: "JWL", 5: "tabulated"}
+_EOS_NAMES = {"stiffened_gas": 1, "ideal_gas_mixture": 2, "mie_gruneisen": 3, "jwl": 4, "table": 5}
+for _f in range(1, NF + 1):
+    CONSTRAINTS[f"fluid_pp({_f})%eos"] = {"choices": [1, 2, 3, 4, 5], "value_labels": _EOS_VALUE_LABELS, "names": _EOS_NAMES}
 
 # Parameter dependencies (requires, recommends)
 DEPENDENCIES = {
@@ -876,6 +888,7 @@ def _load():
         px = f"fluid_pp({f})%"
         for a, sym in [("gamma", r"\f$\gamma_k\f$"), ("pi_inf", r"\f$\pi_{\infty,k}\f$"), ("cv", r"\f$c_{v,k}\f$"), ("qv", r"\f$q_{v,k}\f$"), ("qvp", r"\f$q'_{v,k}\f$")]:
             _r(f"{px}{a}", REAL, math=sym)
+        _r(f"{px}eos", INT, math=r"\f$\mathrm{EOS}_k\f$")
         _r(f"{px}G", REAL, {"elasticity"}, math=r"\f$G_k\f$")
         _r(f"{px}Re(1)", REAL, {"viscosity"}, math=r"\f$\mathrm{Re}_k\f$ (shear)")
         _r(f"{px}Re(2)", REAL, {"viscosity"}, math=r"\f$\mathrm{Re}_k\f$ (bulk)")

--- a/toolchain/mfc/params/descriptions.py
+++ b/toolchain/mfc/params/descriptions.py
@@ -338,6 +338,7 @@ PATTERNS = [
     (r"fluid_pp\((\d+)\)%cv", "Specific heat at constant volume for fluid {0}"),
     (r"fluid_pp\((\d+)\)%qv", "Heat of formation for fluid {0}"),
     (r"fluid_pp\((\d+)\)%qvp", "Heat of formation prime for fluid {0}"),
+    (r"fluid_pp\((\d+)\)%eos", "Equation of state selector for fluid {0}"),
     (r"fluid_pp\((\d+)\)%Re\((\d+)\)", "Reynolds number component {1} for fluid {0}"),
     (r"fluid_pp\((\d+)\)%non_newtonian", "Enable Herschel-Bulkley non-Newtonian viscosity for fluid {0}"),
     (r"fluid_pp\((\d+)\)%K", "HB consistency index for fluid {0}"),

--- a/toolchain/mfc/params/generators/fortran_gen.py
+++ b/toolchain/mfc/params/generators/fortran_gen.py
@@ -153,6 +153,10 @@ def generate_constants_fpp() -> str:
 
     lines = [_HEADER.rstrip()]
     for param in sorted(CONSTRAINTS):
+        # Compound keys (e.g. fluid_pp(1)%eos) cannot form valid Fortran identifiers;
+        # their enum constants are hand-written in m_constants.fpp instead.
+        if "%" in param or "(" in param:
+            continue
         names = CONSTRAINTS[param].get("names")
         if not names:
             continue


### PR DESCRIPTION
## Description

Second step of the incremental multi-equation-of-state (EOS) interface: an explicit, stable per-fluid EOS selector in place of scattered booleans. Each fluid carries an integer `fluid_pp(i)%eos` drawn from a five-value enumeration:

| Name | Value | Status |
|---|---|---|
| `stiffened_gas` | 1 | exposed (default) |
| `ideal_gas_mixture` | 2 | exposed (chemistry) |
| `mie_gruneisen` | 3 | reserved, rejected |
| `jwl` | 4 | reserved, rejected |
| `table` | 5 | reserved, rejected |

Only the already-supported backends are exposed: stiffened gas stays the default, and `ideal_gas_mixture` (Pyrometheus) is used when `chemistry = T`. The remaining three values are defined for forward compatibility but explicitly rejected at validation, so no unsupported combination can be selected. Case files use readable names, e.g. `"fluid_pp(1)%eos": "stiffened_gas"`; the integer representation is internal.

No hot-path change: `%eos` is written as a default and read only in validation, never in a flux / Riemann / pressure / RHS path. The default `merge(eos_ideal_gas_mixture, eos_stiffened_gas, chemistry)` reproduces prior solver assumptions exactly, so results are unchanged.

Unsupported `(eos, feature)` combinations are rejected in both layers, correctly placed: the shared Fortran runtime checker (`s_check_eos` in `m_checker_common.fpp`) and the Python static validator (`check_eos` in `case_validator.py`, with a `PHYSICS_DOCS` entry). The toolchain auto-generation is preserved, including a compound-key skip in `generate_constants_fpp` so the `fluid_pp(1)%eos` key does not emit an invalid Fortran identifier.

### Type of change

- New feature (non-breaking)

## Testing

Full golden suite bit-identical across all three targets (pre_process, simulation, post_process) on gfortran; no golden files changed, since `%eos` never enters a numerical path. Validation behavior: unsupported `(eos, feature)` pairs are rejected with a clear message, readable names resolve to the enum, and a chemistry case resolves to `ideal_gas_mixture`.

This PR is independent of #1663 (central thermodynamics interface): the branch sits directly on `master`, shares no symbols with that PR, and the two touch `m_global_parameters_common.fpp` only in disjoint regions, so they can be reviewed and merged in either order.


## Related

Part of the incremental EOS ladder tracked in #1638. Ladder so far: PR 1 #1663 (central thermodynamics interface), PR 2 #1664 (explicit EOS selector), PR 3 #1665 (generic Mie-Gruneisen core); JWL follows as a Mie-Gruneisen reference curve. The three open PRs are independent and can be reviewed in parallel.
