### PR TITLE
Fix LF volume-fraction flux and interface velocity

### DIFF
--- a/src/simulation/m_riemann_solver_lf.fpp
+++ b/src/simulation/m_riemann_solver_lf.fpp
@@ -306,11 +306,12 @@ contains
                             ! Advection flux and source: interface velocity for volume fraction transport
                             $:GPU_LOOP(parallelism='[seq]')
                             do i = eqn_idx%adv%beg, eqn_idx%adv%end
-                                flux_rsx_vf(${SF('')}$, i) = (qL_prim_rsx_vf(${SF('')}$, i) - qR_prim_rsx_vf(${SF(' + 1')}$, &
-                                            & i))*s_M*s_P/(s_M - s_P)
-                                flux_src_rsx_vf(${SF('')}$, i) = (s_M*qR_prim_rsx_vf(${SF(' + 1')}$, &
-                                                & i) - s_P*qL_prim_rsx_vf(${SF('')}$, i))/(s_M - s_P)
+                                flux_rsx_vf(${SF('')}$, i) = (s_M*qR_prim_rsx_vf(${SF(' + 1')}$, &
+                                            & i)*vel_R(norm_dir) - s_P*qL_prim_rsx_vf(${SF('')}$, &
+                                            & i)*vel_L(norm_dir) + s_M*s_P*(qL_prim_rsx_vf(${SF('')}$, &
+                                            & i) - qR_prim_rsx_vf(${SF(' + 1')}$, i)))/(s_M - s_P)
                             end do
+                            flux_src_rsx_vf(${SF('')}$, eqn_idx%adv%beg) = (s_M*vel_R(norm_dir) - s_P*vel_L(norm_dir))/(s_M - s_P)
 
                             if (bubbles_euler) then
                                 ! From HLLC: Kills mass transport @ bubble gas density
@@ -345,7 +346,7 @@ contains
                                     ! Geometrical source of the void fraction(s) is zero
                                     $:GPU_LOOP(parallelism='[seq]')
                                     do i = eqn_idx%adv%beg, eqn_idx%adv%end
-                                        flux_gsrc_rsx_vf(${SF('')}$, i) = flux_rsx_vf(${SF('')}$, i)
+                                        flux_gsrc_rsx_vf(${SF('')}$, i) = 0._wp
                                     end do
                                 end if
                             #:endif


### PR DESCRIPTION
Fixes #1818.

MFC’s LF solver selects the formulation in which the RHS reads the first fraction source entry as a shared face normal velocity. The solver currently writes an averaged volume fraction there and returns only the dissipative part of the fraction flux. For identical states with alpha=0.25 and velocity=2, it returns flux=0 and interface velocity=0.25.

This PR restores the advective contribution to the LF flux and exports the shared velocity. The same input then gives flux=0.5 and velocity=2. For reconstructed fractions summing to one, the summed fraction flux equals that shared velocity, allowing the conservative flux and nonconservative source to preserve the volume partition.

The radial fraction geometric source is set to zero because the geometric contributions from conservative transport and the fraction source cancel in this formulation.

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:
- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm this PR meets the above expectations and reflects my own understanding and real-world context.

---

_PR template credit: junegunn_
