### PR TITLE
Run inactive-patch validation over all patch slots

### DIFF
--- a/src/pre_process/m_check_patches.fpp
+++ b/src/pre_process/m_check_patches.fpp
@@ -95,7 +95,7 @@ contains
         end do
 
         ! Constraints on overwrite rights initial condition patch parameters
-        do i = 1, num_patches
+        do i = 1, num_patches_max
             if (i <= num_patches) then
                 call s_check_active_patch_alteration_rights(i)
             else
@@ -104,7 +104,7 @@ contains
         end do
 
         ! Constraints on smoothing initial condition patch parameters
-        do i = 1, num_patches
+        do i = 1, num_patches_max
             if (i > 1 .and. (patch_icpp(i)%geometry == 2 .or. patch_icpp(i)%geometry == 3 .or. patch_icpp(i)%geometry == 4 &
                 & .or. patch_icpp(i)%geometry == 5 .or. patch_icpp(i)%geometry == 8 .or. patch_icpp(i)%geometry == 9 &
                 & .or. patch_icpp(i)%geometry == 10 .or. patch_icpp(i)%geometry == 11 .or. patch_icpp(i)%geometry == 12 &
@@ -116,7 +116,7 @@ contains
         end do
 
         ! Constraints on flow variables initial condition patch parameters
-        do i = 1, num_patches
+        do i = 1, num_patches_max
             if (i <= num_patches) then
                 call s_check_active_patch_primitive_variables(i)
             else


### PR DESCRIPTION
Three of the four per-patch validation loops in `s_check_patches` were bounded at
`num_patches` instead of `num_patches_max`, so their `else` branches — the ones
that validate the *inactive* patch slots — could never be reached.

The first loop (alteration of deprecated geometry numbers, L43) is already
correct: it runs `do i = 1, num_patches_max` and uses `if (i <= num_patches)` to
split active from inactive slots. The other three copy that same
`if (i <= num_patches) ... else ...` shape but only ever iterate to
`num_patches`, which makes the predicate unconditionally true. That left three
validators as dead code:

| loop | validator that was unreachable |
|---|---|
| L98 — alteration rights | `s_check_inactive_patch_alteration_rights` (L405) |
| L107 — smoothing | `s_check_unsupported_patch_smoothing` (L442) |
| L119 — primitive variables | `s_check_inactive_patch_primitive_variables` (L512) |

The fix widens those three bounds to `num_patches_max`. That's the whole change,
+3/-3 in one file.

The smoothing loop is worth a second look because it's structurally different —
its predicate is a geometry whitelist (`i > 1 .and. geometry == 2/3/4/...`)
rather than `i <= num_patches`. An inactive slot has `geometry == dflt_int`, so
once the bound is widened it falls through to the `else`/unsupported branch,
which is the intended behaviour. I verified that empirically rather than by
reading (see the `smooth` row below).

## Why this can't change results for any valid case

`m_global_parameters.fpp:230-268` initialises all `num_patches_max` (= 10, from
`m_constants.fpp:26`) slots to defaults in its own `do i = 1, num_patches_max`
loop — `alter_patch = .false.` with `alter_patch(0) = .true.`, `smoothen =
.false.`, `smooth_patch_id = i`, and `dflt_real` for every primitive variable.
Those defaults are exactly what the inactive-patch validators assert. So for a
well-formed case the newly-reachable checks are no-ops; the change only tightens
validation on misconfigured input and cannot move a golden file.

## How it was tested

I built a 1D Sod-like case with `num_patches: 2` and then set one forbidden
parameter on the *inactive* slot 3, one variant per broken loop, plus a clean
control. Run through `./mfc.sh run <case.json> -t pre_process -n 1`:

| variant | what it sets on patch 3 | before | after |
|---|---|---|---|
| `control` | nothing (valid case) | exit 0 | exit 0 |
| `alter` | `alter_patch(1) = T` | exit 0 — wrongly accepted | aborts: `Inactive patch 3: cannot have any alter_patch(i) enabled` |
| `smooth` | `smoothen = T`, `smooth_coeff = 0.5` | exit 0 — wrongly accepted | aborts: `Inactive patch 3: cannot have smoothen enabled` |
| `prim` | `pres`, `vel(1)`, `rho` | exit 0 — wrongly accepted | aborts: `Inactive patch 3: rho must not be set` |

Each bad variant produces a *different* message, which is what proves the three
loops independently rather than just showing that some check fires. The control
still passes in both directions, so nothing valid became newly rejected.

Both CI gates pass locally on the committed tree:

- `./mfc.sh lint` → `372 passed, 4 subtests passed in 9.74s`
- `./mfc.sh precheck -j 4` → all 7 checks OK (formatting, spelling, toolchain
  lint, source lint, doc refs, parameter docs, example cases)

## Note on prior work

PR #1599 took the same approach and was closed for author inactivity, not
because anything was wrong with it. This is a clean re-do with the reachability
matrix above as evidence.

Fixes #1482
