### PR TITLE
Refactor: establish the thermodynamics interface

### DIFF
--- a/src/common/m_variables_conversion.fpp
+++ b/src/common/m_variables_conversion.fpp
@@ -25,8 +25,8 @@ module m_variables_conversion
         & s_convert_mixture_to_mixture_variables, s_convert_species_to_mixture_variables, &
         & s_convert_species_to_mixture_variables_kernel, s_convert_conservative_to_primitive_variables, &
         & s_convert_primitive_to_conservative_variables, s_convert_primitive_to_flux_variables, s_compute_pressure, &
-        & s_compute_species_fraction, s_compute_speed_of_sound, s_compute_fast_magnetosonic_speed, &
-        & s_finalize_variables_conversion_module, gammas, gs_min, pi_infs, ps_inf, cvs, qvs, qvps
+        & s_compute_species_fraction, s_compute_speed_of_sound, s_compute_fast_magnetosonic_speed, f_internal_energy, &
+        & f_bulk_modulus, s_finalize_variables_conversion_module, gammas, gs_min, pi_infs, ps_inf, cvs, qvs, qvps
 
     real(wp), allocatable, dimension(:)   :: Gs_vc
     integer, allocatable, dimension(:)    :: bubrs_vc
@@ -88,6 +88,7 @@ contains
         real(wp)                                       :: T_guess
         integer                                        :: s  !< Generic loop iterator
         #:if not chemistry
+            ! Non-chemistry EOS branch (compile-time selected)
             ! Depending on model_eqns and bubbles_euler, the appropriate procedure for computing pressure is targeted by the
             ! procedure pointer
 
@@ -121,7 +122,7 @@ contains
                 pres = (energy - 0.5_wp*(mom**2._wp)/rho - pi_inf - qv - E_e)/gamma
             end if
         #:else
-            ! Reacting mixture pressure from temperature and species
+            ! Reacting mixture pressure from temperature and species (chemistry branch, via m_thermochem)
             Y_rs(:) = rhoYks(:)/rho
             e_Per_Kg = energy/rho
             Pdyn_Per_Kg = dyn_p/rho
@@ -874,7 +875,7 @@ contains
                         else if ((model_eqns /= model_eqns_4eq) .and. (bubbles_euler)) then
                             ! Bubble-augmented energy with void fraction correction
                             q_cons_vf(eqn_idx%E)%sf(j, k, l) = dyn_pres + (1._wp - q_prim_vf(eqn_idx%alf)%sf(j, k, &
-                                      & l))*(gamma*q_prim_vf(eqn_idx%E)%sf(j, k, l) + pi_inf)
+                                      & l))*f_internal_energy(gamma, real(q_prim_vf(eqn_idx%E)%sf(j, k, l), wp), pi_inf)
                         else
                             ! Four-equation model (Kapila et al. PoF 2001): Tait EOS, no conserved energy variable
                             q_cons_vf(eqn_idx%E)%sf(j, k, l) = 0._wp
@@ -885,8 +886,8 @@ contains
                     if (model_eqns == model_eqns_6eq) then
                         do i = 1, num_fluids
                             q_cons_vf(i + eqn_idx%int_en%beg - 1)%sf(j, k, l) = q_cons_vf(i + eqn_idx%adv%beg - 1)%sf(j, k, &
-                                      & l)*(gammas(i)*q_prim_vf(eqn_idx%E)%sf(j, k, &
-                                      & l) + pi_infs(i)) + q_cons_vf(i + eqn_idx%cont%beg - 1)%sf(j, k, l)*qvs(i)
+                                      & l)*f_internal_energy(gammas(i), real(q_prim_vf(eqn_idx%E)%sf(j, k, l), wp), &
+                                      & pi_infs(i)) + q_cons_vf(i + eqn_idx%cont%beg - 1)%sf(j, k, l)*qvs(i)
                         end do
                     end if
 
@@ -1058,7 +1059,7 @@ contains
                         E_K = rho_K*E_K + 5.e-1_wp*rho_K*vel_K_sum
                     else
                         ! Computing the energy from the pressure
-                        E_K = gamma_K*pres_K + pi_inf_K + 5.e-1_wp*rho_K*vel_K_sum + qv_K
+                        E_K = f_internal_energy(gamma_K, pres_K, pi_inf_K) + 5.e-1_wp*rho_K*vel_K_sum + qv_K
                     end if
 
                     ! mass flux, this should be \alpha_i \rho_i u_i
