### PR TITLE
ci(phoenix): bound SLURM queue wait and combine build+test into one allocation

### DIFF
--- a/.github/scripts/monitor_slurm_job.sh
+++ b/.github/scripts/monitor_slurm_job.sh
@@ -86,7 +86,15 @@ is_terminal_state() {
 # (Phoenix 'embers') a job can stay PENDING for hours, burning the CI job
 # timeout and holding a runner slot; fail early so it reads as queue starvation,
 # not a test failure. 0 = wait indefinitely.
-: "${SLURM_MAX_QUEUE_SECONDS:=5400}"   # 90 minutes
+#
+# The budget has to clear a normal bad day on a busy machine, or it converts
+# routine queue pressure into red CI. Frontier's own numbers make the case:
+# over one week, MFC jobs on `batch` waited p50=1m but p90=96m and p95=176m,
+# with a 466m tail. A 90-minute budget cut into that distribution, tripping on
+# 11% of the jobs that did eventually start -- plus the ones that never did.
+# Four hours clears p95 with room to spare while staying well inside the 480m
+# job-level `timeout-minutes`, which remains the real backstop.
+: "${SLURM_MAX_QUEUE_SECONDS:=14400}"   # 4 hours
 # Reject a non-integer override rather than silently skipping the budget.
 if ! [[ "$SLURM_MAX_QUEUE_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "ERROR: SLURM_MAX_QUEUE_SECONDS must be a non-negative integer (seconds), got '$SLURM_MAX_QUEUE_SECONDS'" >&2

--- a/.github/scripts/monitor_slurm_job.sh
+++ b/.github/scripts/monitor_slurm_job.sh
@@ -90,6 +90,12 @@ is_terminal_state() {
 # failure reads as infrastructure (queue starvation), not a code/test failure.
 # Set SLURM_MAX_QUEUE_SECONDS=0 to wait indefinitely (previous behaviour).
 : "${SLURM_MAX_QUEUE_SECONDS:=5400}"   # 90 minutes
+# Fail loudly on a non-integer override rather than silently disabling the
+# budget (a bad `[ -gt ]` comparison would otherwise just skip the check).
+if ! [[ "$SLURM_MAX_QUEUE_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: SLURM_MAX_QUEUE_SECONDS must be a non-negative integer (seconds), got '$SLURM_MAX_QUEUE_SECONDS'" >&2
+  exit 1
+fi
 queue_start=$(date +%s)
 
 abort_queue_starvation() {

--- a/.github/scripts/monitor_slurm_job.sh
+++ b/.github/scripts/monitor_slurm_job.sh
@@ -82,13 +82,48 @@ is_terminal_state() {
   esac
 }
 
+# Bound how long the job may sit un-started in the scheduler queue.
+# Under a contended, preemptible QOS (e.g. Phoenix 'embers') a job can stay
+# PENDING for many hours, burning the entire CI job timeout, holding a
+# self-hosted runner slot hostage, and surfacing as an opaque ~8 h 'cancelled'.
+# Give up after a bounded queue wait with a loud, greppable message so the
+# failure reads as infrastructure (queue starvation), not a code/test failure.
+# Set SLURM_MAX_QUEUE_SECONDS=0 to wait indefinitely (previous behaviour).
+: "${SLURM_MAX_QUEUE_SECONDS:=5400}"   # 90 minutes
+queue_start=$(date +%s)
+
+abort_queue_starvation() {
+  local waited="$1"
+  echo "##[error]SLURM job $job_id did not start within ${waited}s (SLURM_MAX_QUEUE_SECONDS=$SLURM_MAX_QUEUE_SECONDS)."
+  echo "QUEUE STARVATION: the cluster scheduler could not start this job in time."
+  echo "This is an infrastructure / queue-availability problem, NOT a code or test failure."
+  echo "Cancelling the queued job so it does not keep holding a CI runner slot."
+  scancel "$job_id" 2>/dev/null || true
+  exit 75   # EX_TEMPFAIL — distinguishes queue starvation from a real test failure
+}
+
 # Wait for file to appear, using robust state checking.
-# Never give up due to transient squeue/sacct failures — the CI job timeout
-# is the ultimate backstop.
+# Never give up due to transient squeue/sacct failures — the queue-wait budget
+# above (or the CI job timeout) is the ultimate backstop.
 echo "Waiting for job to start..."
 unknown_count=0
 while [ ! -f "$output_file" ]; do
   state=$(get_job_state "$job_id")
+
+  # Enforce the queue-wait budget. A job that has actually started
+  # (RUNNING/COMPLETING) but whose output file is merely NFS-delayed is exempt,
+  # so a job that is already doing work is never killed here.
+  if [ "$SLURM_MAX_QUEUE_SECONDS" -gt 0 ]; then
+    case "$state" in
+      RUNNING|COMPLETING) ;;
+      *)
+        waited=$(( $(date +%s) - queue_start ))
+        if [ "$waited" -ge "$SLURM_MAX_QUEUE_SECONDS" ]; then
+          abort_queue_starvation "$waited"
+        fi
+        ;;
+    esac
+  fi
 
   case "$state" in
     PENDING|CONFIGURING|PREEMPTED)

--- a/.github/scripts/monitor_slurm_job.sh
+++ b/.github/scripts/monitor_slurm_job.sh
@@ -82,16 +82,12 @@ is_terminal_state() {
   esac
 }
 
-# Bound how long the job may sit un-started in the scheduler queue.
-# Under a contended, preemptible QOS (e.g. Phoenix 'embers') a job can stay
-# PENDING for many hours, burning the entire CI job timeout, holding a
-# self-hosted runner slot hostage, and surfacing as an opaque ~8 h 'cancelled'.
-# Give up after a bounded queue wait with a loud, greppable message so the
-# failure reads as infrastructure (queue starvation), not a code/test failure.
-# Set SLURM_MAX_QUEUE_SECONDS=0 to wait indefinitely (previous behaviour).
+# Bound how long a job may sit un-started in the queue. On a preemptible QOS
+# (Phoenix 'embers') a job can stay PENDING for hours, burning the CI job
+# timeout and holding a runner slot; fail early so it reads as queue starvation,
+# not a test failure. 0 = wait indefinitely.
 : "${SLURM_MAX_QUEUE_SECONDS:=5400}"   # 90 minutes
-# Fail loudly on a non-integer override rather than silently disabling the
-# budget (a bad `[ -gt ]` comparison would otherwise just skip the check).
+# Reject a non-integer override rather than silently skipping the budget.
 if ! [[ "$SLURM_MAX_QUEUE_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "ERROR: SLURM_MAX_QUEUE_SECONDS must be a non-negative integer (seconds), got '$SLURM_MAX_QUEUE_SECONDS'" >&2
   exit 1
@@ -116,9 +112,8 @@ unknown_count=0
 while [ ! -f "$output_file" ]; do
   state=$(get_job_state "$job_id")
 
-  # Enforce the queue-wait budget. A job that has actually started
-  # (RUNNING/COMPLETING) but whose output file is merely NFS-delayed is exempt,
-  # so a job that is already doing work is never killed here.
+  # A started job (RUNNING/COMPLETING) whose output file is merely NFS-delayed
+  # is exempt, so work in progress is never killed here.
   if [ "$SLURM_MAX_QUEUE_SECONDS" -gt 0 ]; then
     case "$state" in
       RUNNING|COMPLETING) ;;

--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -34,8 +34,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Detect job type from submitted script basename
 script_basename="$(basename "$script_path" .sh)"
 case "$script_basename" in
-    bench*) job_type="bench" ;;
-    *)      job_type="test"  ;;
+    bench*)          job_type="bench" ;;
+    build-and-test*) job_type="buildtest" ;;
+    *)               job_type="test"  ;;
 esac
 
 # --- Cluster configuration ---
