### PR TITLE
ci: resubmit SLURM jobs on preemption instead of failing (Phoenix embers)

### DIFF
--- a/.github/scripts/monitor_slurm_job.sh
+++ b/.github/scripts/monitor_slurm_job.sh
@@ -70,9 +70,13 @@ get_job_state() {
   echo "UNKNOWN"
 }
 
-# Check if a state is terminal (job is done, for better or worse)
-# PREEMPTED is intentionally excluded: with --requeue the job restarts under
-# the same job ID and we must keep monitoring rather than exiting early.
+# Check if a state is terminal (job is done, for better or worse).
+# PREEMPTED is handled separately (below): Phoenix preempts 'embers' jobs with
+# PreemptMode=CANCEL, not REQUEUE (verified via `scontrol show config`), so a
+# preempted job is killed outright and never restarts under the same ID.
+# --requeue is a no-op for it. It is surfaced via PREEMPT_EXIT so the submit
+# wrapper can resubmit a fresh job instead of failing the CI step.
+PREEMPT_EXIT=76
 is_terminal_state() {
   case "$1" in
     COMPLETED|FAILED|CANCELLED|CANCELLED+|TIMEOUT|OUT_OF_MEMORY|NODE_FAIL|BOOT_FAIL|DEADLINE|REVOKED)
@@ -130,7 +134,13 @@ while [ ! -f "$output_file" ]; do
   fi
 
   case "$state" in
-    PENDING|CONFIGURING|PREEMPTED)
+    PREEMPTED)
+      # Preempted before producing output (embers, PreemptMode=CANCEL): the job
+      # is dead and will not requeue. Signal the caller to resubmit a fresh job.
+      echo "[$(date +%H:%M:%S)] Job $job_id PREEMPTED before start/output — signaling resubmit."
+      exit "$PREEMPT_EXIT"
+      ;;
+    PENDING|CONFIGURING)
       unknown_count=0
       sleep 5
       ;;
@@ -176,6 +186,12 @@ tail_pid=$!
 last_heartbeat=$(date +%s)
 while true; do
   state=$(get_job_state "$job_id")
+
+  if [ "$state" = "PREEMPTED" ]; then
+    # Preempted mid-run (embers, PreemptMode=CANCEL): dead, will not requeue.
+    echo "[$(date +%H:%M:%S)] Job $job_id PREEMPTED mid-run — signaling resubmit."
+    exit "$PREEMPT_EXIT"
+  fi
 
   if is_terminal_state "$state"; then
     echo "[$(date +%H:%M:%S)] Job $job_id reached terminal state: $state"

--- a/.github/scripts/run_monitored_slurm_job.sh
+++ b/.github/scripts/run_monitored_slurm_job.sh
@@ -21,6 +21,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 monitor_exit=0
 bash "$SCRIPT_DIR/monitor_slurm_job.sh" "$job_id" "$output_file" || monitor_exit=$?
 
+# Exit 76 = the monitor detected preemption (Phoenix 'embers', PreemptMode=CANCEL).
+# Propagate it verbatim so the submit wrapper resubmits a fresh job rather than
+# treating a killed-by-preemption job as a genuine test failure.
+if [ "$monitor_exit" -eq 76 ]; then
+    echo "Monitor reports SLURM job $job_id was PREEMPTED — signaling caller to resubmit."
+    exit 76
+fi
+
 if [ "$monitor_exit" -ne 0 ]; then
     echo "Monitor exited with code $monitor_exit; re-checking SLURM job $job_id final state..."
     # Give the SLURM epilog time to finalize if the job just finished
@@ -30,6 +38,12 @@ if [ "$monitor_exit" -ne 0 ]; then
     final_exit=$(sacct -j "$job_id" -X --format=ExitCode --noheader --parsable2 2>/dev/null | head -n1 | tr -d ' ' || true)
     final_exit="${final_exit:-}"
     echo "Final SLURM state=$final_state exit=$final_exit"
+    if [ "$final_state" = "PREEMPTED" ]; then
+        # Monitor was killed (e.g. SIGKILL) before it could classify this, but
+        # the authoritative final state is PREEMPTED — signal a resubmit.
+        echo "SLURM job $job_id final state PREEMPTED — signaling caller to resubmit."
+        exit 76
+    fi
     if [ "$final_state" = "COMPLETED" ] && [ "$final_exit" = "0:0" ]; then
         echo "SLURM job $job_id completed successfully despite monitor failure — continuing."
     else

