### PR TITLE
Avoid NVHPC 25.5 fort2 ICE by expanding f_compute_multidim_cfl_terms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -306,6 +306,30 @@ jobs:
             /bin/bash mfc.sh test -v --dry-run -j 2 --test-all --gpu mp
           '
 
+      # Case-optimized build guard.
+      #
+      # --case-optimization hard-codes case parameters into the generated
+      # sources, which sharply increases cross-file inlining pressure in the
+      # -Mextract/-Minline IPO pass (cmake/MFCTargets.cmake). That pass is
+      # where NVHPC fort2 has historically hit internal compiler errors, and
+      # the jobs above cannot see them: they never pass --case-optimization,
+      # and the self-hosted case-opt jobs run a single pinned NVHPC. NVHPC
+      # 25.5 shipped an ICE that was invisible to CI for exactly that reason.
+      #
+      # One 3D case is enough: the failure is at compile time, so nothing is
+      # run. 3D specifically, because m_sim_helpers.fpp guards its 3D block
+      # with "#:if not MFC_CASE_OPTIMIZATION or num_dims > 2" -- a
+      # case-optimized 2D build elides that code entirely. OpenACC only,
+      # since the two-pass IPO is disabled for OpenMP offload.
+      - name: Build (NVHPC GPU, case-optimized)
+        if:   matrix.nvhpc && matrix.target == 'gpu'
+        run: |
+          docker exec nvhpc bash -c '
+            source /etc/nvhpc-env.sh
+            /bin/bash mfc.sh build -v -j 2 --gpu acc -t simulation \
+              -i examples/3D_sphbubcollapse/case.py --case-optimization
+          '
+
       - name: Test (NVHPC)
         if:   matrix.nvhpc && matrix.target == 'cpu'
         run: |

--- a/src/simulation/m_sim_helpers.fpp
+++ b/src/simulation/m_sim_helpers.fpp
@@ -41,34 +41,6 @@ contains
 
     end function f_compute_filtered_dtheta
 
-    !> Computes inviscid CFL terms for multi-dimensional cases (2D/3D only)
-    function f_compute_multidim_cfl_terms(vel, c, j, k, l) result(cfl_terms)
-
-        $:GPU_ROUTINE(parallelism='[seq]')
-        real(wp), dimension(num_vels), intent(in) :: vel
-        real(wp), intent(in)                      :: c
-        integer, intent(in)                       :: j, k, l
-        real(wp)                                  :: cfl_terms
-        real(wp)                                  :: fltr_dtheta
-
-        fltr_dtheta = f_compute_filtered_dtheta(k, l)
-
-        if (p > 0) then
-            ! 3D
-            #:if not MFC_CASE_OPTIMIZATION or num_dims > 2
-                if (grid_geometry == 3) then
-                    cfl_terms = min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c), fltr_dtheta/(abs(vel(3)) + c))
-                else
-                    cfl_terms = min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c), dz(l)/(abs(vel(3)) + c))
-                end if
-            #:endif
-        else
-            ! 2D
-            cfl_terms = min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c))
-        end if
-
-    end function f_compute_multidim_cfl_terms
-
     !> Computes enthalpy
     subroutine s_compute_enthalpy(q_prim_vf, pres, rho, gamma, pi_inf, Re, H, alpha, vel, vel_sum, qv, j, k, l)
 
@@ -145,8 +117,21 @@ contains
         real(wp)                                  :: fltr_dtheta
 
         ! Inviscid CFL calculation
-        if (p > 0 .or. n > 0) then
-            icfl = dt/f_compute_multidim_cfl_terms(vel, c, j, k, l)
+        ! The multi-dimensional CFL terms are written out here rather than
+        ! obtained from a shared helper procedure: NVHPC 25.5's fort2 segfaults
+        ! when a routine containing a call to that helper is cross-file inlined
+        ! by -Minline (the IPO setup in cmake/MFCTargets.cmake).
+        if (p > 0) then
+            #:if not MFC_CASE_OPTIMIZATION or num_dims > 2
+                if (grid_geometry == 3) then
+                    fltr_dtheta = f_compute_filtered_dtheta(k, l)
+                    icfl = dt/min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c), fltr_dtheta/(abs(vel(3)) + c))
+                else
+                    icfl = dt/min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c), dz(l)/(abs(vel(3)) + c))
+                end if
+            #:endif
+        else if (n > 0) then
+            icfl = dt/min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c))
         else
             icfl = (dt/dx(j))*(abs(vel(1)) + c)
         end if
@@ -206,8 +191,21 @@ contains
         real(wp)                                  :: fltr_dtheta
 
         ! Inviscid CFL calculation
