### PR TITLE
Stop the coverage unit tests committing into the developer's own repository

### DIFF
--- a/toolchain/mfc/test/test_coverage_unit.py
+++ b/toolchain/mfc/test/test_coverage_unit.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 import tempfile
@@ -461,19 +462,47 @@ def test_health_fails_immediately_when_map_predates_last_source_change():
 CHANGED_SCRIPT = Path(__file__).resolve().parents[3] / ".github" / "scripts" / "coverage_map_changed.py"
 
 
+def _env_without_git():
+    """The environment minus every GIT_* variable.
+
+    `git -C <dir>` changes directory but does NOT override an inherited GIT_DIR or
+    GIT_INDEX_FILE. Git exports both when it runs a hook, and MFC's pre-commit hook runs
+    precheck, which runs this suite -- so without this scrub the commits below are made
+    against the real repository instead of the throwaway one.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
 def _repo_with_committed_map(d, entries):
     """A throwaway git repo whose HEAD holds `entries` as the coverage map."""
     repo = Path(d)
+    env = _env_without_git()
     git = ["git", "-c", "user.name=t", "-c", "user.email=t@t", "-C", str(repo)]
-    subprocess.run([*git, "init", "-q"], check=True)
+    subprocess.run([*git, "init", "-q"], check=True, env=env)
     save_map(repo / "tests" / "coverage_map.json.gz", entries, n_tests=len(entries), git_sha="aaa", gfortran_version="13")
-    subprocess.run([*git, "add", "-A"], check=True)
-    subprocess.run([*git, "commit", "-q", "--no-verify", "-m", "map"], check=True)
+    subprocess.run([*git, "add", "-A"], check=True, env=env)
+    subprocess.run([*git, "commit", "-q", "--no-verify", "-m", "map"], check=True, env=env)
     return repo
 
 
 def _run_guard(repo):
-    return subprocess.run([sys.executable, str(CHANGED_SCRIPT)], cwd=repo, capture_output=True, text=True, check=False).returncode
+    return subprocess.run([sys.executable, str(CHANGED_SCRIPT)], cwd=repo, capture_output=True, text=True, check=False, env=_env_without_git()).returncode
+
+
+def test_throwaway_repos_are_isolated_from_an_inherited_git_dir():
+    """The helper above must not commit into whatever repo GIT_DIR names.
+
+    Precheck runs this suite from the pre-commit hook, where git exports GIT_DIR and
+    GIT_INDEX_FILE. Without the scrub, `git -C tmpdir commit` rewrites the developer's
+    checked-out branch -- silently, while every test still reports as passing.
+    """
+    with patch.dict(os.environ, {"GIT_DIR": "/nonexistent.git", "GIT_INDEX_FILE": "/nonexistent.index"}):
+        assert not [k for k in _env_without_git() if k.startswith("GIT_")]
+        with tempfile.TemporaryDirectory() as d:
+            repo = _repo_with_committed_map(d, {"k1": ["src/simulation/m_rhs.fpp"]})
+            # The commit is in the throwaway repo, so it went nowhere near GIT_DIR.
+            log = subprocess.run(["git", "-C", str(repo), "log", "--oneline"], capture_output=True, text=True, check=True, env=_env_without_git())
+            assert log.stdout.strip().endswith("map")
 
 
 def test_guard_reports_unchanged_with_a_code_that_is_not_the_crash_code():


### PR DESCRIPTION
The coverage unit tests build a throwaway git repo with `git -C <tmpdir>`. That sets the working directory but does **not** override an inherited `GIT_DIR`/`GIT_INDEX_FILE`.

Git exports both when it runs a hook. Our pre-commit hook runs `precheck`, and precheck runs this suite (`toolchain/bootstrap/lint.sh:36`). So on any machine using the hook we tell contributors to use, `git commit` ran three `git commit` calls against the *contributor's own checkout*.

The damage:

```
a5c25682 map          <- tests/coverage_map.json.gz
4439e379 map          <- tests/coverage_map.json.gz
4d6d696a map          <- 2090 files changed, 359333 deletions(-)
02ce639a <your actual work>
```

The first one deletes every file in the repository, because the helper's `git add -A` had already replaced the index with its single-file tree.

**It is silent.** pytest reports every test passing while it happens. The only visible symptom is that the commit you were making dies with `fatal: cannot lock ref 'HEAD': is at <x> but expected <y>` — because the child commits moved HEAD out from under it. I hit this on a real branch and force-pushed the 2090-file deletion to its PR before noticing.

### The fix

Scrub `GIT_*` from the environment for the four git invocations backing these fixtures.

### Verification

Reproduced and confirmed in a sandbox, simulating the hook environment exactly (`GIT_DIR`/`GIT_INDEX_FILE` exported at a scratch repo, then running the suite):

| | outer repo HEAD | suite result |
|---|---|---|
| before | **moved** — 3 `map` commits appear | `58 passed` |
| after | unchanged | `59 passed` |

The added regression test pins `GIT_DIR` at a path git cannot write and asserts the commit still lands in the throwaway repo. Without the scrub it fails with `/nonexistent.git: Permission denied`; the rest of the suite passes either way, which is exactly why this went unnoticed.

Final end-to-end check: committing this PR itself **with the hook enabled** moved HEAD exactly once.

### Merge order

Independent of my other open PRs — no shared files. Worth taking first regardless, since without it any contributor running the hook can silently rewrite their branch.