--- a/.github/scripts/run_parallel_benchmarks.sh
+++ b/.github/scripts/run_parallel_benchmarks.sh
@@ -55,10 +55,43 @@ echo "Both SLURM jobs submitted — running concurrently on compute nodes."
 echo "Monitoring sequentially to conserve login node memory."
 
 # --- Phase 2: Monitor sequentially (one at a time on login node) ---
+# On Phoenix 'embers' a long benchmark job can be preempted (PreemptMode=CANCEL,
+# so it is killed rather than requeued). On preemption (run_monitored exit 76)
+# resubmit a fresh job in the same tree and re-monitor, bounded by
+# MAX_PREEMPT_RESUBMITS (the 480m job timeout is the real backstop). Note: a
+# resubmitted job no longer overlaps its counterpart, slightly reducing
+# same-load fairness -- still preferable to failing the run on an infra preempt.
+: "${MAX_PREEMPT_RESUBMITS:=10}"
+monitor_bench_with_resubmit() {  # arg: <dir> (pr|master); sets BENCH_MON_RC
+    local dir="$1"
+    local out="${dir}/${job_slug}.out"
+    local jobid attempt=0 rc
+    jobid=$(cat "${dir}/${job_slug}.slurm_job_id")
+    while :; do
+        rc=0
+        bash "${SCRIPT_DIR}/run_monitored_slurm_job.sh" "$jobid" "$out" || rc=$?
+        if [ "$rc" -ne 76 ]; then
+            BENCH_MON_RC="$rc"
+            return
+        fi
+        if [ "$attempt" -ge "$MAX_PREEMPT_RESUBMITS" ]; then
+            echo "::error::${dir} benchmark preempted ${MAX_PREEMPT_RESUBMITS}x without completing; giving up."
+            BENCH_MON_RC=1
+            return
+        fi
+        attempt=$((attempt + 1))
+        echo "::warning::${dir} benchmark job $jobid was preempted; resubmitting (attempt ${attempt}/${MAX_PREEMPT_RESUBMITS})."
+        rm -f "$out"
+        ( cd "$dir" && SUBMIT_ONLY=1 bash "${SCRIPT_DIR}/submit-slurm-job.sh" "$PR_BENCH_SCRIPT" "$device" "$interface" "$cluster" )
+        jobid=$(cat "${dir}/${job_slug}.slurm_job_id")
+        echo "${dir} benchmark resubmitted as job $jobid"
+    done
+}
+
 echo ""
 echo "=== Monitoring PR job $pr_job_id ==="
-pr_exit=0
-bash "${SCRIPT_DIR}/run_monitored_slurm_job.sh" "$pr_job_id" "pr/${job_slug}.out" || pr_exit=$?
+monitor_bench_with_resubmit pr
+pr_exit=$BENCH_MON_RC
 if [ "$pr_exit" -ne 0 ]; then
     echo "PR job exited with code: $pr_exit"
     tail -n 50 "pr/${job_slug}.out" 2>/dev/null || echo "  Could not read PR log"
@@ -74,8 +107,8 @@ fi
 
 echo ""
 echo "=== Monitoring master job $master_job_id ==="
-master_exit=0
-bash "${SCRIPT_DIR}/run_monitored_slurm_job.sh" "$master_job_id" "master/${job_slug}.out" || master_exit=$?
+monitor_bench_with_resubmit master
+master_exit=$BENCH_MON_RC
 if [ "$master_exit" -ne 0 ]; then
     echo "Master job exited with code: $master_exit"
     tail -n 50 "master/${job_slug}.out" 2>/dev/null || echo "  Could not read master log"

--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -221,16 +221,43 @@ $sbatch_script_contents
 EOT
 )
 