-        if (p > 0 .or. n > 0) then
-            max_dt = cfl_target*f_compute_multidim_cfl_terms(vel, c, j, k, l)
+        ! The multi-dimensional CFL terms are written out here rather than
+        ! obtained from a shared helper procedure: NVHPC 25.5's fort2 segfaults
+        ! when a routine containing a call to that helper is cross-file inlined
+        ! by -Minline (the IPO setup in cmake/MFCTargets.cmake).
+        if (p > 0) then
+            #:if not MFC_CASE_OPTIMIZATION or num_dims > 2
+                if (grid_geometry == 3) then
+                    fltr_dtheta = f_compute_filtered_dtheta(k, l)
+                    max_dt = cfl_target*min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c), fltr_dtheta/(abs(vel(3)) + c))
+                else
+                    max_dt = cfl_target*min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c), dz(l)/(abs(vel(3)) + c))
+                end if
+            #:endif
+        else if (n > 0) then
+            max_dt = cfl_target*min(dx(j)/(abs(vel(1)) + c), dy(k)/(abs(vel(2)) + c))
         else
             max_dt = cfl_target*(dx(j)/(abs(vel(1)) + c))
         end if


### PR DESCRIPTION
## Problem

Building `simulation` with NVHPC 25.5 and our two-pass IPO crashes the compiler:

```
nvfortran-Fatal-.../25.5/compilers/bin/tools/fort2 TERMINATED by signal 11
gmake[3]: *** [.../simulation.dir/fypp/simulation/m_data_output.fpp.f90.o] Error 2
```

Reported by OLCF on a GH200 (Grace + H100, NVHPC 25.5, CUDA 12.9) while running the
scaling benchmark. **It is not architecture specific** — it reproduces on x86_64 with
the stock NVHPC 25.5 tarball, same signal and same file.

## Root cause

`fort2` segfaults during the `-Minline` pass when it cross-file inlines a routine whose
body contains a **call to** `f_compute_multidim_cfl_terms`.

The crash belongs to the call site, not the callee. Bisected against a live reproducer:

| Body of `s_compute_stability_from_dt` | Result |
| --- | --- |
| gutted | builds |
| calls `f_compute_filtered_dtheta` (scalar args) | builds |
| calls `f_compute_multidim_cfl_terms` | **SIGSEGV** |
| ...with that helper's body emptied | **SIGSEGV** |
| ...with its array dummy replaced by a scalar | **SIGSEGV** |
| call removed (helper expanded in place) | builds |

This also explains why `except:f_compute_multidim_cfl_terms` does not help: excluding the
*callee* still leaves the offending call inside the inlined *caller*. Only excluding the
caller avoids it.

It also explains the second crash site. `m_time_steppers` calls `s_compute_dt_from_cfl`,
the sibling routine in the same module with the same call pattern — which is exactly where
the ICE relocates if `m_data_output` is added to the `-Mnoinline` list.

## Fix

`f_compute_multidim_cfl_terms` was `private` with exactly two call sites, so it is expanded
in place and removed. No `-Mnoinline`, no macro, net −1 line. The resulting
`if (p > 0) / else if (n > 0) / else` structure matches the viscous and capillary blocks
already present in both routines.

Semantics are unchanged: the original nested logic selected 3D for `p > 0` and 2D
otherwise, guarded by `if (p > 0 .or. n > 0)`. Every read of `fltr_dtheta` in both routines
is still immediately preceded by its own assignment.

## Verification

| Config | Before | After |
| --- | --- | --- |
| NVHPC 25.5, GPU+MPI, case-optimized, IPO on | ❌ SIGSEGV | ✅ builds |
| NVHPC 25.5, same, **all `-Mnoinline` exclusions removed** | — | ✅ builds |
| NVHPC 25.11, same config | ✅ | ✅ (no regression) |
| `cfl_adap_dt` golden-file tests (CPU) | — | ✅ 7/7 |

Full CPU test suite is running locally and was clean through the first ~315/628 cases at
the time of opening; CI covers it here regardless.

## Follow-up (not in this PR)

With this fix, NVHPC 25.5 builds cleanly with the existing `m_start_up` / `m_cbc`
`-Mnoinline` exclusions in `cmake/MFCTargets.cmake` **removed entirely**. Those were added
for an NVHPC 25.x ICE and look like the same bug. I left them in place here to keep this
change minimal — worth removing separately once CI confirms across the matrix, since it
would restore full IPO to those files.

NVHPC 25.11 compiles the unmodified source fine, so the underlying defect is a 25.5 codegen
bug; this change avoids the construct that triggers it. Worth filing upstream with NVIDIA.