### PR TITLE
ci: resolve CodeQL code-scanning alerts in workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,8 +11,11 @@ concurrency:
   cancel-in-progress: true
 
 # Least-privilege default: no job in this workflow writes to the repo.
+# pull-requests: read is required by dorny/paths-filter, which reads the PR's
+# changed-file list through the API on pull_request events.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   file-changes:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,11 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 # Least-privilege default: no job in this workflow writes to the repo.
-# pull-requests: read is required by dorny/paths-filter, which reads the PR's
-# changed-file list through the API on pull_request events.
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   file-changes:
@@ -23,6 +20,13 @@ jobs:
     if: >
       github.event_name != 'pull_request_review' ||
       github.event.review.user.type != 'Bot'
+    # Job-level permissions replace the workflow default outright rather than
+    # merging with it, so contents must be restated here. paths-filter reads the
+    # PR's changed-file list via pulls.listFiles; this is the only job that needs
+    # it, so it is granted here instead of workflow-wide.
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: 'ubuntu-latest'
     outputs:
       checkall: ${{ steps.changes.outputs.checkall }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ github.event_name == 'pull_request_review' && format('-review-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   file-changes:
     name: Detect File Changes

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,25 +58,16 @@ jobs:
             exit 1
           fi
 
-          PR_HEAD_REF="$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName --jq .headRefName)"
-
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "pr_head_ref=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
 
+      # Base repo only. This job is privileged (pull_request_target / issue_comment:
+      # it holds secrets and a write-capable token), so the PR head is never checked
+      # out or fetched here. The diff and per-file context are pulled through the gh
+      # API in later steps and treated purely as data.
       - name: Checkout base repo
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: Fetch PR head
-        shell: bash
-        env:
-          PR_NUMBER: ${{ steps.mode.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-          # Fetch the PR merge ref — works for both same-repo and fork PRs
-          # (fork branches don't exist on origin, but pull/<n>/head always does)
-          git fetch origin "pull/${PR_NUMBER}/head"
 
       - name: Resolve review state
         id: state

--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -11,8 +11,11 @@ concurrency:
   cancel-in-progress: true
 
 # Least-privilege default: no job in this workflow writes to the repo.
+# pull-requests: read is required by dorny/paths-filter, which reads the PR's
+# changed-file list through the API on pull_request events.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   file-changes:

--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -11,15 +11,19 @@ concurrency:
   cancel-in-progress: true
 
 # Least-privilege default: no job in this workflow writes to the repo.
-# pull-requests: read is required by dorny/paths-filter, which reads the PR's
-# changed-file list through the API on pull_request events.
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   file-changes:
     name: Detect File Changes
+    # Job-level permissions replace the workflow default outright rather than
+    # merging with it, so contents must be restated here. paths-filter reads the
+    # PR's changed-file list via pulls.listFiles; this is the only job that needs
+    # it, so it is granted here instead of workflow-wide.
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: 'ubuntu-latest'
     outputs: 
       checkall: ${{ steps.changes.outputs.checkall }}

--- a/.github/workflows/cleanliness.yml
+++ b/.github/workflows/cleanliness.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   file-changes:
     name: Detect File Changes

--- a/.github/workflows/convergence.yml
+++ b/.github/workflows/convergence.yml
@@ -11,8 +11,11 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 # Least-privilege default: no job in this workflow writes to the repo.
+# pull-requests: read is required by dorny/paths-filter, which reads the PR's
+# changed-file list through the API on pull_request events.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   file-changes:

--- a/.github/workflows/convergence.yml
+++ b/.github/workflows/convergence.yml
@@ -11,15 +11,19 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 # Least-privilege default: no job in this workflow writes to the repo.
-# pull-requests: read is required by dorny/paths-filter, which reads the PR's
-# changed-file list through the API on pull_request events.
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   file-changes:
     name: Detect File Changes
+    # Job-level permissions replace the workflow default outright rather than
+    # merging with it, so contents must be restated here. paths-filter reads the
+    # PR's changed-file list via pulls.listFiles; this is the only job that needs
+    # it, so it is granted here instead of workflow-wide.
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     outputs:
       checkall: ${{ steps.changes.outputs.checkall }}

--- a/.github/workflows/convergence.yml
+++ b/.github/workflows/convergence.yml
@@ -10,6 +10,10 @@ on:
 env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   file-changes:
     name: Detect File Changes

--- a/.github/workflows/coverage-health.yml
+++ b/.github/workflows/coverage-health.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 7 * * *'      # daily; loud if the refresh stopped working
   workflow_dispatch:
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   health:
     if: github.repository == 'MFlowCode/MFC'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   file-changes:
     name: Detect File Changes

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,15 +12,19 @@ concurrency:
   cancel-in-progress: true
 
 # Least-privilege default: no job in this workflow writes to the repo.
-# pull-requests: read is required by dorny/paths-filter, which reads the PR's
-# changed-file list through the API on pull_request events.
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   file-changes:
     name: Detect File Changes
+    # Job-level permissions replace the workflow default outright rather than
+    # merging with it, so contents must be restated here. paths-filter reads the
+    # PR's changed-file list via pulls.listFiles; this is the only job that needs
+    # it, so it is granted here instead of workflow-wide.
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: 'ubuntu-latest'
     outputs: 
       checkall: ${{ steps.changes.outputs.checkall }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,8 +12,11 @@ concurrency:
   cancel-in-progress: true
 
 # Least-privilege default: no job in this workflow writes to the repo.
+# pull-requests: read is required by dorny/paths-filter, which reads the PR's
+# changed-file list through the API on pull_request events.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   file-changes:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
     branches: [master]
   pull_request:
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Verify

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   docs:
     name:    Formatting

--- a/.github/workflows/fp-stability.yml
+++ b/.github/workflows/fp-stability.yml
@@ -36,15 +36,19 @@ on:
   workflow_dispatch:
 
 # Least-privilege default: no job in this workflow writes to the repo.
-# pull-requests: read is required by dorny/paths-filter, which reads the PR's
-# changed-file list through the API on pull_request events.
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   file-changes:
     name: Detect File Changes
+    # Job-level permissions replace the workflow default outright rather than
+    # merging with it, so contents must be restated here. paths-filter reads the
+    # PR's changed-file list via pulls.listFiles; this is the only job that needs
+    # it, so it is granted here instead of workflow-wide.
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     outputs:
       checkall: ${{ steps.changes.outputs.checkall }}

--- a/.github/workflows/fp-stability.yml
+++ b/.github/workflows/fp-stability.yml
@@ -35,6 +35,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   file-changes:
     name: Detect File Changes

--- a/.github/workflows/fp-stability.yml
+++ b/.github/workflows/fp-stability.yml
@@ -36,8 +36,11 @@ on:
   workflow_dispatch:
 
 # Least-privilege default: no job in this workflow writes to the repo.
+# pull-requests: read is required by dorny/paths-filter, which reads the PR's
+# changed-file list through the API on pull_request events.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   file-changes:

--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -21,6 +21,10 @@ on:
         type: boolean
         default: false
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   update-homebrew-tap:
     name: Update homebrew-mfc tap

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -11,6 +11,10 @@ on:
       - '.github/workflows/homebrew.yml'
   workflow_dispatch:
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   # Fast smoke tests that run before expensive operations
   smoke-test:

--- a/.github/workflows/lint-toolchain.yml
+++ b/.github/workflows/lint-toolchain.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   lint-toolchain:
     name:    Lint Toolchain

--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:    
   pmd:
       name: PMD

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   run:
     name: Spell Check

--- a/.github/workflows/test-toolchain-compat.yml
+++ b/.github/workflows/test-toolchain-compat.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   test-toolchain:
     name: "Python ${{ matrix.python-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 # Least-privilege default: no job in this workflow writes to the repo.
+# pull-requests: read is required by dorny/paths-filter, which reads the PR's
+# changed-file list through the API on pull_request events.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   lint-gate:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 # Least-privilege default: no job in this workflow writes to the repo.
-# pull-requests: read is required by dorny/paths-filter, which reads the PR's
-# changed-file list through the API on pull_request events.
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   lint-gate:
@@ -57,6 +54,13 @@ jobs:
 
   file-changes:
     name: Detect File Changes
+    # Job-level permissions replace the workflow default outright rather than
+    # merging with it, so contents must be restated here. paths-filter reads the
+    # PR's changed-file list via pulls.listFiles; this is the only job that needs
+    # it, so it is granted here instead of workflow-wide.
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: 'ubuntu-latest'
     outputs:
       checkall: ${{ steps.changes.outputs.checkall }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
+# Least-privilege default: no job in this workflow writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   lint-gate:
     name: Lint Gate


### PR DESCRIPTION
Clears all 27 open [code-scanning alerts](https://github.com/MFlowCode/MFC/security/code-scanning). Both classes live in GitHub Actions workflows — no Fortran or toolchain source is touched.

## `missing-workflow-permissions` — 26 alerts, medium

No workflow declared a `permissions:` block, so every job inherited the repository-default `GITHUB_TOKEN` scope. That's read-only under current settings, but it's settings-dependent and would silently become write if the org default ever changed.

I checked what each flagged job actually does with the token: **none of the 26 write to the repo via `GITHUB_TOKEN`**. The three jobs that do publish use their own secrets instead — `docs.yml` clones `secrets.DOC_PUSH_URL`, `homebrew-release.yml` uses `secrets.TAP_REPO_TOKEN`, `coverage.yml` uses `secrets.CODECOV_TOKEN`. So a workflow-level read default is sufficient everywhere:

```yaml
# Least-privilege default: no job in this workflow writes to the repo.
permissions:
  contents: read
```

Applied to `bench`, `cleanliness`, `convergence`, `coverage-health`, `coverage`, `docs`, `formatting`, `fp-stability`, `homebrew-release`, `homebrew`, `lint-toolchain`, `pmd`, `spelling`, `test-toolchain-compat`, `test`. All 21 workflows now declare permissions at workflow or job level, and every file still parses as YAML.

## `untrusted-checkout/high` — 1 alert, high (#57)

`claude-code-review.yml` runs privileged — `pull_request_target` + `issue_comment`, so it holds `CLAUDE_CODE_OAUTH_TOKEN` along with `pull-requests: write` and `issues: write` — and it fetched fork commits into that privileged workspace via `git fetch origin pull/<n>/head`.

That step turned out to be **dead code**: nothing read `FETCH_HEAD`, and the `pr_head_ref` output was written to `$GITHUB_OUTPUT` and never consumed. The review already sources its diff and per-file context through `gh` API calls that treat fork content as data rather than as checked-out code. So the step and the unused output are removed outright rather than sandboxed — the flagged pattern goes away with no behavior change.

A comment on the remaining `actions/checkout` records why the base repo is the only thing checked out, so the fetch doesn't get reintroduced later.

## Follow-ups, not addressed here

Two things worth a separate look — neither is flagged by CodeQL and neither is fixed in this PR:

- **Prompt-injection surface remains in `claude-code-review.yml`.** Claude reads an attacker-authored diff while running `--dangerously-skip-permissions` with `Bash` allowed, in a job holding write scopes. `claude-code-action` gating on the triggering actor's write access is the main protection. Since the review comment is already posted by a *separate* step, the job could be split — review at `contents: read`, publish at `pull-requests: write` — so the model's step holds no write token at all.
- ~~**`bench.yml`'s `pull_request_review` path may be a functional bug.**~~ **Retracted — I checked and this was wrong.** On `pull_request_review`, `actions/checkout` resolves to the PR merge ref (`refs/remotes/pull/<n>/merge`), not the base branch, so `Clone - PR` clones the PR as intended. Verified against run logs, and confirmed end-to-end: PR #1772's approval at `18:32:41Z` triggered a bench run 4 seconds later in which all six Phoenix/Frontier jobs ran for 34–175 minutes. No bug here.

https://claude.ai/code/session_01XPqfEaUBG7ZaZVzeMWnKHd