@@ -47,6 +48,10 @@ case "$cluster" in
         qos="embers"
         extra_sbatch="#SBATCH --requeue"
         test_time="03:00:00"
+        # Combined build+test runs both phases in one allocation (one queue
+        # wait instead of two). It needs headroom for the build on top of the
+        # test budget; kept modest so it still backfills well under 'embers'.
+        buildtest_time="03:30:00"
         bench_time="04:00:00"
         gpu_partition_dynamic=true
         ;;
@@ -85,11 +90,11 @@ case "$cluster" in
 esac
 
 # --- Time limit ---
-if [ "$job_type" = "bench" ]; then
-    sbatch_time="#SBATCH -t $bench_time"
-else
-    sbatch_time="#SBATCH -t $test_time"
-fi
+case "$job_type" in
+    bench)     sbatch_time="#SBATCH -t $bench_time" ;;
+    buildtest) sbatch_time="#SBATCH -t $buildtest_time" ;;
+    *)         sbatch_time="#SBATCH -t $test_time" ;;
+esac
 
 # --- Device-specific SBATCH options ---
 if [ "$device" = "cpu" ]; then
@@ -196,12 +201,14 @@ set -x
 cd "\$SLURM_SUBMIT_DIR"
 echo "Running in \$(pwd):"
 
