### PR TITLE
ci(claude): checkout with fetch-depth: 0 so the review bot works on fork PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,15 @@ jobs:
       actions: read
 
     steps:
+      # Check out with full history first. Without this, claude-code-action does its own
+      # shallow `git fetch --depth=20 pull/<n>/head`, which fails on fork PRs (the shallow
+      # base lacks the objects to reconcile), aborting the whole action. A fetch-depth: 0
+      # checkout gives the action the history it needs. Mirrors claude-code-review.yml.
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Description

The `Claude Code` workflow (`.github/workflows/claude.yml`) has no checkout step, so `anthropics/claude-code-action@v1` performs its own shallow `git fetch --depth=20 pull/<n>/head` to obtain the PR. On **fork PRs** that fetch fails — the shallow base lacks the objects needed to reconcile the PR head — and the whole action aborts before it can post a review:

```
Failed to compute SHA for <file>: Command failed: git hash-object <file>
##[error]Action failed with error: Command failed: git fetch origin --depth=20 pull/<n>/head
```

(Observed on #1670.)

This adds a full-history checkout (`fetch-depth: 0`) before the action, giving it the history it needs so the internal fetch succeeds. This mirrors the sibling `claude-code-review.yml`, which already checks out with `fetch-depth: 0` and does not hit this failure.

### Type of change

- Bug fix (CI)

## Testing

- YAML validated (`yaml.safe_load`).
- `./mfc.sh precheck` passes.
- One-line CI-only change; no source or toolchain behavior is affected.

## Checklist

- [x] I added or updated tests for new behavior — n/a (CI workflow fix)
- [x] I updated documentation if user-facing behavior changed — n/a