-job_id=$(retry_sbatch "$_sbatch_script")
+# --- Submit + monitor, resubmitting on preemption -------------------------
+# Phoenix preempts 'embers' jobs with PreemptMode=CANCEL (not REQUEUE), so a
+# preempted job is killed outright and `--requeue` never restarts it. When the
+# monitor reports preemption (exit 76), submit a fresh job and monitor again.
+# Bounded by MAX_PREEMPT_RESUBMITS as a runaway guard; the job-level
+# `timeout-minutes` (480m) remains the real backstop.
+: "${MAX_PREEMPT_RESUBMITS:=10}"
+preempt_attempt=0
+while :; do
+    job_id=$(retry_sbatch "$_sbatch_script")
+    echo "Submitted batch job $job_id"
+    echo "$job_id" > "$id_file"
+    echo "Job ID written to $id_file"
+
+    # SUBMIT_ONLY=1 (parallel submission, e.g. benchmarks): the caller monitors
+    # each job and handles its own preemption resubmits.
+    if [ "${SUBMIT_ONLY:-0}" = "1" ]; then
+        echo "SUBMIT_ONLY mode: skipping monitor (job_id=$job_id output=$output_file)"
+        break
+    fi
+
+    monitor_rc=0
+    bash "$SCRIPT_DIR/run_monitored_slurm_job.sh" "$job_id" "$output_file" || monitor_rc=$?
+    if [ "$monitor_rc" -eq 0 ]; then
+        break
+    fi
+    if [ "$monitor_rc" -eq 76 ]; then
+        if [ "$preempt_attempt" -lt "$MAX_PREEMPT_RESUBMITS" ]; then
+            preempt_attempt=$((preempt_attempt + 1))
+            echo "::warning::SLURM job $job_id was preempted (Phoenix embers). Resubmitting a fresh job (attempt ${preempt_attempt}/${MAX_PREEMPT_RESUBMITS})."
+            rm -f "$output_file"
+            continue
+        fi
+        echo "::error::SLURM job preempted ${MAX_PREEMPT_RESUBMITS} times without completing; giving up."
+        exit 1
+    fi
+    # Genuine failure (not preemption).
+    exit "$monitor_rc"
+done
 unset _sbatch_script
-
-echo "Submitted batch job $job_id"
-echo "$job_id" > "$id_file"
-echo "Job ID written to $id_file"
-
-# --- Monitor (skip if SUBMIT_ONLY=1, e.g. for parallel submission) ---
-if [ "${SUBMIT_ONLY:-0}" = "1" ]; then
-    echo "SUBMIT_ONLY mode: skipping monitor (job_id=$job_id output=$output_file)"
-else
-    bash "$SCRIPT_DIR/run_monitored_slurm_job.sh" "$job_id" "$output_file"
-fi


### PR DESCRIPTION
## Problem

Phoenix CI jobs on the free **embers** QOS fail red when preempted — most visibly long benchmark jobs. Root cause, verified on the login node:

```
PreemptType       = preempt/qos
PreemptMode       = CANCEL          # cluster-wide + on gpu-l40s/v100/h100
PreemptExemptTime = 01:00:00        # a job is immune for its first 1h
inferno (prio 250000)  preempts→  embers (prio 0)
```

So preemption **cancels** the job (SIGTERM, exit `0:15`) — it does **not** requeue it, and `#SBATCH --requeue` is a no-op here. The monitor's existing "PREEMPTED is non-terminal, wait for the requeue" logic can therefore never be satisfied: the job is dead and never comes back under the same ID. Jobs under 1h are immune (why tests pass); the 4h bench jobs blow past the exempt window and get clipped (why benchmarks fail).

Example: [job on #1766](https://github.com/MFlowCode/MFC/actions/runs/33081310752/job/98549430315) ran 2h21m, then `CANCELLED ... DUE TO PREEMPTION`, final state `PREEMPTED`, and CI went red even though its cases passed (`0 failed, 13 passed`).

## Fix: application-level resubmit on preemption

Since `--requeue` can't help, recover in the CI scripts:

1. **`monitor_slurm_job.sh`** — treat `PREEMPTED` as its own terminal case and exit a distinct code **76** (both before-output and mid-run).
2. **`run_monitored_slurm_job.sh`** — propagate `76` verbatim (and classify a sacct-observed `PREEMPTED` after a monitor death as `76`), so preemption isn't conflated with a real test failure.
3. **`submit-slurm-job.sh`** — wrap submit+monitor in a loop: on `76`, submit a **fresh** job (new ID) and re-monitor. Bounded by `MAX_PREEMPT_RESUBMITS` (default 10) as a runaway guard; the 480m job-level `timeout-minutes` remains the real backstop. Covers the standard test/build/case-opt path.
4. **`run_parallel_benchmarks.sh`** — same resubmit loop for the PR and master bench jobs (the `SUBMIT_ONLY` path). Note: a resubmitted bench job no longer overlaps its counterpart, slightly reducing same-load fairness — still preferable to a red on an infra preempt.

Genuine test failures (non-`76`) still fail immediately as before. Verified all four scripts with `bash -n` and unit-tested the resubmit decision logic.