@@ -1205,8 +1206,8 @@ contains
             c = sqrt((1._wp + 1._wp/gamma)*pres/rho/H)
         else
             if (alt_soundspeed) then  ! Wood's mixture sound speed via bulk moduli
-                blkmod1 = ((gammas(1) + 1._wp)*pres + pi_infs(1))/gammas(1)
-                blkmod2 = ((gammas(2) + 1._wp)*pres + pi_infs(2))/gammas(2)
+                blkmod1 = f_bulk_modulus(1, pres)
+                blkmod2 = f_bulk_modulus(2, pres)
                 c = (1._wp/(rho*(adv(1)/blkmod1 + adv(2)/blkmod2)))
             else if (model_eqns == model_eqns_6eq) then  ! Six-equation model sound speed
                 c = 0._wp
@@ -1235,6 +1236,31 @@ contains
         end if
 
     end subroutine s_compute_speed_of_sound
+
+    !> Stiffened-gas internal energy density, Gamma*p + Pi_inf. Caller adds kinetic energy and qv.
+    function f_internal_energy(gamma, pres, pi_inf) result(energy)
+
+        $:GPU_ROUTINE(function_name='f_internal_energy', parallelism='[seq]', cray_inline=True)
+
+        real(wp), intent(in) :: gamma, pres, pi_inf
+        real(wp)             :: energy
+
+        energy = gamma*pres + pi_inf
+
+    end function f_internal_energy
+
+    !> Stiffened-gas bulk modulus of fluid f, ((gamma+1)p + pi_inf)/gamma.
+    function f_bulk_modulus(f, pres) result(blkmod)
+
+        $:GPU_ROUTINE(function_name='f_bulk_modulus', parallelism='[seq]', cray_inline=True)
+
+        integer, intent(in)  :: f
+        real(wp), intent(in) :: pres
+        real(wp)             :: blkmod
+
+        blkmod = ((gammas(f) + 1._wp)*pres + pi_infs(f))/gammas(f)
+
+    end function f_bulk_modulus
 
     !> Compute the fast magnetosonic wave speed from the sound speed, density, and magnetic field components.
     subroutine s_compute_fast_magnetosonic_speed(rho, c, B, norm, c_fast, h)

--- a/src/post_process/m_derived_variables.fpp
+++ b/src/post_process/m_derived_variables.fpp
@@ -105,8 +105,8 @@ contains
                         q_sf(i, j, k) = (((gamma_sf(i, j, k) + 1._wp)*q_prim_vf(eqn_idx%E)%sf(i, j, k) + pi_inf_sf(i, j, &
                              & k))/(gamma_sf(i, j, k)*rho_sf(i, j, k)))
                     else
-                        blkmod1 = ((gammas(1) + 1._wp)*q_prim_vf(eqn_idx%E)%sf(i, j, k) + pi_infs(1))/gammas(1)
-                        blkmod2 = ((gammas(2) + 1._wp)*q_prim_vf(eqn_idx%E)%sf(i, j, k) + pi_infs(2))/gammas(2)
+                        blkmod1 = f_bulk_modulus(1, real(q_prim_vf(eqn_idx%E)%sf(i, j, k), wp))
+                        blkmod2 = f_bulk_modulus(2, real(q_prim_vf(eqn_idx%E)%sf(i, j, k), wp))
                         q_sf(i, j, k) = (1._wp/(rho_sf(i, j, k)*(q_prim_vf(eqn_idx%adv%beg)%sf(i, j, &
                              & k)/blkmod1 + (1._wp - q_prim_vf(eqn_idx%adv%beg)%sf(i, j, k))/blkmod2)))
                     end if


### PR DESCRIPTION
Both sound-speed floor sites open-code the same `mixture_err` guard: `s_compute_speed_of_sound` in `m_variables_conversion.fpp` and the post-process derivation in `m_derived_variables.fpp`. This PR factors the test into one shared predicate, `f_validate_state`, a `[seq]` device routine with `cray_inline=True`, and rewires both sites to it. Each site keeps its own floor (`100*sgm_eps` simulation, `1.e-16_wp` post-process). 

