### PR TITLE
ci: keep build/venv when the build retry nukes the build directory

### DIFF
--- a/.github/scripts/retry-build.sh
+++ b/.github/scripts/retry-build.sh
@@ -15,7 +15,7 @@
 : "${MFC_BUILD_RETRY_DELAY:=30}"
 
 nuke_build() {
-    find build -mindepth 1 -maxdepth 1 ! -name venv -exec rm -rf {} + 2>/dev/null || true
+    find build -mindepth 1 -maxdepth 1 ! -name venv -exec rm -rf -- {} + 2>/dev/null || true
 }
 
 retry_build() {
@@ -29,7 +29,7 @@ retry_build() {
                 if ! eval "$validate_cmd"; then
                     echo "Post-build validation failed on attempt $attempt."
                     if [ $attempt -lt $max_attempts ]; then
-                        echo "  Nuking build directory before retry..."
+                        echo "  Clearing the build directory (keeping build/venv) before retry..."
                         nuke_build
                         sleep 5
                         attempt=$((attempt + 1))
@@ -44,7 +44,7 @@ retry_build() {
             return 0
         fi
         if [ $attempt -lt $max_attempts ]; then
-            echo "  Build failed — nuking build directory before retry..."
+            echo "  Build failed — clearing the build directory (keeping build/venv) before retry..."
             nuke_build
             sleep "$MFC_BUILD_RETRY_DELAY"
         else

--- a/.github/scripts/retry-build.sh
+++ b/.github/scripts/retry-build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Provides retry_build(): 2-attempt loop.
-# On failure of attempt 1, nukes the entire build directory before attempt 2.
+# On failure of attempt 1, nukes the build directory before attempt 2, keeping
+# build/venv: a compute node cannot reinstall it (no route to PyPI), and a
+# failed reinstall is misread as a cluster-wide outage (#1813).
 # If RETRY_VALIDATE_CMD is set, runs it after a successful build; a non-zero
 # exit triggers the same nuke-and-retry, catching e.g. SIGILL from binaries
 # compiled on a different CPU architecture.
@@ -11,6 +13,10 @@
 # Delay between build attempts. Overridable so tests can exercise the retry
 # path without waiting on it; CI leaves it at the default.
 : "${MFC_BUILD_RETRY_DELAY:=30}"
+
+nuke_build() {
+    find build -mindepth 1 -maxdepth 1 ! -name venv -exec rm -rf {} + 2>/dev/null || true
+}
 
 retry_build() {
     local max_attempts=2
@@ -24,7 +30,7 @@ retry_build() {
                     echo "Post-build validation failed on attempt $attempt."
                     if [ $attempt -lt $max_attempts ]; then
                         echo "  Nuking build directory before retry..."
-                        rm -rf build 2>/dev/null || true
+                        nuke_build
                         sleep 5
                         attempt=$((attempt + 1))
                         continue
@@ -39,7 +45,7 @@ retry_build() {
         fi
         if [ $attempt -lt $max_attempts ]; then
             echo "  Build failed — nuking build directory before retry..."
-            rm -rf build 2>/dev/null || true
+            nuke_build
             sleep "$MFC_BUILD_RETRY_DELAY"
         else
             echo "Build failed after $max_attempts attempts."


### PR DESCRIPTION
Fixes #1813.

`retry_build` answered a failed first attempt with `rm -rf build`, which also removed `build/venv`. On Frontier the venv is fetched on the login node because compute nodes have no route to PyPI, so attempt 2 could never reinstall it, and `classify-build-failure.sh` read the resulting `Failed to fetch https://pypi.org/...` as a cluster-wide outage. One compile error on one branch then exited every Frontier job on every PR with code 78 for twenty minutes, and refreshed the marker each time it happened again. Today it was tripped twice (18:01 by a syscheck install timeout on another branch, 19:14 by a compile error on a probe branch) and skipped the Frontier lanes on #1805, #1807 and #1811.

The retry now removes everything under `build/` except `venv`. Checked in a scratch tree: after two failed attempts only `build/venv` remains. Nothing else changes; a genuine PyPI failure on the login node still marks the breaker.
