### PR TITLE
CI: exclude bad Phoenix GPU node atl1-1-03-007-29-0 (uncorrectable ECC)

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -126,7 +126,7 @@ elif [ "$device" = "gpu" ]; then
 #SBATCH -p $gpu_partition
 #SBATCH --ntasks-per-node=4
 #SBATCH -G2
-#SBATCH --exclude=atl1-1-03-002-29-0"
+#SBATCH --exclude=atl1-1-03-002-29-0,atl1-1-03-007-29-0"
             ;;
         frontier|frontier_amd)
             sbatch_device_opts="\


### PR DESCRIPTION
## Problem

Phoenix GPU CI jobs (`Georgia Tech | Phoenix (NVHPC)`, both `gpu-acc` and `gpu-omp`, including Case-Opt) have been failing repeatedly on `master` and across open PRs. Every failure is the same hardware fault, hit at `syscheck` before any real test runs:

```
Accelerator Fatal Error: call to cuCtxCreate returned error 214
  (CUDA_ERROR_ECC_UNCORRECTABLE): uncorrectable ECC error encountered
mfc: ERROR > syscheck failed with exit code 1.
```

It is intermittent because it depends on which node SLURM assigns: healthy node → pass, bad node → instant failure of every case. CPU/GNU jobs are unaffected.

## Root cause

A single GPU node, **`atl1-1-03-007-29-0`** (an L40S node — first in our partition priority, so CI lands on it often), has uncorrectable ECC memory errors. It accounts for the ECC failures in the last 5 failed runs:

| Run | Branch |
|-----|--------|
| 32374295683 | master |
| 32328468536 | master |
| 32581097507 | debug-wall-collisions |
| 32313406801 | feature/eos-selector-v2 |
| 32302074298 | fix/ptilde-probe-output |

The node is still `State=MIXED` in SLURM (not drained by PACE), so CI keeps getting scheduled onto it.

## Fix

Add the node to the existing `--exclude` list in `submit-slurm-job.sh` (which already excludes one previously-dead GPU node). This is the immediate unblock; the node is also being reported to PACE for GPU repair/drain.

```
#SBATCH --exclude=atl1-1-03-002-29-0,atl1-1-03-007-29-0
```