### PR TITLE
build: base dependency and configure skips on real state, not CMakeCache.txt

### DIFF
--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -367,9 +367,21 @@ class MFCTarget:
         return os.sep.join([self.get_install_dirpath(case), "bin", self.name])
 
     def is_configured(self, case: Case) -> bool:
-        # We assume that if the CMakeCache.txt file exists, then the target is
-        # configured. (this isn't perfect, but it's good enough for now)
-        return os.path.isfile(os.sep.join([self.get_staging_dirpath(case), "CMakeCache.txt"]))
+        # CMake writes CMakeCache.txt before it generates the build system, so the
+        # cache alone does not mean the target is ready to build: a configure that
+        # was interrupted leaves the cache behind with no Makefile, and skipping
+        # configure on that basis fails later with "No rule to make target".
+        # Require the generator's build file too.
+        staging_dirpath = self.get_staging_dirpath(case)
+        if not os.path.isfile(os.sep.join([staging_dirpath, "CMakeCache.txt"])):
+            return False
+
+        return any(os.path.isfile(os.sep.join([staging_dirpath, f])) for f in ("build.ninja", "Makefile"))
+
+    def is_installed(self, case: Case) -> bool:
+        # CMake writes install_manifest.txt only after a successful install, so
+        # unlike CMakeCache.txt it is not left behind by a build that crashed.
+        return os.path.isfile(os.sep.join([self.get_staging_dirpath(case), "install_manifest.txt"]))
 
     def get_configuration_txt(self, case: Case) -> typing.Optional[dict]:
         if not self.is_configured(case):
