### PR TITLE
Fix incorrect parameter name Tw_out -> Twall_out in validator message

### DIFF
--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -1550,7 +1550,7 @@ class CaseValidator:
                 tw_out = self.get(f"bc_{dir}%Twall_out")
                 self.prohibit(tw_out is None, f"Isothermal Out (bc_{dir}%isothermal_out) requires a wall temperature to be set (e.g., bc_{dir}%Twall_out).")
                 if tw_out is not None and self._is_numeric(tw_out):
-                    self.prohibit(tw_out <= 0.0, f"Wall temperature bc_{dir}%Tw_out must be strictly positive for thermodynamics (got {tw_out}).")
+                    self.prohibit(tw_out <= 0.0, f"Wall temperature bc_{dir}%Twall_out must be strictly positive for thermodynamics (got {tw_out}).")
 
     def check_misc_pre_process(self):
         """Checks miscellaneous pre-process constraints"""


### PR DESCRIPTION
## Description
The isothermal-out wall-temperature positivity check in
`toolchain/mfc/case_validator.py` printed a parameter name that does not
exist. The value is correctly fetched as `bc_{dir}%Twall_out`, but the
error string in the positivity `prohibit` call referred to
`bc_{dir}%Tw_out`. The actual parameter is `Twall_out` (defined in
`toolchain/mfc/params/definitions.py`); there is no `Tw_out` parameter.
A user setting a non-positive exit wall temperature was told to fix a
parameter that doesn't exist, misdirecting the fix.

This changes the message string from `bc_{dir}%Tw_out` to
`bc_{dir}%Twall_out`, matching the parallel `Twall_in` branch. The change
is diagnostic-message-only — no validation logic is affected, and it is
output-neutral / golden-file-safe.

Closes #1480.

### Type of change
- Bug fix

## Testing
This is a diagnostic-string-only change with no effect on control flow or
numerical output, so no case results change. I verified it by:
- Confirming `Tw_out` appeared exactly once in the codebase (the incorrect
  message) and that `Twall_out` is the parameter actually defined in
  `toolchain/mfc/params/definitions.py`.
- Reviewing `git diff` to confirm the change is a single line, with no
  unrelated or line-ending changes.

## Checklist
__Check these like this `[x]` to indicate which of the below applies.__
- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed

_Neither applies: no behavior changes (message text only), and no
user-facing documentation references this string._

See the [developer guide](https://mflowcode.github.io/documentation/contributing.html) for full coding standards.

<details>
<summary><strong>GPU changes</strong> (expand if you modified <code>src/simulation/</code>)</summary>
- [ ] GPU results match CPU results
- [ ] Tested on NVIDIA GPU or AMD GPU
</details>

_No changes to `src/simulation/`; GPU section not applicable._

## AI code reviews
Reviews are not retriggered automatically. To request a review, comment on the PR:
- `@claude full review` — Claude full review (also triggers on PR open/reopen/ready)
- Or add label `claude-full-review` — Claude full review via label