-job_slug="$job_slug"
-job_device="$device"
-job_interface="$interface"
-job_shard="$shard"
-job_variant="$variant"
-job_cluster="$cluster"
+# Exported so a wrapper script (e.g. build-and-test.sh) can run build.sh and
+# test.sh as child processes that inherit these, not just inline this shell.
+export job_slug="$job_slug"
+export job_device="$device"
+export job_interface="$interface"
+export job_shard="$shard"
+export job_variant="$variant"
+export job_cluster="$cluster"
 export GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME"
 
 . ./mfc.sh load -c $compiler_flag -m $module_mode

--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -62,7 +62,10 @@ case "$cluster" in
         # CFD154; submitting under it now fails outright with "Invalid qos
         # specification". "normal" is the only QOS on this allocation without a
         # one-job-at-a-time cap, so it is the only one that can run the CI
-        # matrix concurrently.
+        # matrix concurrently. Note that the g1 partition carries its own
+        # partition QOS (also named "g1"), which slurmctld applies on its own
+        # when a job lands there. Do not add --qos=g1: CFD154 has no
+        # association with it and sbatch rejects the job outright.
         qos="normal"
         # Let each job's slurmstepd broker its own steps instead of routing
         # every srun through slurmctld. The in-job test suite launches ~1700+
@@ -105,9 +108,11 @@ if [ "$device" = "cpu" ]; then
 #SBATCH --mem-per-cpu=8G"
             ;;
         frontier|frontier_amd)
+            # g1 is a dedicated 64-node carve-out; its nodes are not in batch,
+            # so CI starts promptly instead of queueing behind the machine.
             sbatch_device_opts="\
 #SBATCH -n 32
-#SBATCH -p batch"
+#SBATCH -p g1"
             ;;
     esac
 elif [ "$device" = "gpu" ]; then
@@ -135,7 +140,7 @@ elif [ "$device" = "gpu" ]; then
         frontier|frontier_amd)
             sbatch_device_opts="\
 #SBATCH -n 8
-#SBATCH -p batch"
+#SBATCH -p g1"
             ;;
     esac
 else

--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -48,9 +48,8 @@ case "$cluster" in
         qos="embers"
         extra_sbatch="#SBATCH --requeue"
         test_time="03:00:00"
-        # Combined build+test runs both phases in one allocation (one queue
-        # wait instead of two). It needs headroom for the build on top of the
-        # test budget; kept modest so it still backfills well under 'embers'.
+        # Combined build+test needs build headroom on top of the test budget;
+        # kept modest to still backfill under 'embers'.
         buildtest_time="03:30:00"
         bench_time="04:00:00"
         gpu_partition_dynamic=true
