### PR TITLE
ci: remove junk separator comment tripping source lint

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -221,7 +221,7 @@ $sbatch_script_contents
 EOT
 )
 
-# --- Submit + monitor, resubmitting on preemption -------------------------
+# --- Submit + monitor, resubmitting on preemption
 # Phoenix preempts 'embers' jobs with PreemptMode=CANCEL (not REQUEUE), so a
 # preempted job is killed outright and `--requeue` never restarts it. When the
 # monitor reports preemption (exit 76), submit a fresh job and monitor again.


### PR DESCRIPTION
## Summary
- `.github/scripts/submit-slurm-job.sh:224` had a trailing-dash comment separator that trips `lint_source.py`'s junk-separator rule, so `master` currently fails its own lint gate (`lint-toolchain.yml`, `test.yml`).
- Drops the trailing dashes from the comment; no functional change.

Fixes #1779

## Test plan
- [x] `python3 toolchain/mfc/lint_source.py` exits 0 locally