### PR TITLE
Restore negative slopes in the SUPERBEE limiter

### DIFF
--- a/src/simulation/m_muscl.fpp
+++ b/src/simulation/m_muscl.fpp
@@ -203,6 +203,7 @@ contains
                                             slope = -1._wp*min(-min(2._wp*abs(slopeL), abs(slopeR)), -min(abs(slopeL), &
                                                                & 2._wp*abs(slopeR)))
                                         end if
+                                        if (slopeL < 0._wp) slope = -slope
                                     end if
 
                                     ! reconstruct from left side


### PR DESCRIPTION
Fixes #1819.

The second order MUSCL implementation computes the SUPERBEE slope magnitude using absolute values but omits its sign. Consequently, decreasing data are reconstructed with an increasing slope.

For cell values (3, 2, 1), both neighboring differences are negative. The correct limited slope is negative one, giving reconstructed left and right values of 2.5 and 1.5 around the central value 2. The current code produces the opposite ordering.

This PR restores the slope sign from slopeL. The existing minmod and MC implementations already apply this sign correction after computing the limited magnitude:

https://github.com/MFlowCode/MFC/blob/40a7d418f84403dc07b483177554b8430ee89907/src/simulation/m_muscl.fpp#L182-L192

The correction is in the shared reconstruction template and therefore applies to all three spatial directions.

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:
- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm this PR meets the above expectations and reflects my own understanding and real-world context.

---

_PR template credit: junegunn_