@@ -201,8 +200,7 @@ set -x
 cd "\$SLURM_SUBMIT_DIR"
 echo "Running in \$(pwd):"
 
-# Exported so a wrapper script (e.g. build-and-test.sh) can run build.sh and
-# test.sh as child processes that inherit these, not just inline this shell.
+# Exported so wrapper scripts (build-and-test.sh) run child scripts that inherit these.
 export job_slug="$job_slug"
 export job_device="$device"
 export job_interface="$interface"

--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -92,7 +92,7 @@ esac
 # --- Time limit ---
 case "$job_type" in
     bench)     sbatch_time="#SBATCH -t $bench_time" ;;
-    buildtest) sbatch_time="#SBATCH -t $buildtest_time" ;;
+    buildtest) sbatch_time="#SBATCH -t ${buildtest_time:-$test_time}" ;;
     *)         sbatch_time="#SBATCH -t $test_time" ;;
 esac
 

--- a/.github/workflows/common/build-and-test.sh
+++ b/.github/workflows/common/build-and-test.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
-# Combined build-then-test for a single SLURM allocation.
-# Runs inside a SLURM job via submit-slurm-job.sh. Doing both phases in one
-# allocation means the scheduler queue wait is paid once instead of twice —
-# on a contended, preemptible QOS (Phoenix 'embers') the queue wait, not the
-# work, is what makes CI slow and flaky.
-#
-# Relies on submit-slurm-job.sh exporting the job_* vars (job_device,
-# job_interface, job_cluster, ...) so the child scripts inherit them. cwd is
-# $SLURM_SUBMIT_DIR (the workspace root), so build/ persists from build.sh into
-# test.sh's --no-build run.
+# Build then test in a single SLURM allocation so the scheduler queue wait is
+# paid once instead of twice (Phoenix 'embers' is queue-bound, not work-bound).
+# submit-slurm-job.sh exports the job_* vars so these child scripts inherit
+# them; cwd is the workspace root, so build/ persists into test.sh's --no-build.
 
 set -euo pipefail
 

--- a/.github/workflows/common/build-and-test.sh
+++ b/.github/workflows/common/build-and-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Combined build-then-test for a single SLURM allocation.
+# Runs inside a SLURM job via submit-slurm-job.sh. Doing both phases in one
+# allocation means the scheduler queue wait is paid once instead of twice —
+# on a contended, preemptible QOS (Phoenix 'embers') the queue wait, not the
+# work, is what makes CI slow and flaky.
+#
+# Relies on submit-slurm-job.sh exporting the job_* vars (job_device,
+# job_interface, job_cluster, ...) so the child scripts inherit them. cwd is
+# $SLURM_SUBMIT_DIR (the workspace root), so build/ persists from build.sh into
+# test.sh's --no-build run.
+
+set -euo pipefail
+
+echo "=== [build-and-test] Build phase ==="
+bash .github/workflows/common/build.sh
+
+echo "=== [build-and-test] Test phase ==="
+bash .github/workflows/common/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -511,8 +511,10 @@ jobs:
         run:  |
           # build_slug matches the plain log (and per-variant base/chem builds);
           # combined_slug matches Phoenix's single build-and-test allocation.
+          # Use `if` (not `[ -f ] && ...`) so a missing file — e.g. test_slug on
+          # Phoenix's combined jobs — doesn't make the loop exit non-zero under -e.
           for f in ${{ steps.log.outputs.build_slug }}*.out ${{ steps.log.outputs.combined_slug }}.out ${{ steps.log.outputs.test_slug }}.out; do
