### PR TITLE
Fill ptil so probe output stops writing undefined ptilde and ptot

### DIFF
--- a/src/simulation/m_bubbles_EE.fpp
+++ b/src/simulation/m_bubbles_EE.fpp
@@ -325,4 +325,65 @@ contains
 
     end subroutine s_compute_bubble_EE_source
 
+    !> Evaluate the Euler-Euler pressure correction at cell centers and store it in ptil. This mirrors the modified mixture pressure
+    !! that the HLLC solver applies to the reconstructed face states in m_riemann_solver_hllc.fpp, following Ando (2010), Eq. (2.5).
+    !! It is a diagnostic: ptil is read only by the probe output path and never feeds back into the solution.
+    impure subroutine s_compute_ptilde(q_cons_vf, q_prim_vf)
+
+        type(scalar_field), dimension(sys_size), intent(in) :: q_cons_vf, q_prim_vf
+        real(wp)                                            :: R3bar, R3V2bar, PbwR3bar
+        real(wp)                                            :: myRho, myP, alf, myR, myV, myPb
+        integer                                             :: j, k, l, q, ii
+
+        $:GPU_PARALLEL_LOOP(private='[j, k, l, q, ii, R3bar, R3V2bar, PbwR3bar, myRho, myP, alf, myR, myV, myPb]', collapse=3)
+        do l = 0, p
+            do k = 0, n
+                do j = 0, m
+                    alf = q_prim_vf(eqn_idx%alf)%sf(j, k, l)
+                    myP = q_prim_vf(eqn_idx%E)%sf(j, k, l)
+
+                    myRho = 0._wp
+                    $:GPU_LOOP(parallelism='[seq]')
+                    do ii = 1, num_fluids
+                        myRho = myRho + q_cons_vf(ii)%sf(j, k, l)
+                    end do
+
+                    if (qbmm) then
+                        R3bar = mom_sp(1)%sf(j, k, l)
+                        R3V2bar = mom_sp(3)%sf(j, k, l)
+                        PbwR3bar = mom_sp(4)%sf(j, k, l)
+                    else
+                        R3bar = 0._wp
+                        R3V2bar = 0._wp
+                        PbwR3bar = 0._wp
+
+                        $:GPU_LOOP(parallelism='[seq]')
+                        do q = 1, nb
+                            myR = q_prim_vf(rs(q))%sf(j, k, l)
+                            myV = q_prim_vf(vs(q))%sf(j, k, l)
+                            if (polytropic) then
+                                myPb = 0._wp
+                            else
+                                myPb = q_prim_vf(ps(q))%sf(j, k, l)
+                            end if
+
+                            R3bar = R3bar + weight(q)*(myR**3._wp)
+                            R3V2bar = R3V2bar + weight(q)*(myR**3._wp)*(myV**2._wp)
+                            PbwR3bar = PbwR3bar + weight(q)*f_cpbw_KM(R0(q), myR, myV, myPb)*(myR**3._wp)
+                        end do
+                    end if
+
+                    ! Same degenerate-state guard the HLLC solver uses
+                    if (alf < small_alf .or. R3bar < small_alf) then
+                        ptil(j, k, l) = alf*myP
+                    else
+                        ptil(j, k, l) = alf*(myP - PbwR3bar/R3bar - myRho*R3V2bar/R3bar)
+                    end if
+                end do
+            end do
+        end do
+        $:END_GPU_PARALLEL_LOOP()
+
+    end subroutine s_compute_ptilde
+
 end module m_bubbles_EE

--- a/src/simulation/m_rhs.fpp
+++ b/src/simulation/m_rhs.fpp
@@ -842,6 +842,13 @@ contains
             call nvtxEndRange
         end if
 
+        ! ptil is a probe-output diagnostic only, so evaluate it only when probes are on.
+        ! This sits outside the source-term branch above so that the qbmm and adap_dt
+        ! paths, which skip that branch, still get a filled ptil.
+        if (bubbles_euler .and. probe_wrt) then
+            call s_compute_ptilde(q_cons_qp%vf(1:sys_size), q_prim_qp%vf(1:sys_size))
+        end if
+
         if (bubbles_lagrange) then
             if (.not. adap_dt) then
                 call nvtxStartRange("RHS-EL-BUBBLES-DYN")

--- a/src/simulation/m_start_up.fpp
+++ b/src/simulation/m_start_up.fpp
@@ -621,6 +621,9 @@ contains
             do i = 1, sys_size
                 $:GPU_UPDATE(host='[q_cons_ts(1)%vf(i)%sf]')
             end do
+            if (bubbles_euler) then
+                $:GPU_UPDATE(host='[ptil]')
+            end if
         end if
 
         ! Total-variation-diminishing (TVD) Runge-Kutta (RK) time-steppers


### PR DESCRIPTION
## Description

`ptil` is allocated in `m_global_parameters.fpp:929` and pushed to the device, but nothing in the codebase ever assigns it. The probe path reads it anyway:

- `m_data_output.fpp:1300` `ptilde = ptil(j - 2, k, l)`
- `m_data_output.fpp:1301` `ptot = pres - ptilde`
- `m_data_output.fpp:1471` both are passed through `s_mpi_allreduce_sum`
- `m_data_output.fpp:1509` both are written to the probe file

So 1D Euler-Euler bubble runs with `probe_wrt = T` and `num_fluids = 3` have been writing undefined values in the `ptilde` and `ptot` columns. Because the values are MPI-reduced first, they are not reproducible across runs or rank counts. Fixes #1741.

## Changes

`s_compute_ptilde` in `m_bubbles_EE.fpp` evaluates the correction at cell centers, mirroring what the HLLC solver applies to reconstructed face states in `m_riemann_solver_hllc.fpp:736-746`:

```
ptil = alpha (p_l - <R^3 p_bw>/<R^3> - rho <R^3 Rdot^2>/<R^3>)
```

which is Eq. (2.5) of Ando (Caltech thesis, 2010). The `small_alf` degenerate branch and the QBMM moment path (`mom_sp` 1, 3, 4) are both mirrored so the diagnostic cannot drift from the solver.

It is called from `s_compute_rhs` rather than from `s_compute_bubble_EE_source`. The latter is guarded by `(.not. adap_dt) .and. (.not. qbmm)` at `m_rhs.fpp:839`, so hanging the fix off it would have left `ptil` unfilled in exactly the QBMM and adaptive-timestep cases.

`m_start_up.fpp` also gains a `GPU_UPDATE(host='[ptil]')` next to the existing `q_cons` sync in the `probe_wrt` block. Without it the array stayed device-resident and the host-side probe read would still have been invalid on GPU builds.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Scope

- [x] This PR comprises a set of related changes with a common goal

## Testing

Built `simulation` locally and ran `examples/1D_bubblescreen` (`bubbles_euler`, `probe_wrt`) with temporary instrumentation on `ptil`. Values are finite and evolve smoothly. The magnitudes check out against the case setup: the background patch has `alpha = 1e-12`, below `small_alf = 1e-11`, so it takes the degenerate branch and gives `ptil = alpha * p` of about `1e-12`, which matches the observed maximum. The bubble screen at `vf0 = 4e-5` contributes near zero because the bubbles start in equilibrium, so `p_l - p_bw` and `Rdot` both vanish. The instrumentation was removed before commit.

`./mfc.sh precheck` passes.

`ptil` is diagnostic only and never feeds back into the solution, and the new computation is gated on `probe_wrt`, so no golden values move.

## Note on coverage

No example or test case combines 1D, `bubbles_euler`, `probe_wrt`, and `num_fluids = 3`, which is why this went unnoticed. Adding one would be a reasonable follow-up.