@@ -593,10 +605,12 @@ def __build_target(target: typing.Union[MFCTarget, str], case: input.MFCInputFil
 
     history.add(target.name)
 
-    # Dependencies are pinned to fixed versions. If already configured
-    # (built & installed by a prior --deps-only step), skip entirely
-    # to avoid re-entering the superbuild (which may access the network).
-    if target.isDependency and target.is_configured(case):
+    # Dependencies are pinned to fixed versions, so skip one that a prior
+    # --deps-only step already installed, avoiding a re-entry into the superbuild
+    # (which may access the network). Gate on the install, not on the configure:
+    # a dependency build that crashed leaves CMakeCache.txt behind, and skipping
+    # on that would point CMAKE_PREFIX_PATH at an empty install tree forever.
+    if target.isDependency and target.is_installed(case):
         return
 
     for dep in target.requires.compute():

--- a/toolchain/mfc/build.py
+++ b/toolchain/mfc/build.py
@@ -371,17 +371,34 @@ class MFCTarget:
         # cache alone does not mean the target is ready to build: a configure that
         # was interrupted leaves the cache behind with no Makefile, and skipping
         # configure on that basis fails later with "No rule to make target".
-        # Require the generator's build file too.
+        # Require the generator's build file too, asking the cache which generator
+        # it is rather than guessing. An unrecognized generator falls back to the
+        # cache alone, so this is never stricter than the old behaviour.
         staging_dirpath = self.get_staging_dirpath(case)
-        if not os.path.isfile(os.sep.join([staging_dirpath, "CMakeCache.txt"])):
+        cache_filepath = os.sep.join([staging_dirpath, "CMakeCache.txt"])
+        if not os.path.isfile(cache_filepath):
             return False
 
-        return any(os.path.isfile(os.sep.join([staging_dirpath, f])) for f in ("build.ninja", "Makefile"))
+        generator = ""
+        with open(cache_filepath, "r") as f:
+            for line in f:
+                if line.startswith("CMAKE_GENERATOR:"):
+                    generator = line.split("=", 1)[-1].strip()
+                    break
+
+        if "Ninja" in generator:
+            return os.path.isfile(os.sep.join([staging_dirpath, "build.ninja"]))
+        if "Makefiles" in generator:
+            return os.path.isfile(os.sep.join([staging_dirpath, "Makefile"]))
+
+        return True
 
     def is_installed(self, case: Case) -> bool:
-        # CMake writes install_manifest.txt only after a successful install, so
-        # unlike CMakeCache.txt it is not left behind by a build that crashed.
-        return os.path.isfile(os.sep.join([self.get_staging_dirpath(case), "install_manifest.txt"]))
+        # CMake writes an install manifest only after a successful install, so unlike
+        # CMakeCache.txt it is not left behind by a build that crashed. Multi-config
+        # generators name it install_manifest_<config>.txt, so match either form.
+        staging_dirpath = self.get_staging_dirpath(case)
+        return any(name.startswith("install_manifest") and name.endswith(".txt") for name in os.listdir(staging_dirpath)) if os.path.isdir(staging_dirpath) else False
 
     def get_configuration_txt(self, case: Case) -> typing.Optional[dict]:
         if not self.is_configured(case):


### PR DESCRIPTION
Fixes #1689. One file, +21/−7. Not compiler- or platform-specific — separated from the CCE 21 port (#1694) because it stands on its own.

## Merge order

**This one has no file overlap with any other open PR and can merge at any time.** Merging it *first* is the most useful, because anyone building or hand-testing #1688 / #1694 on Frontier will otherwise hit the bug this fixes.

Suggested order for the CCE 21 work as a whole:

| order | PR | why |
|---|---|---|
| 1 | **#1696** (this) | independent; unblocks hand-testing the rest |
| 2 | **#1688** QBMM hoist | self-contained, correct on any compiler; removes 275 lines of move-only diff from #1694 on rebase |
| 3 | **#1694** CCE 21 port | rebase after #1688; its `m_qbmm.fpp` hunk then drops out |

⚠️ **#1694 and #1679 conflict** — see #1694's description. Not this PR's problem, but it affects the order of everything else.

## The problem

`MFCTarget.is_configured()` decides whether to skip configure *and* whether to skip a dependency entirely, based only on `CMakeCache.txt` existing:

```python
def is_configured(self, case: Case) -> bool:
    # We assume that if the CMakeCache.txt file exists, then the target is
    # configured. (this isn't perfect, but it's good enough for now)
    return os.path.isfile(os.sep.join([self.get_staging_dirpath(case), "CMakeCache.txt"]))
```

CMake writes that file *before* it generates the build system, and long before anything is installed. Two callers draw stronger conclusions than it supports.

**Configure gets skipped.** An interrupted configure leaves a cache with no `Makefile`. Every later build then skips configure and dies with a message that names the target, not the cause:

```
gmake: Makefile: No such file or directory
gmake: *** No rule to make target 'Makefile'.  Stop.
Error: Failed to build the post_process target.
```

**A dependency gets skipped permanently.** The comment states the assumption outright:

```python
# Dependencies are pinned to fixed versions. If already configured
# (built & installed by a prior --deps-only step), skip entirely
```

*configured ⇒ built & installed* is false for any dependency build that failed. The superbuild creates the staging dir and cache before it downloads, so a clone that fails — very easy to hit, since **compute nodes have no outbound network** — leaves the cache behind with nothing installed. From then on MFC skips that dependency forever, `CMAKE_PREFIX_PATH` points at an empty install tree, and the user sees an error from somewhere else entirely:

```
CMake Error at .../FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find SILO (missing: SILO_LIBRARY SILO_INCLUDE_DIR)
```

or, for hipfort, a silent fallback to ROCm's system copy — which on ROCm 7.2.0 is itself incomplete (missing `hipfort-hipfft-targets.cmake`) and produces a baffling error deep inside `/opt/rocm-7.2.0`. A related report on #1692 had `./mfc.sh build --deps-only` return `rc=0` with no hipfort installed, surfacing later as `HIPFFTPLANMANY has no explicit type` in `M_FFTW`.

## The fix

Ask the question each caller actually means:

* **ready to build** — require the generator's build file (`build.ninja` or `Makefile`) alongside the cache
* **already installed** — require `install_manifest.txt`, which CMake writes only after a successful `install`

## Verification

`install_manifest.txt` is present for all five dependencies (`fftw`, `hdf5`, `silo`, `lapack`, `hipfort`) after a normal build, checked across two independent worktrees — so the stricter predicate does not cause spurious rebuilds.

It also discriminated correctly on a real broken tree, which is the case that matters:

| dependency | cache | manifest | action |
|---|---|---|---|
| silo | present | **absent** | **rebuilt** ✅ |
| lapack | present | absent | rebuilt ✅ |
| hipfort | present | absent | rebuilt ✅ |
| hdf5, fftw | present | present | correctly skipped ✅ |

Four correct skips, three correct rebuilds, no manual intervention. `./mfc.sh precheck` passes 7/7.

## Behaviour change worth reviewing

A dependency provisioned **by hand**, outside MFC's own install path, will no longer be recognised and will be rebuilt. That is arguably correct — MFC manages its own dependencies — but it converts a silent-wrong-answer case into a loud-failure one, and on a compute node that rebuild will fail for lack of network rather than succeed. Anyone relying on hand-provisioned deps should know.

## Why this is worth taking on its own

Over one porting effort this single predicate destroyed six batch jobs, produced a false negative in a compiler-flag experiment (a link reported as failing when it had never been attempted), broke a control run, and silently voided two full benchmark campaigns. In every instance the visible error implicated the compiler, a missing system package, or a slow machine — never the skip logic. The cost is not the failure itself but that it consistently points investigation at the wrong layer.