### PR TITLE
ci(lychee): exclude the VS Code Marketplace, it returns 503 to automated requests

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -32,4 +32,5 @@ exclude = [
     "https://apps\\.microsoft\\.com/store/detail/",  # Microsoft Store detail pages return 403 to automated requests
     "https://code\\.visualstudio\\.com/?$",           # Root page returns 403 to automated requests
     "https://stackoverflow\\.com",                    # Returns 403 to automated requests
+    "https://marketplace\\.visualstudio\\.com",        # Returns 503 to automated requests
 ]


### PR DESCRIPTION
## Description

The Lychee link check fails on `Build & Verify` with a single error:

```
### Errors in build/install/docs/mfc/documentation/getting-started.html

* [503] <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl> (at 218:86)
      | Rejected status code: 503 Service Unavailable
```

That is the "Remote - WSL" extension link at `docs/documentation/getting-started.md:87`, the only
marketplace.visualstudio.com URL in the tree. The link is not broken for a human — the Marketplace
returns 503 to automated requests, the same bot-blocking `.lychee.toml` already carries exclusions
for on `apps.microsoft.com/store/detail/` (403), `code.visualstudio.com` (403), `stackoverflow.com`
(403) and `olcf.ornl.gov/summit` (503). `accept` lists 502 and 504 but not 503, so it fails hard
after all 5 retries and takes the job with it.

Excluding the host is the targeted fix; adding "503" to `accept` would suppress genuinely dead
links everywhere else.

### Type of change

- Other (CI configuration)

## Testing

- `.lychee.toml` parses, and the new pattern matches the failing URL.
- Checked it does not over-match: `visualstudio.com`, `github.com` and `mflowcode.github.io` links
  are still checked.
- `./mfc.sh precheck` passes all seven gates.

## Checklist

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed
