### PR TITLE
ci: run the NVHPC container lanes without MPI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,12 +289,21 @@ jobs:
           CHANGED_FILES: ${{ needs.file-changes.outputs.changed_files }}
 
       # ── NVHPC build + test (via docker exec into long-lived container) ──
+      # --no-mpi: every failure these lanes have produced has been an MPI test.
+      # post_process segfaults under mpirun on the GitHub-hosted runners --
+      # "3D -> 2 MPI Ranks" and "MPI Consistency -> 3D -> Viscous" -- while the
+      # same tests pass everywhere else, including the self-hosted clusters that
+      # actually run MPI at scale. The harness skips ppn>1 cases without MPI
+      # (test.py), so this drops exactly those and keeps the rest of --test-all,
+      # which is what these lanes exist for: compile coverage across 15 NVHPC
+      # releases. MPI runtime coverage stays on the GNU, Intel and self-hosted
+      # lanes.
       - name: Build (NVHPC)
         if:   matrix.nvhpc && matrix.target == 'cpu'
         run: |
           docker exec nvhpc bash -c '
             source /etc/nvhpc-env.sh
-            /bin/bash mfc.sh test -v --dry-run -j $(nproc) --test-all
+            /bin/bash mfc.sh test -v --dry-run -j $(nproc) --test-all --no-mpi
           '
 
       - name: Build (NVHPC GPU)
@@ -336,7 +345,7 @@ jobs:
           docker exec nvhpc bash -c '
             source /etc/nvhpc-env.sh
             ulimit -s unlimited || ulimit -s 65536 || true
-            /bin/bash mfc.sh test -v --max-attempts 3 -j $(nproc) --test-all
+            /bin/bash mfc.sh test -v --max-attempts 3 -j $(nproc) --test-all --no-mpi
           '
 
       # ── Cleanup ─────────────────────────────────────────────────────────

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,6 +187,7 @@ jobs:
             -e "FFLAGS=-tp=px -Kieee -noswitcherror" \
             -e CFLAGS=-tp=px \
             -e CXXFLAGS=-tp=px \
+            -e "MFC_NVHPC_TEST_FLAGS=--test-all --no-mpi" \
             "$NVHPC_IMAGE" sleep infinity
 
       - name: Setup NVHPC
@@ -289,21 +290,19 @@ jobs:
           CHANGED_FILES: ${{ needs.file-changes.outputs.changed_files }}
 
       # ── NVHPC build + test (via docker exec into long-lived container) ──
-      # --no-mpi: every failure these lanes have produced has been an MPI test.
-      # post_process segfaults under mpirun on the GitHub-hosted runners --
-      # "3D -> 2 MPI Ranks" and "MPI Consistency -> 3D -> Viscous" -- while the
-      # same tests pass everywhere else, including the self-hosted clusters that
-      # actually run MPI at scale. The harness skips ppn>1 cases without MPI
-      # (test.py), so this drops exactly those and keeps the rest of --test-all,
-      # which is what these lanes exist for: compile coverage across 15 NVHPC
-      # releases. MPI runtime coverage stays on the GNU, Intel and self-hosted
-      # lanes.
+      # MFC_NVHPC_TEST_FLAGS carries --no-mpi: post_process segfaults under
+      # mpirun in these containers, and every failure the lanes have produced
+      # has been an MPI test (see PR #1822). The harness skips ppn>1 cases
+      # without MPI, so the rest of --test-all -- the compile coverage these
+      # lanes exist for -- is unaffected, as is MPI coverage elsewhere. Set in
+      # one place so the build and test steps cannot disagree: a no-MPI build
+      # tested with MPI would run ppn>1 cases against a binary that has none.
       - name: Build (NVHPC)
         if:   matrix.nvhpc && matrix.target == 'cpu'
         run: |
           docker exec nvhpc bash -c '
             source /etc/nvhpc-env.sh
-            /bin/bash mfc.sh test -v --dry-run -j $(nproc) --test-all --no-mpi
+            /bin/bash mfc.sh test -v --dry-run -j $(nproc) $MFC_NVHPC_TEST_FLAGS
           '
 
       - name: Build (NVHPC GPU)
@@ -345,7 +344,7 @@ jobs:
           docker exec nvhpc bash -c '
             source /etc/nvhpc-env.sh
             ulimit -s unlimited || ulimit -s 65536 || true
-            /bin/bash mfc.sh test -v --max-attempts 3 -j $(nproc) --test-all --no-mpi
+            /bin/bash mfc.sh test -v --max-attempts 3 -j $(nproc) $MFC_NVHPC_TEST_FLAGS
           '
 
       # ── Cleanup ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Every failure the NVHPC container lanes have produced has been an **MPI test**.

`post_process` segfaults under `mpirun` on the GitHub-hosted runners — exit 139, then `h5dump` cannot open `p0/0.silo` because the file was never written. Observed on:

| test | UUID | seen on |
|---|---|---|
| `3D -> 2 MPI Ranks` | `CE232828` | #1816, #1800 |
| `MPI Consistency -> 3D -> Viscous` | `0090B316` | #1800, TerminalOutput |

It is intermittent, spans NVHPC 24.9 / 24.11 / 25.11, and the build always succeeds — the crash is at run time. The same tests pass on the GNU and Intel lanes and on the self-hosted clusters that run MPI at scale, so this is specific to running MPI in these containers on GitHub's runners.

## The change

Add `--no-mpi` to the NVHPC **cpu** build and test steps. The harness already skips `ppn > 1` cases when built without MPI (`toolchain/mfc/test/test.py`), and both failing tests are `ppn=2`, so this drops exactly those and keeps the rest of `--test-all`.

That preserves what these lanes exist for: compile coverage across 15 NVHPC releases, where breaks have reached CI before (the `GPU_DECLARE` ordering break and two ICEs). MPI runtime coverage is unaffected — the GNU, Intel and self-hosted lanes all still run it.

Only the `cpu` lanes change; the `gpu` lanes are build-only and never ran tests.

## What this does not do

It does not diagnose the segfault. A bisect against #1762 was inconclusive — it did not reproduce locally under NVHPC 24.1, which is not one of the affected versions, so that result says nothing either way. If the crash is a real `post_process` bug rather than runner flakiness, this hides it on these lanes; it would still be caught by the GNU, Intel and self-hosted MPI lanes, which exercise the same code paths.
