### PR TITLE
test: smoke-test the LOC bot from a fork (do not merge)

### DIFF
--- a/src/simulation/m_global_parameters.fpp
+++ b/src/simulation/m_global_parameters.fpp
@@ -681,7 +681,8 @@ contains
     !> Initialize the global parameters module
     impure subroutine s_initialize_global_parameters_module
 
-        integer :: i, j, k
+        integer :: i, j
+        integer :: k
         integer :: fac
 
         #:if not MFC_CASE_OPTIMIZATION


### PR DESCRIPTION
Second smoke test for the bot from #1753, this time **from a fork** — the case #1754 could not cover. **Do not merge — will be closed.**

Two things under test:

1. **Fork PRs get commented at all.** This is the entire reason the workflow uses `pull_request_target`; under `pull_request` a fork's `GITHUB_TOKEN` is read-only and the comment would fail. It also exercises fetching `refs/pull/N/head` for a fork head.

2. **Merge-base counting.** This fork's master is 32 commits stale, and its `src/` tree differs from upstream master by **-1403 lines**. Counting against master's *tip* would blame this PR for roughly -1403 lines of other people's deletions. Counting against the merge base should report **+1** — the one declaration line this PR actually splits.

Expected comment: `m_global_parameters.fpp +1`, `**total** +1`. Anything near -1403 means the merge-base logic is broken.