-            [ -f "$f" ] && echo "=== $f ===" && cat "$f"
+            if [ -f "$f" ]; then echo "=== $f ==="; cat "$f"; fi
           done
 
       - name: Archive Logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -455,7 +455,9 @@ jobs:
         run:  bash .github/workflows/${{ matrix.cluster }}/build.sh ${{ matrix.device }} ${{ matrix.interface }}
 
       - name: Build
-        if:   ${{ !(matrix.cluster == 'frontier_amd' && matrix.device == 'gpu') }}
+        # Phoenix builds+tests in one allocation (see "Build & Test" below); every
+        # other cluster keeps the separate build job.
+        if:   ${{ matrix.cluster != 'phoenix' && !(matrix.cluster == 'frontier_amd' && matrix.device == 'gpu') }}
         run:  bash .github/scripts/submit-slurm-job.sh .github/workflows/common/build.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }} ${{ matrix.shard }}
 
       - name: Build (concurrent variants)
@@ -474,7 +476,14 @@ jobs:
           for p in $pids; do wait "$p" || rc=1; done
           exit $rc
 
+      - name: Build & Test
+        # Phoenix: build and test in a single SLURM allocation so the scheduler
+        # queue wait (preemptible 'embers' QOS) is paid once instead of twice.
+        if:   matrix.cluster == 'phoenix'
+        run:  bash .github/scripts/submit-slurm-job.sh .github/workflows/common/build-and-test.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }} ${{ matrix.shard }}
+
       - name: Test
+        if:   matrix.cluster != 'phoenix'
         run:  bash .github/scripts/submit-slurm-job.sh .github/workflows/common/test.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }} ${{ matrix.shard }}
 
       - name: Cancel SLURM Jobs
@@ -497,13 +506,15 @@ jobs:
           fi
           echo "build_slug=build-${{ matrix.device }}-${{ matrix.interface }}${SHARD_SUFFIX}" >> "$GITHUB_OUTPUT"
           echo "test_slug=test-${{ matrix.device }}-${{ matrix.interface }}${SHARD_SUFFIX}" >> "$GITHUB_OUTPUT"
+          echo "combined_slug=build-and-test-${{ matrix.device }}-${{ matrix.interface }}${SHARD_SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Print Logs
         if:   always()
         run:  |
           # The build slug matches the plain log and, where the build is split per
-          # variant, the build-...-base/-chem ones.
-          for f in ${{ steps.log.outputs.build_slug }}*.out ${{ steps.log.outputs.test_slug }}.out; do
+          # variant, the build-...-base/-chem ones. The combined slug matches
+          # Phoenix's single build-and-test allocation.
+          for f in ${{ steps.log.outputs.build_slug }}*.out ${{ steps.log.outputs.combined_slug }}.out ${{ steps.log.outputs.test_slug }}.out; do
             [ -f "$f" ] && echo "=== $f ===" && cat "$f"
           done
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -455,8 +455,7 @@ jobs:
         run:  bash .github/workflows/${{ matrix.cluster }}/build.sh ${{ matrix.device }} ${{ matrix.interface }}
 
       - name: Build
-        # Phoenix builds+tests in one allocation (see "Build & Test" below); every
-        # other cluster keeps the separate build job.
+        # Phoenix builds+tests in one allocation (see "Build & Test"); others build separately.
         if:   ${{ matrix.cluster != 'phoenix' && !(matrix.cluster == 'frontier_amd' && matrix.device == 'gpu') }}
         run:  bash .github/scripts/submit-slurm-job.sh .github/workflows/common/build.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }} ${{ matrix.shard }}
 
@@ -477,8 +476,7 @@ jobs:
           exit $rc
 
       - name: Build & Test
-        # Phoenix: build and test in a single SLURM allocation so the scheduler
-        # queue wait (preemptible 'embers' QOS) is paid once instead of twice.
+        # Phoenix: build+test in one allocation so the 'embers' queue wait is paid once.
         if:   matrix.cluster == 'phoenix'
         run:  bash .github/scripts/submit-slurm-job.sh .github/workflows/common/build-and-test.sh ${{ matrix.device }} ${{ matrix.interface }} ${{ matrix.cluster }} ${{ matrix.shard }}
 
