### PR TITLE
Docs: exclude stackoverflow.com from lychee link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -31,4 +31,5 @@ exclude = [
     "https://www\\.olcf\\.ornl\\.gov/summit",            # Returns 503 to automated requests
     "https://apps\\.microsoft\\.com/store/detail/",  # Microsoft Store detail pages return 403 to automated requests
     "https://code\\.visualstudio\\.com/?$",           # Root page returns 403 to automated requests
+    "https://stackoverflow\\.com",                    # Returns 403 to automated requests
 ]


### PR DESCRIPTION
## Description

The docs link check fails on a Stack Overflow URL in `docs/documentation/docker.md`:

```
### Errors in build/install/docs/mfc/documentation/docker.html
* [403] <https://stackoverflow.com/questions/9727688/how-to-get-the-cuda-version> (at 192:180) | Rejected status code: 403 Forbidden
```

Stack Overflow returns 403 to automated requests. The link resolves fine in a
browser — it is not broken, it just refuses bots. This adds it to the existing
`exclude` list in `.lychee.toml`, alongside the entries already there for the
same reason (Microsoft Store, VS Code, OLCF Summit).

Scoped to the domain rather than the single question URL, since Stack Overflow
blocks bots site-wide and any future SO link would hit the same failure.

### Type of change

- Bug fix

## Testing

Reproduced and verified locally with lychee 0.24.2 against a minimal HTML file
containing the failing URL:

- without the config: `[403] ... Rejected status code: 403 Forbidden` — matches CI exactly
- with the config: `0 Errors, 1 Excluded`

Also confirmed in CI: the same one-line change applied to the branch of #1628
turned the previously failing Documentation workflow green
([run 30662138744](https://github.com/MFlowCode/MFC/actions/runs/30662138744)).

## Checklist

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed
