### PR TITLE
CI: skip the redundant rebuild in the case-opt run job

### DIFF
--- a/.github/scripts/run_case_optimization.sh
+++ b/.github/scripts/run_case_optimization.sh
@@ -80,14 +80,17 @@ for case in "${benchmarks[@]}"; do
 
     # Run with --case-optimization, small grid, 10 timesteps. On phoenix and
     # frontier_amd $build_opts is --no-build, so the run reuses the pre-build's
-    # binaries. A prebuilt binary can be missing at run time (the pre-build and
-    # run SLURM jobs may be separated by a long embers queue wait, or clean_build
-    # on a retry may have wiped build/), and a bare --no-build run would then
-    # hard-fail. Fall back to a rebuild-and-run for that case so a lost prebuild
-    # artifact degrades to a slower run instead of a red CI.
+    # binaries. On phoenix (a single, unsharded job) a prebuilt binary can still
+    # be missing at run time (the pre-build and run SLURM jobs may be separated
+    # by a long embers queue wait, or clean_build on a retry may have wiped
+    # build/), which would hard-fail a bare --no-build run; fall back to a
+    # rebuild-and-run so a lost artifact degrades to a slower run instead of a
+    # red CI. frontier_amd is excluded: its run is sharded across concurrent
+    # jobs sharing one workspace, so a fallback rebuild would race on the shared
+    # install paths (the collision the --no-build guard above prevents).
     if ./mfc.sh run "$case" --case-optimization $gpu_opts $build_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
         run_ok=1
-    elif [ -n "$build_opts" ] && \
+    elif [ "$job_cluster" = phoenix ] && \
          ./mfc.sh run "$case" --case-optimization $gpu_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
         echo "NOTE: $case_name rebuilt in-run (prebuilt binary was unavailable)"
         run_ok=1

--- a/.github/scripts/run_case_optimization.sh
+++ b/.github/scripts/run_case_optimization.sh
@@ -78,9 +78,24 @@ for case in "${benchmarks[@]}"; do
     # Clean any previous output
     rm -rf "$case_dir/D" "$case_dir/p_all" "$case_dir/restart_data"
 
-    # Run with --case-optimization, small grid, 10 timesteps. Builds first
-    # unless $build_opts holds --no-build (see above).
+    # Run with --case-optimization, small grid, 10 timesteps. On phoenix and
+    # frontier_amd $build_opts is --no-build, so the run reuses the pre-build's
+    # binaries. A prebuilt binary can be missing at run time (the pre-build and
+    # run SLURM jobs may be separated by a long embers queue wait, or clean_build
+    # on a retry may have wiped build/), and a bare --no-build run would then
+    # hard-fail. Fall back to a rebuild-and-run for that case so a lost prebuild
+    # artifact degrades to a slower run instead of a red CI.
     if ./mfc.sh run "$case" --case-optimization $gpu_opts $build_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
+        run_ok=1
+    elif [ -n "$build_opts" ] && \
+         ./mfc.sh run "$case" --case-optimization $gpu_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
+        echo "NOTE: $case_name rebuilt in-run (prebuilt binary was unavailable)"
+        run_ok=1
+    else
+        run_ok=0
+    fi
+
+    if [ "$run_ok" = 1 ]; then
         # Validate output
         if build/venv/bin/python3 .github/scripts/check_case_optimization_output.py "$case_dir"; then
             echo "PASS: $case_name"

--- a/.github/scripts/run_case_optimization.sh
+++ b/.github/scripts/run_case_optimization.sh
@@ -80,23 +80,33 @@ for case in "${benchmarks[@]}"; do
 
     # Run with --case-optimization, small grid, 10 timesteps. On phoenix and
     # frontier_amd $build_opts is --no-build, so the run reuses the pre-build's
