### PR TITLE
fix(container): disable -Mfprelaxed in container builds (NVHPC 24.5 RSQRT14 ICE)

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -51,6 +51,11 @@ RUN python3.12 -m venv /opt/MFC/build/venv && \
     /opt/MFC/build/venv/bin/pip install --upgrade pip && \
     /opt/MFC/build/venv/bin/pip install numpy
 
+# Disable -Mfprelaxed for container builds only: NVHPC 24.5 crashes (llc RSQRT14
+# ICE, see cmake/GPU.cmake) on the GitHub Actions runner CPUs used to build these
+# images. Cluster/normal builds are unaffected.
+ENV MFC_CONTAINER_BUILD=1
+
 RUN echo "TARGET=$TARGET CC=$CC_COMPILER FC=$FC_COMPILER" && \
     cd /opt/MFC && \
     if [ "$TARGET" = "gpu" ]; then \

--- a/cmake/GPU.cmake
+++ b/cmake/GPU.cmake
@@ -151,8 +151,11 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
     # cannot select, crashing llc (signal 6) while building the release container
     # images (e.g. s_read_stl_binary in m_model.fpp). Skip -Mfprelaxed for
     # container builds only; cluster/normal builds are unaffected. The switch is
-    # set in .github/Dockerfile (MFC_CONTAINER_BUILD).
-    if (NOT DEFINED ENV{MFC_CONTAINER_BUILD})
+    # set in .github/Dockerfile (MFC_CONTAINER_BUILD=1). Read it as a boolean so a
+    # stray empty/0/false export doesn't silently drop the flag from a normal
+    # build; only a truthy value skips it.
+    set(_mfc_container_build "$ENV{MFC_CONTAINER_BUILD}")
+    if (NOT _mfc_container_build)
         add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-Mfprelaxed>)
     endif()
 

--- a/cmake/GPU.cmake
+++ b/cmake/GPU.cmake
@@ -143,8 +143,18 @@ elseif ((CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_Fortran_COMPILER_
         $<$<COMPILE_LANGUAGE:Fortran>:-cpp>
         $<$<COMPILE_LANGUAGE:Fortran>:-Minfo=inline>
         $<$<COMPILE_LANGUAGE:Fortran>:-Minfo=accel>
-        $<$<COMPILE_LANGUAGE:Fortran>:-Mfprelaxed>
     )
+
+    # -Mfprelaxed enables relaxed-precision FP, including the a/sqrt(b) ->
+    # a*rsqrt(b) idiom. On NVHPC 24.5 that idiom can emit an AVX-512 reciprocal-
+    # sqrt node (X86ISD::RSQRT14S) that the non-AVX-512 GitHub Actions runner CPUs
+    # cannot select, crashing llc (signal 6) while building the release container
+    # images (e.g. s_read_stl_binary in m_model.fpp). Skip -Mfprelaxed for
+    # container builds only; cluster/normal builds are unaffected. The switch is
+    # set in .github/Dockerfile (MFC_CONTAINER_BUILD).
+    if (NOT DEFINED ENV{MFC_CONTAINER_BUILD})
+        add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-Mfprelaxed>)
+    endif()
 
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(


### PR DESCRIPTION
## Description

The `Containerization` workflow fails on release (e.g. [run for v5.6.0](https://github.com/MFlowCode/MFC/actions/runs/30040679662)). The GPU image build crashes the NVHPC 24.5 compiler while building `pre_process`:

```
LLVM ERROR: Cannot select: v4f32 = X86ISD::RSQRT14S ... m_model.fpp:78
In function: m_model_s_read_stl_binary_
nvfortran-Fatal-.../llc TERMINATED by signal 6
```

**Root cause.** `-Mfprelaxed` enables relaxed-precision FP, including the `a/sqrt(b) -> a*rsqrt(b)` idiom. On NVHPC 24.5 the backend can emit an **AVX-512** reciprocal-sqrt node (`X86ISD::RSQRT14S`) for the STL-normal normalization in `s_read_stl_binary`, *even when targeting a non-AVX-512 CPU*. The GitHub Actions x86 runners are AMD Zen 3 (no AVX-512), so `llc` cannot select the node and aborts with signal 6. The `exit code: 143` / `Terminated` in the workflow annotations is downstream fallout, not the cause.

This is **not** a v5.6.0 code change — `m_model.fpp` is unchanged since v5.5.0, whose container build passed, as did the scheduled master build days earlier. The trigger is `-march=native` resolving to whichever runner CPU GitHub schedules; the current x86 fleet reproduces it deterministically (confirmed on two consecutive runs). The `arm` GPU job compiled the same file fine — consistent with an x86-only (`X86ISD`) codegen bug.

**Fix.** Gate `-Mfprelaxed` on a new `MFC_CONTAINER_BUILD` env var, set only in `.github/Dockerfile`. Container builds drop the flag for all NVHPC targets (so it doesn't matter which file would trip it); cluster/normal builds are completely unaffected. The affected code paths are cold geometry I/O, so relaxed FP there has no meaningful cost.

### Type of change

- Bug fix

## Testing

Diagnosed by reproducing the full toolchain locally (NVHPC 24.5) and confirming the crash is specific to the `-Mfprelaxed` rsqrt idiom under cross-module IPO on a non-AVX-512 target. The authoritative verification is this workflow itself: the `Containerization` job is the only environment that reproduces the crash, so a green run on this branch confirms the fix.

## Checklist

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed
