### PR TITLE
CI: reclaim Phoenix V100 node atl1-1-03-002-29-0 (ECC verified clean)

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -126,7 +126,7 @@ elif [ "$device" = "gpu" ]; then
 #SBATCH -p $gpu_partition
 #SBATCH --ntasks-per-node=4
 #SBATCH -G2
-#SBATCH --exclude=atl1-1-03-002-29-0,atl1-1-03-007-29-0"
+#SBATCH --exclude=atl1-1-03-007-29-0"
             ;;
         frontier|frontier_amd)
             sbatch_device_opts="\


### PR DESCRIPTION
## What

Removes `atl1-1-03-002-29-0` from the Phoenix GPU `--exclude` list, leaving only the confirmed-bad `atl1-1-03-007-29-0` (excluded in #1748).

## Why

`atl1-1-03-002-29-0` was excluded a while ago for the same uncorrectable-ECC failure we just hit on the L40S node. I verified directly on the node (job 12217630, `inferno` QOS) that its GPU is now healthy:

```
Tesla V100-PCIE-32GB, ECC Enabled
uncorrected ECC — aggregate: 0, volatile: 0
CUDA context creates cleanly — job COMPLETED, exit 0:0
```

Zero uncorrectable ECC errors and `cuCtxCreate` succeeds, so the exclusion is stale. The blacklist should track genuinely-broken hardware only; the one actively-faulting node (`atl1-1-03-007-29-0`) stays excluded.

Note: the V100 partition is still last in `select-gpu-partition.sh` priority, so reclaiming this node adds little scheduling capacity — but there's no hardware reason to keep it blocked.