### PR TITLE
Restore pT equilibrium after phase depletion

### DIFF
--- a/src/common/m_phase_change.fpp
+++ b/src/common/m_phase_change.fpp
@@ -137,6 +137,11 @@ contains
                         q_cons_vf(vp + eqn_idx%cont%beg - 1)%sf(j, k, l) = m2
 
                         call s_infinite_ptg_relaxation_k(j, k, l, pS, rhoe, q_cons_vf, TS)
+
+                        if (q_cons_vf(lp + eqn_idx%cont%beg - 1)%sf(j, k, &
+                            & l) == 0.0_wp .or. q_cons_vf(vp + eqn_idx%cont%beg - 1)%sf(j, k, l) == 0.0_wp) then
+                            call s_infinite_pt_relaxation_k(j, k, l, 2, pS, p_infpT, q_cons_vf, rhoe, TS)
+                        end if
                     end if
 
                     ! Calculations AFTER equilibrium


### PR DESCRIPTION
Fixes #1820.

During relax_model=6 relaxation, the pTg solver can project a reacting phase mass to zero while returning pressure and temperature that do not satisfy volume and energy closure for the final masses. Reconstructing fractions and phasic energies from that state then produces inconsistent conservative variables.

The existing D21F4F38 golden contains zero liquid mass and a vapor volume fraction of 1.051528. With liquid absent, vapor must occupy the entire cell. Its stored phasic internal energies also fail to sum to the mixture internal energy obtained from total energy and momentum.

This PR calls the existing pT solver whenever either reacting mass is exactly zero after pTg relaxation. The pT solve uses the final masses and conserved mixture internal energy to recover pressure and temperature before reconstructing fractions and phasic energies. The exact zero check matches the endpoints explicitly produced by the mass projection.

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:
- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm this PR meets the above expectations and reflects my own understanding and real-world context.

---

_PR template credit: junegunn_
