### PR TITLE
CI: exclude bad Phoenix L40S node atl1-1-03-007-31-0 (uncorrectable ECC)

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -126,7 +126,7 @@ elif [ "$device" = "gpu" ]; then
 #SBATCH -p $gpu_partition
 #SBATCH --ntasks-per-node=4
 #SBATCH -G2
-#SBATCH --exclude=atl1-1-03-007-29-0"
+#SBATCH --exclude=atl1-1-03-007-29-0,atl1-1-03-007-31-0"
             ;;
         frontier|frontier_amd)
             sbatch_device_opts="\


### PR DESCRIPTION
## What

Adds `atl1-1-03-007-31-0` to the Phoenix GPU `--exclude` list. Net exclude is now `atl1-1-03-007-29-0,atl1-1-03-007-31-0`.

## Why

A second L40S node in the **same chassis** as the already-excluded `007-29-0` (both `atl1-1-03-007-*`) is failing every GPU job with the same hardware fault:

```
Accelerator Fatal Error: call to cuCtxCreate returned error 214
  (CUDA_ERROR_ECC_UNCORRECTABLE): uncorrectable ECC error encountered
```

Confirmed across a CI sweep — `007-31-0` is the ECC source in the most recent `master` run ([32601124944](https://github.com/MFlowCode/MFC/actions/runs/32601124944), 105 ECC hits) and a PR run, exactly as `007-29-0` was in the prior batch. Reruns don't help: SLURM has no GPU-health awareness and keeps rescheduling onto the same bad node.

Note: the `PMIX ERROR: PMIX_ERR_NO_PERMISSIONS ... dstore_base.c` lines in these logs are **benign** (they appear on passing syscheck/pre_process steps too, from the hpcx/2.19-cuda PMIx dstore); they are not the failure cause. The failure is the ECC fault above.

Both bad GPUs are being reported to PACE for repair/drain; this exclude is the CI unblock in the meantime.