-    # binaries. On phoenix (a single, unsharded job) a prebuilt binary can still
-    # be missing at run time (the pre-build and run SLURM jobs may be separated
-    # by a long embers queue wait, or clean_build on a retry may have wiped
-    # build/), which would hard-fail a bare --no-build run; fall back to a
-    # rebuild-and-run so a lost artifact degrades to a slower run instead of a
-    # red CI. frontier_amd is excluded: its run is sharded across concurrent
-    # jobs sharing one workspace, so a fallback rebuild would race on the shared
-    # install paths (the collision the --no-build guard above prevents).
-    if ./mfc.sh run "$case" --case-optimization $gpu_opts $build_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
+    # binaries. On phoenix (a single, unsharded job) a prebuilt binary can go
+    # missing at run time (the pre-build and run SLURM jobs may be separated by
+    # a long embers queue wait, or clean_build on a retry may have wiped
+    # build/), which makes mpirun fail to launch it. Only that specific failure
+    # triggers a rebuild-and-rerun, so a lost artifact degrades to a slower run
+    # instead of a red CI; any other failure (a real crash, a NaN, an MPI fault)
+    # is reported as-is and never masked by the retry. frontier_amd is excluded:
+    # its run is sharded across concurrent jobs sharing one workspace, so a
+    # fallback rebuild would race on the shared install paths (the collision the
+    # --no-build guard above prevents).
+    run_log="$(mktemp)"
+    ./mfc.sh run "$case" --case-optimization $gpu_opts $build_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10 2>&1 | tee "$run_log"
+    run_rc=${PIPESTATUS[0]}
+    if [ "$run_rc" -eq 0 ]; then
         run_ok=1
-    elif [ "$job_cluster" = phoenix ] && \
-         ./mfc.sh run "$case" --case-optimization $gpu_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
-        echo "NOTE: $case_name rebuilt in-run (prebuilt binary was unavailable)"
-        run_ok=1
+    elif [ "$job_cluster" = phoenix ] && grep -q "could not access or execute" "$run_log"; then
+        echo "NOTE: $case_name rebuilding in-run (prebuilt binary was unavailable)"
+        rm -rf "$case_dir/D" "$case_dir/p_all" "$case_dir/restart_data"
+        if ./mfc.sh run "$case" --case-optimization $gpu_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
+            run_ok=1
+        else
+            run_ok=0
+        fi
     else
         run_ok=0
     fi
+    rm -f "$run_log"
 
     if [ "$run_ok" = 1 ]; then
         # Validate output

--- a/.github/scripts/run_case_optimization.sh
+++ b/.github/scripts/run_case_optimization.sh
@@ -45,6 +45,19 @@ if [ "$job_cluster" != "phoenix" ] && [ "$job_cluster" != "frontier_amd" ]; then
         ./mfc.sh build -i "$case" --case-optimization $gpu_opts -j 8
     done
     echo "=== All case-optimized binaries built ==="
+    build_opts=""
+else
+    # Nothing was built here, so `mfc.sh run` must not build either. Left to
+    # itself it re-runs `cmake --build` and `cmake --install` for every target
+    # on every case, and syscheck/pre_process/post_process hash to a single
+    # slug shared by all cases, so every shard installs to the same
+    # build/staging and build/install paths. The shards share this workspace
+    # and leave the SLURM queue together, then march through an identical
+    # startup, so those installs collide and the losing shard dies with
+    # "file INSTALL cannot copy file ... No such file or directory".
+    # The pre-build serializes its own shared-target build for this reason;
+    # here there is nothing to serialize, because there is nothing to build.
+    build_opts="--no-build"
 fi
 
 passed=0
@@ -65,8 +78,9 @@ for case in "${benchmarks[@]}"; do
     # Clean any previous output
     rm -rf "$case_dir/D" "$case_dir/p_all" "$case_dir/restart_data"
 
-    # Build + run with --case-optimization, small grid, 10 timesteps
-    if ./mfc.sh run "$case" --case-optimization $gpu_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
+    # Run with --case-optimization, small grid, 10 timesteps. Builds first
+    # unless $build_opts holds --no-build (see above).
+    if ./mfc.sh run "$case" --case-optimization $gpu_opts $build_opts -n "$ngpus" -j 8 -c "$job_cluster" -- --gbpp 1 --steps 10; then
         # Validate output
         if build/venv/bin/python3 .github/scripts/check_case_optimization_output.py "$case_dir"; then
             echo "PASS: $case_name"


### PR DESCRIPTION
## Description

The `Case Opt | Oak Ridge | Frontier (AMD) (gpu-omp)` job fails intermittently during `cmake --install`:

