### PR TITLE
Require two fluids for phase change

### DIFF
--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -645,12 +645,17 @@ class CaseValidator:
         relax = self.get("relax", "F") == "T"
         relax_model = self.get("relax_model")
         model_eqns = self.get("model_eqns")
+        num_fluids = self.get("num_fluids")
         palpha_eps = self.get("palpha_eps")
         ptgalpha_eps = self.get("ptgalpha_eps")
 
         if not relax:
             return
 
+        self.prohibit(
+            num_fluids is None or num_fluids < 2,
+            "phase change requires num_fluids >= 2 (liquid = 1, vapor = 2)",
+        )
         self.prohibit(
             (model_eqns not in (2, 3) or (model_eqns == 2 and relax_model not in (5, 6)) or (model_eqns == 3 and relax_model not in (1, 4, 5, 6))),
             "phase change requires model_eqns==2 with relax_model in [5,6] or model_eqns==3 with relax_model in [1,4,5,6]",

--- a/toolchain/mfc/test_case_validator.py
+++ b/toolchain/mfc/test_case_validator.py
@@ -242,6 +242,36 @@ class TestReactiveBurnFluidPairing(ConstraintTestCase):
         self.assertAccepts(REACTIVE_BURN)
 
 
+class TestPhaseChangeFluidPairing(ConstraintTestCase):
+    MSG = "phase change requires num_fluids >= 2 (liquid = 1, vapor = 2)"
+
+    def test_rejects_single_fluid(self):
+        self.assertRejects({**BASE, "relax": "T", "relax_model": 5}, self.MSG)
+
+    def test_rejects_unset_num_fluids(self):
+        params = {k: v for k, v in TWO_FLUID.items() if k != "num_fluids"}
+        self.assertRejects({**params, "relax": "T", "relax_model": 5}, self.MSG)
+
+    def test_accepts_two_fluids(self):
+        self.assertAccepts({**TWO_FLUID, "relax": "T", "relax_model": 5})
+
+    def test_accepts_three_fluids(self):
+        params = {
+            **TWO_FLUID,
+            "num_fluids": 3,
+            "fluid_pp(3)%gamma": 0.4,
+            "fluid_pp(3)%pi_inf": 0.0,
+            "patch_icpp(1)%alpha_rho(3)": 0.0,
+            "patch_icpp(1)%alpha(3)": 0.0,
+            "relax": "T",
+            "relax_model": 5,
+        }
+        self.assertAccepts(params)
+
+    def test_not_checked_when_disabled(self):
+        self.assertAccepts({**BASE, "relax": "F"})
+
+
 class TestSyntheticTurbulence(ConstraintTestCase):
     """A 2D case with one fully specified forcing zone."""
 


### PR DESCRIPTION
## Description

Reject phase-change configurations with fewer than two carrier fluids.

The phase-change operator uses fixed liquid and vapor indices `lp = 1` and
`vp = 2` and writes both indexed fields. With one carrier fluid, the vapor
index aliases x-momentum.

This implements the narrow validation guard requested in Issue #1738. It
intentionally does not address the broader phase-change/Euler–Euler
compatibility question.

Fixes #1738.

### Type of change

- Bug fix

## Testing

- Added direct validator coverage for:
  - disabled phase change;
  - missing `num_fluids`;
  - one fluid;
  - two fluids;
  - three fluids.
- `TestPhaseChangeFluidPairing`: 5 passed.
- Complete `test_case_validator.py`: 51 passed.
- Complete `./mfc.sh lint`: passed.
  - Ruff passed for toolchain, examples, and benchmarks.
  - 459 bundled tests passed with 8 warnings and 9 subtests passed.
- Validator-only one-fluid probe: the new constraint was reported for all three
  validation stages.
- Validator-only two-fluid phase-change probe: passed all three stages.
- Unmodified `2D_phasechange_bubble` positive control: passed all three stages.
- Normal pre-commit hook: all seven stages passed.
- `git diff --check`: passed.

No preprocessing or simulation of the unsafe one-fluid configuration was
performed.

## Checklist

- [x] I added or updated tests for the new behavior.
- [x] The change is limited to the validator and focused validator tests.