### PR TITLE
famd: move Frontier AMD builds to AFAR drop 23.2.1

### DIFF
--- a/cmake/MFCTargets.cmake
+++ b/cmake/MFCTargets.cmake
@@ -269,10 +269,17 @@ exit 0
                         PRIVATE -DFRONTIER_UNIFIED)
                 endif()
 
-		        find_library(HIP_LIB amdhip64
-                    HINTS "$ENV{OLCF_AFAR_ROOT}/lib" "$ENV{OLCF_AFAR_ROOT}/lib/llvm/lib" REQUIRED)
+                # Search the AFAR drop first: the ROCm module also ships
+                # libhipfort-amdgcn.a, and HINTS lose to CMAKE_PREFIX_PATH, which
+                # would pair the drop's .mod files with another flang's archive.
+                find_library(HIP_LIB amdhip64
+                    PATHS "$ENV{OLCF_AFAR_ROOT}/lib" "$ENV{OLCF_AFAR_ROOT}/lib/llvm/lib"
+                    NO_DEFAULT_PATH)
+                find_library(HIP_LIB amdhip64 REQUIRED)
                 find_library(HIPFORT_AMDGCN_LIB hipfort-amdgcn
-                    HINTS "$ENV{OLCF_AFAR_ROOT}/lib" "$ENV{OLCF_AFAR_ROOT}/lib/llvm/lib" REQUIRED)
+                    PATHS "$ENV{OLCF_AFAR_ROOT}/lib" "$ENV{OLCF_AFAR_ROOT}/lib/llvm/lib"
+                    NO_DEFAULT_PATH)
+                find_library(HIPFORT_AMDGCN_LIB hipfort-amdgcn REQUIRED)
                 # The hipfort module dir moved to lib/llvm/include in newer AFAR
                 # (therock) drops; keep the classic path for Frontier's layout.
                 target_include_directories(${a_target} PRIVATE

--- a/toolchain/bootstrap/modules.sh
+++ b/toolchain/bootstrap/modules.sh
@@ -234,15 +234,19 @@ if [ ! -z ${CRAY_LD_LIBRARY_PATH+x} ] && [ "$u_c" '!=' 'c' ] &&  [ "$u_c" '!=' '
 fi
 
 if [ "$u_c" '==' 'famd' ]; then 
-    export OLCF_AFAR_ROOT="/sw/crusher/ums/compilers/afar/therock-23.1.0-gfx90a-7.12.0-bb5005b6"
+    export OLCF_AFAR_ROOT="${OLCF_AFAR_ROOT:-/sw/crusher/ums/compilers/afar/therock-afar-23.2.1-gfx90a-7.13.0-7357b5084b}"
 
     export PATH=${OLCF_AFAR_ROOT}/lib/llvm/bin:${PATH}
     export LD_LIBRARY_PATH=${OLCF_AFAR_ROOT}/lib:${OLCF_AFAR_ROOT}/lib/llvm/lib:${LD_LIBRARY_PATH}
+    # Pinned: cray-mpich's libmpifort_amd.so needs the classic-flang runtimes
+    # (libpgmath/libflang/libflangrti/libompstub), which no AFAR drop ships and
+    # which ROCm dropped after 7.0.2. Do not retarget at $ROCM_PATH.
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm-7.0.2/lib/llvm/lib:/opt/rocm-7.0.2/lib/
 
-    export CRAY_MPICH_INC="-I${OLCF_AFAR_ROOT}/include/mpich3.4a2"
-    export CRAY_HIPFORT_INC="-I${OLCF_AFAR_ROOT}/include/hipfort/amdgcn"
-    export CRAY_HIPFORT_LIB="-L${OLCF_AFAR_ROOT}/lib -lhipfort-amdgcn -lhipfft -lamdhip64"
+    # AFAR >= 23.2: no mpich3.4a2, hipfort moved under lib/llvm.
+    export CRAY_MPICH_INC="-I${OLCF_AFAR_ROOT}/include/mpich4.3.1"
+    export CRAY_HIPFORT_INC="-I${OLCF_AFAR_ROOT}/lib/llvm/include/hipfort/amdgcn"
+    export CRAY_HIPFORT_LIB="-L${OLCF_AFAR_ROOT}/lib -L${OLCF_AFAR_ROOT}/lib/llvm/lib -lhipfort-amdgcn -lhipfft -lamdhip64"
     export CRAY_HIP_INC="-I${OLCF_AFAR_ROOT}/include/hip"
     export CRAY_MPICH_LIB="-L${CRAY_MPICH_PREFIX}/lib \
                         ${CRAY_PMI_POST_LINK_OPTS} \


### PR DESCRIPTION
Moves the `famd` (Frontier AMD / amdflang) toolchain from the `therock-23.1.0` AFAR drop to `therock-afar-23.2.1-gfx90a-7.13.0-7357b5084b`, the newest drop available on Frontier (module `afar/23.2.1-7.13.0-7357b5084b`, staged 2026-08-25).

## What changed

**`toolchain/bootstrap/modules.sh`** — the 23.2.x drop layout differs from 23.1.0:
- `include/mpich3.4a2` is gone; only `mpich4.3.1` ships, which is the right one for cray-mpich 9.x anyway.
- hipfort moved from `include/hipfort` + `lib/` to `lib/llvm/include/hipfort` + `lib/llvm/lib`.
- `$OLCF_AFAR_ROOT` is now overridable, matching the `amdfund` block below it, so testing the next drop doesn't need a source edit.

**`cmake/MFCTargets.cmake`** — resolve HIP and hipfort out of the drop explicitly. The loaded ROCm module also ships `libhipfort-amdgcn.a`, and `find_library` searches `CMAKE_PREFIX_PATH` before `HINTS`, so `HIPFORT_AMDGCN_LIB` was silently resolving to `/opt/rocm-7.2.0/lib/libhipfort-amdgcn.a` — pairing the drop's flang `.mod` files with an archive built by a different flang. It linked, but only because the `-L$OLCF_AFAR_ROOT/...` flags happened to come first.

## What deliberately did not change

`toolchain/modules` stays on `amd/7.2.0 rocm/7.2.0`. `/opt/rocm-7.13.0` (with modules `amd/7.13.0` / `rocm/7.13.0`) is new on Frontier and ships amdflang 23, but it cannot be used here:

- It and the AFAR drop both ship `libclang-cpp.so.23.0git` and `libLLVM.so.23.0git`. `famd` puts the drop's `lib/llvm/lib` first on `LD_LIBRARY_PATH`, so the system `cc` loads the drop's LLVM and dies with `malloc(): invalid size (unsorted)` compiling a trivial `.c`, which fails the `hipfort` dependency configure. `amd/7.2.0` has LLVM 22 sonames, so no collision.
- It ships no hipfort.
- Cray's `amd`-built `mpi.mod` (both `9.0.1/ofi/amd/6.0` and `9.1.0/ofi/amd/7.0`) is rejected by flang 23 with `'mpi.mod' is not a module file for this compiler`. Only the drop's own `include/mpich4.3.1` works, so the drop has to stay the base.

Also worth noting: the `/opt/rocm-7.0.2` entry on `LD_LIBRARY_PATH` is load-bearing, not stale. cray-mpich's `libmpifort_amd.so` is built with classic flang and needs `libpgmath`/`libflang`/`libflangrti`/`libompstub`, which no AFAR drop ships and which ROCm dropped after 7.0.2. Retargeting it at `$ROCM_PATH` produces `libpgmath.so: cannot open shared object file` at run time. Added a comment so it doesn't get cleaned up again.

## Verification

Frontier, 1 node, gfx90a, `--gpu mp`, MFC master `b2a01f9`:

- `syscheck` **PASSED** — MPI init/barrier/finalize, `omp_get_num_devices() > 0`, device selection.
- Test suite: **667/686 passed**. All 19 failures are chemistry cases failing on a missing `gpu-mp-chem-*` binary, which this run never built (`--no-build`; CI builds that variant in a separate job) — not compiler failures.
- `simulation` device-LTO link: **1682 s on 23.1.0 → 780–951 s on 23.2.1**. Both builds shared a login node so the numbers are approximate, but the ~2x is well outside the noise. This is the cost that drives the concurrent `base`/`chem` job split in `.github/workflows/common/build.sh`; that split is left alone here, but there may be room to simplify it in a follow-up.