@@ -511,9 +509,8 @@ jobs:
       - name: Print Logs
         if:   always()
         run:  |
-          # The build slug matches the plain log and, where the build is split per
-          # variant, the build-...-base/-chem ones. The combined slug matches
-          # Phoenix's single build-and-test allocation.
+          # build_slug matches the plain log (and per-variant base/chem builds);
+          # combined_slug matches Phoenix's single build-and-test allocation.
           for f in ${{ steps.log.outputs.build_slug }}*.out ${{ steps.log.outputs.combined_slug }}.out ${{ steps.log.outputs.test_slug }}.out; do
             [ -f "$f" ] && echo "=== $f ===" && cat "$f"
           done


### PR DESCRIPTION
## What & why

Phoenix CI has been failing as opaque ~8h `cancelled` jobs. Root cause, from the run logs, is **SLURM queue starvation, not test failures**:

- Jobs sit `PENDING` for hours on the preemptible `embers` QOS (few idle GPU nodes on `gpu-l40s`), burning the entire `timeout-minutes: 480` budget.
- **Build** and **Test** are two *separate* SLURM submissions in one GitHub job, so we pay the queue lottery twice, back-to-back, under one 8h cap. In a representative run, Build queued ~4h15m and Test then never started before the cap.
- A stuck job also holds a self-hosted `phoenix-N` runner slot for the full 8h, so unrelated PRs back up behind it.

Across the last 30 `test.yml` runs, Phoenix jobs were **61% cancelled / 32% success / 7% failure** — but of jobs that actually *ran to completion*, ~83% passed. The red is overwhelmingly queue/infra, not code.

This PR does not try to buy more nodes; it makes the failure mode fast and legible, and halves each job's exposure to the queue.

## Changes

**A. Bound the queue wait** (`monitor_slurm_job.sh`)
- New `SLURM_MAX_QUEUE_SECONDS` (default 90m; `0` = old behaviour). If a job never leaves the queue, `scancel` it and fail fast with an explicit `QUEUE STARVATION … infrastructure, not a code/test failure` message (exit 75).
- A job that has actually started (`RUNNING`/`COMPLETING`) but whose output file is merely NFS-delayed is exempt, so a job already doing work is never killed.
- Effect: no more 8h zombies; stuck jobs release their runner slot in ~90m; queue problems are greppable instead of masquerading as `cancelled`.

**B. Combine build+test into one Phoenix allocation** (`build-and-test.sh`, `submit-slurm-job.sh`, `test.yml`)
- Phoenix now submits a single `build-and-test.sh` allocation (build → test) so the scheduler queue wait is paid **once instead of twice**.
- `submit-slurm-job.sh` exports the `job_*` vars so the child `build.sh`/`test.sh` inherit them, and gets a `buildtest` time budget (3h30m — test budget plus build headroom, kept modest to preserve `embers` backfill).
- Every other cluster (Frontier CCE / AMD) is untouched: separate build/test steps, same times.

## Testing

- Stubbed-SLURM harness for A: a stuck `PENDING` job aborts with the starvation message and exit 75; a `RUNNING` job is exempt from the budget and proceeds to stream. 
- Verified job-type → time-budget → log-slug derivation for `build-and-test` / `test` / `bench` so Phoenix's combined `build-and-test-*.out` is still picked up by *Print Logs*.
- `bash -n` on all three scripts; YAML validated.

## Notes / follow-ups

- The one tunable knob is `buildtest_time` (3h30m). If combined runs ever approach it, bump there.
- A natural follow-up (deliberately out of scope): escalate `embers → inferno` after the queue-wait budget elapses, behind a flag, to spend SUs only when the free queue is starved.

## Acknowledgement

- [x] I confirm this PR meets the above expectations and reflects my own understanding and real-world context.
