### PR TITLE
bug: m_bubbles_EL: delete non-finite bubbles in the boundary enforcement

### DIFF
--- a/src/simulation/m_bubbles_EL.fpp
+++ b/src/simulation/m_bubbles_EL.fpp
@@ -1361,9 +1361,7 @@ contains
                      & 2) <= pcomm_coords(1)%end) then
                 wrap_bubble_dir(k, 1) = 1
                 wrap_bubble_loc(k, 1) = 1
-            else if (mtn_pos(k, 1, 2) >= x_cb(m)) then
-                keep_bubble(k) = 0
-            else if (mtn_pos(k, 1, 2) < x_cb(-1)) then
+            else if (.not. (mtn_pos(k, 1, 2) >= x_cb(-1) .and. mtn_pos(k, 1, 2) < x_cb(m))) then
                 keep_bubble(k) = 0
             end if
 
@@ -1381,9 +1379,7 @@ contains
                      & 2) <= pcomm_coords(2)%end) then
                 wrap_bubble_dir(k, 2) = 1
                 wrap_bubble_loc(k, 2) = 1
-            else if (mtn_pos(k, 2, 2) >= y_cb(n)) then
-                keep_bubble(k) = 0
-            else if (mtn_pos(k, 2, 2) < y_cb(-1)) then
+            else if (.not. (mtn_pos(k, 2, 2) >= y_cb(-1) .and. mtn_pos(k, 2, 2) < y_cb(n))) then
                 keep_bubble(k) = 0
             end if
 
@@ -1402,9 +1398,7 @@ contains
                          & 2) <= pcomm_coords(3)%end) then
                     wrap_bubble_dir(k, 3) = 1
                     wrap_bubble_loc(k, 3) = 1
-                else if (mtn_pos(k, 3, 2) >= z_cb(p)) then
-                    keep_bubble(k) = 0
-                else if (mtn_pos(k, 3, 2) < z_cb(-1)) then
+                else if (.not. (mtn_pos(k, 3, 2) >= z_cb(-1) .and. mtn_pos(k, 3, 2) < z_cb(p))) then
                     keep_bubble(k) = 0
                 end if
             end if


### PR DESCRIPTION
The single bubble's ODE state can go non-finite under the strong acoustic forcing (mag=20000), so mtn_pos becomes NaN. s_enforce_EL_bubbles_boundary_conditions removes out-of-range bubbles with
```
else if (mtn_pos(k,1,2) >= x_cb(m)) then keep_bubble = 0
else if (mtn_pos(k,1,2) < x_cb(-1)) then keep_bubble = 0
```
and both comparisons are false for NaN, so the non-finite bubble is never deleted. Its NaN `mtn_s` reaches `s_get_cell` (int(NaN) = INT_MIN), and `s_compute_stddsv` reads `dx(cell(1))` ~17 GB out of bounds

This causes all bubbles_lagrange to crash on GPUs when the bubble goes NaN, at different steps. For example, case 80CC6F73 crashes at step 96.

The CI currently does not catch this bug as it is only run for 50 steps. It also will not crash in CPU release mode because OOB read is silent there, and the simulation just proceeds with a corrupted NaN state. To verify on CPU, one need to run with debug mode -Mbound, and it will correctly show the OOB at step 96.

The fix is to flip the check from checking if it is outside to negate(if it is inside), so NaN correctly become false and is deleted

cc @wilfonba as discussed in SC26 SCC google group

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:
- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm this PR meets the above expectations and reflects my own understanding and real-world context.

---

_PR template credit: junegunn_
