### PR TITLE
ci: run Frontier CI on the g1 partition, and raise the queue-wait budget to 4h

### DIFF
--- a/.github/scripts/monitor_slurm_job.sh
+++ b/.github/scripts/monitor_slurm_job.sh
@@ -86,7 +86,15 @@ is_terminal_state() {
 # (Phoenix 'embers') a job can stay PENDING for hours, burning the CI job
 # timeout and holding a runner slot; fail early so it reads as queue starvation,
 # not a test failure. 0 = wait indefinitely.
-: "${SLURM_MAX_QUEUE_SECONDS:=5400}"   # 90 minutes
+#
+# The budget has to clear a normal bad day on a busy machine, or it converts
+# routine queue pressure into red CI. Frontier's own numbers make the case:
+# over one week, MFC jobs on `batch` waited p50=1m but p90=96m and p95=176m,
+# with a 466m tail. A 90-minute budget cut into that distribution, tripping on
+# 11% of the jobs that did eventually start -- plus the ones that never did.
+# Four hours clears p95 with room to spare while staying well inside the 480m
+# job-level `timeout-minutes`, which remains the real backstop.
+: "${SLURM_MAX_QUEUE_SECONDS:=14400}"   # 4 hours
 # Reject a non-integer override rather than silently skipping the budget.
 if ! [[ "$SLURM_MAX_QUEUE_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "ERROR: SLURM_MAX_QUEUE_SECONDS must be a non-negative integer (seconds), got '$SLURM_MAX_QUEUE_SECONDS'" >&2

--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -58,7 +58,10 @@ case "$cluster" in
         # CFD154; submitting under it now fails outright with "Invalid qos
         # specification". "normal" is the only QOS on this allocation without a
         # one-job-at-a-time cap, so it is the only one that can run the CI
-        # matrix concurrently.
+        # matrix concurrently. Note that the g1 partition carries its own
+        # partition QOS (also named "g1"), which slurmctld applies on its own
+        # when a job lands there. Do not add --qos=g1: CFD154 has no
+        # association with it and sbatch rejects the job outright.
         qos="normal"
         # Let each job's slurmstepd broker its own steps instead of routing
         # every srun through slurmctld. The in-job test suite launches ~1700+
@@ -101,9 +104,11 @@ if [ "$device" = "cpu" ]; then
 #SBATCH --mem-per-cpu=8G"
             ;;
         frontier|frontier_amd)
+            # g1 is a dedicated 64-node carve-out; its nodes are not in batch,
+            # so CI starts promptly instead of queueing behind the machine.
             sbatch_device_opts="\
 #SBATCH -n 32
-#SBATCH -p batch"
+#SBATCH -p g1"
             ;;
     esac
 elif [ "$device" = "gpu" ]; then
@@ -131,7 +136,7 @@ elif [ "$device" = "gpu" ]; then
         frontier|frontier_amd)
             sbatch_device_opts="\
 #SBATCH -n 8
-#SBATCH -p batch"
+#SBATCH -p g1"
             ;;
     esac
 else


### PR DESCRIPTION
> **Stacked on #1763** — base is `ci/phoenix-queue-timeout-combined-alloc`. Merge that one first; this PR's second commit retunes the budget it introduces. The net diff over #1763 is two files.

Two related fixes for Frontier CI reliability.

## 1. Run Frontier CI on the `g1` partition

Frontier CI jobs are submitted to `batch`, where they queue behind the rest of the machine. A full matrix routinely sits pending for a long stretch before any node is handed over.

`g1` is a dedicated 64-node carve-out (`frontier10177-10240`). Those nodes belong to `g1` only and are not part of `batch`, so CI starts promptly instead of competing for the general pool. They are otherwise ordinary Frontier hardware — `Gres=gpu:8`, 112 allocatable cores — so both the GPU (`acc`/`omp`) and CPU matrices run unchanged.

This points the CPU and GPU device blocks at `g1` for `frontier` and `frontier_amd`. Nothing else about the job header changes: `--stepmgr`, `--qos=normal`, `-N 1`, and the `01:59:00` walltime all carry over, comfortably inside `g1`'s 2-day cap.

### The QOS deliberately stays `normal`

`g1` carries a *partition* QOS that is also named `g1`. slurmctld applies it on its own once a job lands in the partition — requesting it explicitly fails, because CFD154 holds no association with it:

```
$ sbatch --test-only -p g1 -A CFD154 --qos=g1 -N1 -t 01:59:00 --wrap=hostname
allocation failure: Invalid qos specification
```

A comment in the script records this, so the next reader doesn't "fix" the partition change by adding `--qos=g1`.

## 2. Raise the queue-wait budget to 4h for all clusters

#1763's `SLURM_MAX_QUEUE_SECONDS:=5400` was sized against Phoenix's preemptible `embers` QOS, where the failure it guards against is a job that sits PENDING indefinitely. As a global default it also lands on Frontier, whose `batch` waits are much longer and fatter — so routine queue pressure surfaces as red CI. That is what [this `bench-gpu-omp` failure](https://github.com/MFlowCode/MFC/actions/runs/33013166496/job/98324495084?pr=1763) is: job 5351071 sat in `batch` for the full 90 minutes and was cancelled, `Elapsed=00:00:00`.

One week of MFC CI jobs on Frontier `batch` (n=1230 that eventually started):

| p50 | p75 | p90 | p95 | max |
|-----|-----|-----|-----|-----|
| 1m  | 22m | 96m | 176m | 466m |

A 90m budget sits at roughly p89 and tripped **11%** of those jobs — and that undercounts, since a further 162 jobs over three days never started at all.

4h clears p95 with margin, stays well inside the job-level `timeout-minutes: 480` that remains the real backstop, and keeps the bound finite so a wedged `embers` job still can't hold a runner slot forever. `SLURM_MAX_QUEUE_SECONDS` is still overridable per workflow, and `0` still means wait indefinitely.

This matters even with `g1` in place: the `g1` QOS caps a user at 16 running nodes (`MaxTRESPU=node=16`) against a measured peak of 25 concurrent CI jobs, so a full matrix runs in about two waves and wave-2 bench jobs can legitimately wait behind a `01:59:00` allocation.

## Verification

I stubbed `sbatch` on `PATH` to capture the header the script actually generates, then ran each captured header through `sbatch --test-only` against the live controller. All eight combinations — `frontier`/`frontier_amd` × `cpu`/`gpu` × `test`/`build-and-test` (the new job type from #1763) — are accepted and schedule immediately onto `g1`:

```
#SBATCH -J MFC-test-gpu-none-1-of-2
#SBATCH --account=CFD154
#SBATCH -N 1
#SBATCH -n 8
#SBATCH -p g1
#SBATCH -t 01:59:00
#SBATCH --qos=normal
#SBATCH --stepmgr

sbatch: Job 5351955 to start at 20:06:34 using 56 processors on nodes frontier10193 in partition g1
```

CPU headers are identical apart from `-n 32`. Phoenix is untouched — its dynamic `select-gpu-partition.sh` path is unaffected, and it keeps the same budget semantics, just with a longer default.

https://claude.ai/code/session_01RPGyAS6S7BRDELsANWaBpR