```
   Installing syscheck...
   ✗ Install failed for syscheck

 Install Failed - Error Details:
 CMake Error at build/staging/gpu-mp-4e60642e2d/cmake_install.cmake:52 (file):
   file INSTALL cannot copy file
   ".../build/staging/gpu-mp-4e60642e2d/syscheck"
   to ".../build/install/gpu-mp-4e60642e2d/bin/syscheck":
   No such file or directory.

Error: Failed to install the syscheck target.
mfc: ERROR > main.py finished with a 143 exit code.
FAIL: viscous_weno5_sgb_acoustic (build or run error)
```

The exit code 143 is not an external kill. `toolchain/main.py` calls `quit(signal.SIGTERM)` on `MFCException`, so any build or install failure surfaces as 143.

### Cause

On `frontier_amd` the run step submits three concurrent SLURM jobs that share one workspace. `run_case_optimization.sh` skips its own build block for that cluster, because `prebuild-case-optimization.sh` already built and installed every binary in a prior SLURM job. It then calls `./mfc.sh run` anyway, and `run` always builds: `run()` calls `build(targets)` unconditionally, and `__build_target` runs `configure`, `build`, and `install` for every non-dependency target on every case.

`syscheck`, `pre_process` and `post_process` hash to a single slug for all five benchmarks, because `get_slug` hashes `case.get_fpp(target)` and `get_fpp` maps only `pre_process` and `simulation` to real generators. Everything else gets `"! This file is purposefully empty."`. The per-shard logs confirm it:

```
run-...-1-of-3.out  syscheck: gpu-mp-4e60642e2d  pre_process: gpu-mp-0e981924c0  post_process: gpu-mp-01766823fa
run-...-2-of-3.out  syscheck: gpu-mp-4e60642e2d  pre_process: gpu-mp-0e981924c0  post_process: gpu-mp-01766823fa
run-...-3-of-3.out  syscheck: gpu-mp-4e60642e2d  pre_process: gpu-mp-0e981924c0  post_process: gpu-mp-01766823fa
```

Only `simulation` gets a per-case slug. So all three shards run `cmake --build` and `cmake --install` against the same `build/staging` and `build/install` paths, with no synchronization. The pre-build already guards against exactly this, with a marker handshake and the comment "Concurrent shards must not build those shared staging dirs simultaneously". The run phase never got the same treatment.

The collision window is at shard startup. All three jobs left the queue in the same second after roughly 90 minutes pending:

```
06:34:38.299  === Streaming output for job 5341449 ===
06:34:38.299  === Streaming output for job 5341447 ===
06:34:38.299  === Streaming output for job 5341448 ===
```

They then walked through an identical startup and reached the shared `syscheck` install together. That is why the failure lands on a shard's first case, and why the losing shard differs between attempts of the same run: attempt 1 failed on `hypo_hll` (shard 3), attempt 2 on `viscous_weno5_sgb_acoustic` (shard 2).

### Fix

Pass `--no-build` to `mfc.sh run` on the clusters whose binaries were built in a prior SLURM job, which is `phoenix` and `frontier_amd`, the same two the in-script build block already skips. `--no-build` makes `is_buildable()` return `False`, so `__build_target` returns before `configure`, `build` and `install`. The run phase then issues no cmake invocations at all and there is nothing left to race on. `run()` still loads and validates the case and still calls `__generate_input_files`, so only the build side is affected.

`frontier` (CCE) is unchanged: it builds on the compute node inside this script, so it keeps building through `run`.

## Testing

- The pre-built binaries are the ones the run resolves, so skipping the build does not change what executes. Every shard finished its cases within 11 minutes of leaving the queue, against roughly 30 minutes per case for an AMD flang case-opt build, so no shard was building anything. `--gbpp` and `--steps` do not enter `get_slug`.
- `bash -n` passes. `shellcheck` reports no new findings; the remaining `SC2086` and `SC2154` warnings are pre-existing and unrelated.
- Real verification is the `Case Opt` matrix on this PR, on both Phoenix and Frontier AMD.

## Known remaining exposure

The pre-build has the same structural hazard and this PR does not address it. Shards 2 and 3 wait on `build/.prebuild-shared-targets-done`, then each runs `./mfc.sh run "$case" --dry-run` per case, which reinstalls the shared targets into the same paths. It has not been observed to fail, most likely because the marker is polled on a 30 second `sleep`, so the shards are staggered rather than released together. Worth a follow-up, but it is a different change and should not ride along with this one.

### Type of change (delete unused ones)

- Bug fix

## Reference

Failing job: https://github.com/MFlowCode/MFC/actions/runs/32684872325/job/97532516750
