### PR TITLE
Fix sign of the radial-velocity term in the documented mixture pressure

### DIFF
--- a/docs/documentation/equations.md
+++ b/docs/documentation/equations.md
@@ -419,7 +419,7 @@ Additional geometric source terms appear with \f$1/r\f$ factors in the continuit
 
 **Modified mixture pressure:**
 
-\f[p = (1 - \alpha)\,p_l + \alpha\left(\frac{R^3\,p_{bw}}{\bar{R}^3} - \frac{\rho\,R^3\,\dot{R}^2}{\bar{R}^3}\right)\f]
+\f[p = (1 - \alpha)\,p_l + \alpha\left(\frac{R^3\,p_{bw}}{\bar{R}^3} + \frac{\rho\,R^3\,\dot{R}^2}{\bar{R}^3}\right)\f]
 
 **Modified stiffened gas for the liquid phase:**
 


### PR DESCRIPTION
## Description

`docs/documentation/equations.md` gave the Euler-Euler modified mixture pressure as

```
p = (1 - alpha) p_l + alpha ( <R^3 p_bw>/<R^3> - rho <R^3 Rdot^2>/<R^3> )
```

with a minus on the radial-velocity term. That sign is wrong. Ando (Caltech thesis, 2010) writes the mixture momentum flux as `p_l - ptilde` in Eq. (2.2), with

```
ptilde = alpha ( p_l - <R^3 p_bw>/<R^3> - rho <R^3 Rdot^2>/<R^3> )   Eq. (2.5)
```

Both terms are negative inside the parenthesis, so

```
p_l - ptilde = (1 - alpha) p_l + alpha ( <R^3 p_bw>/<R^3> + rho <R^3 Rdot^2>/<R^3> )
```

and the radial-velocity contribution is positive. Eq. (A.71) of the same thesis carries the two contributions in a single bracket with the same sign, which is an independent check.

This matches what `m_riemann_solver_hllc.fpp` computes, where the correction is folded into `pres_L` and `pres_R` in place. The documentation was wrong, not the solver.

## Type of change

- [x] Documentation

## Scope

- [x] This PR comprises a set of related changes with a common goal

## Testing

Documentation only. No solver code is touched and no golden files move. `./mfc.sh precheck` passes.

## Notes

Reported by R. Jason Scharff in #1739, which this resolves.