### PR TITLE
Fix Python 3.9 fastjsonschema compatibility

### DIFF
--- a/toolchain/pyproject.toml
+++ b/toolchain/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "PyYAML",
     "argparse",
     "dataclasses",
-    "fastjsonschema",
+    "fastjsonschema<2.22; python_version < '3.10'",
+    "fastjsonschema; python_version >= '3.10'",
     "rapidfuzz",  # For "did you mean?" typo suggestions
 
     # Build System


### PR DESCRIPTION
## Description

Constrain `fastjsonschema` to versions below 2.22 on Python 3.9 while leaving Python 3.10 and newer unconstrained.

`fastjsonschema` 2.22.0 introduced PEP 604 type annotations such as `dict | bool`, which require Python 3.10, but the release does not declare a corresponding `Requires-Python` constraint. As a result, MFC's Python 3.9 compatibility job installs 2.22.0 and fails while importing `fastjsonschema`.

Upstream issue: https://github.com/horejsek/python-fastjsonschema/issues/211

Observed MFC failure: https://github.com/MFlowCode/MFC/actions/runs/30178357153/job/89730733375

### Type of change (delete unused ones)

- Bug fix

## Testing

- `uv pip compile toolchain/pyproject.toml --python-version 3.9` resolves `fastjsonschema==2.21.2`.
- `uv pip compile toolchain/pyproject.toml --python-version 3.10` resolves `fastjsonschema==2.22.0`.
- `./mfc.sh lint` -- 350 tests and 4 subtests passed.
- Commit precheck -- all seven checks passed.

## Checklist

__Check these like this `[x]` to indicate which of the below applies.__

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed

See the [developer guide](https://mflowcode.github.io/documentation/contributing.html) for full coding standards.

<details>
<summary><strong>GPU changes</strong> (expand if you modified <code>src/simulation/</code>)</summary>

- [ ] GPU results match CPU results
- [ ] Tested on NVIDIA GPU or AMD GPU

</details>

## AI code reviews

Reviews are not retriggered automatically. To request a review, comment on the PR:
- `@claude full review` — Claude full review (also triggers on PR open/reopen/ready)
- Or add label `claude-full-review` — Claude full review via label