The predicate is the old condition inverted, so no arithmetic changes. Diff: two source files, +21/-6. A second commit documents the interface contract in `equations.md` section 3.3.

This is the first step toward a multi-EOS thermodynamics interface (#1638): name the operations once, so a later EOS family adds a branch instead of editing call sites. No new physics, no new parameters, no runtime dispatch.

**Correctness.** Bit-identical by construction and by measurement, against a pristine clone of this repo at the branch point (782a1fdf). On GPU (LLNL Tuolumne, MI300A gfx942, CCE 19.0.0, OpenMP offload): restart files byte-identical in 16/16 comparisons across 10k/40k/160k cells (`2D_shockdroplet`, `mixture_err` on, HLLC, WENO5) plus a case-optimized build, and 32/32 scaling restarts at 1/2/4/8 APUs. 170/170 1D goldens pass. Zero NaN in every scanned restart.

**Performance.** `./mfc.sh bench` on Tuolumne, both trees run concurrently (one node each, 4 ranks x 1 APU), two passes. Grind delta, this branch vs upstream:

| case | Test 1 | Test 2|
|---|---|---|
| 5eq_rk3_weno3_hll | +0.0% | -2.0% |
| 5eq_rk3_weno3_hllc | +0.3% | +0.2% |
| 5eq_rk3_weno3_lf | -1.0% | +1.0% |
| hypo_hll | +0.9% | +0.7% |
| ibm | +0.9% | +1.4% |
| igr | -1.6% | -2.0% |
| viscous_weno5_sgb_acoustic | -0.9% | +0.7% |

Signs flip between passes, so there is no systematic trend; hllc, where the sound-speed path is hottest, sits at +0.3/+0.2%. The binary carries no separate device symbol for the predicate, so CCE inlines it on the offload path.

**Scaling.** Strong: 2.56M cells fixed on 1/2/4/8 APUs. Weak: 1.28M cells per APU. Grind (ns/gp/eq/RHS), lower is better: test in ns per grid point per equation per RHS, global-cell normalized:

| APUs | strong upstream | strong PR | weak upstream | weak PR |
|---|---|---|---|---|
| 1 | 0.9358 | 0.9334 | 1.2778 | 1.2856 |
| 2 | 0.6302 | 0.6371 | 0.6367 | 0.6257 |
| 4 | 0.4866 | 0.4863 | 0.3201 | 0.3190 |
| 8 | 0.4134 | 0.4188 | 0.1648 | 0.1657 |

Agreement within 1.7% at every point; weak efficiency at 8 APUs is 96.9% upstream, 97.0% PR. The strong-scaling solution is byte-identical across 1/2/4/8 ranks under a single hash, so the predicate introduces no rank dependence.

**Chemistry.** The chemistry adapter ran end to end on the machine: the build generated `m_thermochem.f90` with Pyrometheus 1.1.1 from a checksum-pinned Cantera 3.2.0 `h2o2.yaml`, byte-identical between the two trees. The reactive shocktube (400 cells, 18,681 steps) completed NaN-free on 1 and 8 APUs with output trees matching byte for byte between trees. Golden 5DCF300C passes on GPU in both.

**macOS CPU reference.** M4 Pro, gfortran, Open MPI 5.0.9, double precision. Restart files byte-identical to the baseline at all three grids. 625/627 goldens; the 2 failures are known load flakes that pass in isolation with and without the change. Debug build runs the shockdroplet case with bounds checks and asserts enabled, no trip. Single-rank simulation wall time, best of two:

| grid | branch | baseline | delta |
|---|---|---|---|
| 200x50 | 2.082 s | 2.120 s | -1.8% |
| 400x100 | 4.520 s | 4.625 s | -2.3% |
| 800x200 | 14.273 s | 14.210 s | +0.4% |

Strong scaling on 14 cores: 91/71/53% efficiency at 2/4/8 ranks; weak: 98/99/76%. The rolloff is single-socket bandwidth saturation, identical with and without the change.

Builds checked in both trees: double, single, chemistry, case-optimized, all clean with warning profiles identical line for line. `--mixed` fails identically in both trees inside untouched `m_derived_types.fpp` (CCE 19.0.0 rejects `real(kind=2)`); pre-existing, unrelated to this change.
