### PR TITLE
Switch Frontier CI from the revoked hackathon QOS to normal

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -54,7 +54,12 @@ case "$cluster" in
         compiler_flag="f"
         account="CFD154"
         job_prefix="MFC"
-        qos="hackathon"
+        # The hackathon QOS was a temporary grant and is no longer held by
+        # CFD154; submitting under it now fails outright with "Invalid qos
+        # specification". "normal" is the only QOS on this allocation without a
+        # one-job-at-a-time cap, so it is the only one that can run the CI
+        # matrix concurrently.
+        qos="normal"
         # Let each job's slurmstepd broker its own steps instead of routing
         # every srun through slurmctld. The in-job test suite launches ~1700+
         # srun steps per allocation, which congests the Frontier controller.
@@ -67,7 +72,7 @@ case "$cluster" in
         compiler_flag="famd"
         account="CFD154"
         job_prefix="MFC"
-        qos="hackathon"
+        qos="normal"
         extra_sbatch="#SBATCH --stepmgr"
         test_time="01:59:00"
         bench_time="01:59:00"


### PR DESCRIPTION
## Description

Frontier CI is currently failing on every job. The `hackathon` QOS that `.github/scripts/submit-slurm-job.sh` submits under was a temporary grant on `CFD154`, and that grant has ended — `sbatch` now rejects it outright:

```
sbatch attempt 1 of 3...
sbatch failed: sbatch: error: Batch job submission failed: Invalid qos specification
Non-transient sbatch failure — not retrying.
```

All 12 Frontier jobs (CCE and AMD, cpu and gpu, including the Case Opt jobs) failed this way in run [32414716605](https://github.com/MFlowCode/MFC/actions/runs/32414716605). `retry-sbatch` correctly classifies this as non-transient, so it fails immediately rather than burning retries.

The `hackathon` QOS was introduced for Frontier CI in c99ac2df ("Default Frontier templates to hackathon QOS/partition", #1407).

This switches both the `frontier` and `frontier_amd` blocks to `qos="normal"`. Nothing else changes — partition (`batch`), `-n 8` / `-n 32`, `01:59:00` walltimes, and `--stepmgr` are all untouched, as is Phoenix's `embers`.

### Why `normal` specifically

It's the only QOS left on this allocation that permits more than one job at a time, which the CI matrix requires:

| QOS | concurrency limit |
|---|---|
| `normal` | none (association caps submissions at 100) |
| `debug` | `MaxSubmitPU=1` — one job in the queue, period |
| `develop` | `MaxJobsPU=1`, plus `node=30` and a hard 2h `MaxWall` |
| `jupyter` | `MaxJobsPU=1` |

`develop` was the pre-#1407 setting, but with `MaxJobsPU=1` it would serialize the matrix one job at a time, and its 2h `MaxWall` leaves no headroom over our `01:59:00`.

### Known regression

Turnaround gets worse. Measured 1-node queue waits on Frontier over the three days before the grant lapsed:

| QOS | n | median | p90 |
|---|---|---|---|
| `hackathon` | 989 | 0.53 min | 1.2 min |
| `normal` | 9602 | 5.1 min | 5.2 h |

`hackathon` gave CI a tight sub-2-minute start. `normal` has a 5-minute median but a long tail, and each run waits on the slowest of ~12 jobs. This unblocks the pipeline; restoring a priority QOS for CI is the real fix and needs an OLCF request against `CFD154`.

### Type of change

- Bug fix

## Testing

Validated the exact job shapes this script generates against the live Frontier scheduler with `sbatch --test-only`:

```
-A CFD154 -p batch -q normal -N1 -n8  -t 01:59:00 --stepmgr  → accepted
-A CFD154 -p batch -q normal -N1 -n32 -t 01:59:00 --stepmgr  → accepted
```

Both are rejected with `Invalid qos specification` under `-q hackathon`, confirming the diagnosis and the fix. Also submitted real 1-node jobs under `-q normal` to confirm concurrency: four submitted simultaneously all went PENDING → RUNNING in 23 s on four separate nodes, with no per-user limit rejections.

Full CI on this PR is the real check.

## Checklist

- [ ] I added or updated tests for new behavior
- [ ] I updated documentation if user-facing behavior changed

CI-only configuration change; no test or documentation surface.
