### PR TITLE
ci: submit Phoenix GPU test jobs to a partition list for backfill

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -126,13 +126,29 @@ elif [ "$device" = "gpu" ]; then
     # Determine GPU partition
     gpu_partition="batch"
     if [ "$gpu_partition_dynamic" = "true" ]; then
-        # Use pre-selected bench partition if available, otherwise query sinfo
-        if [ -n "${BENCH_GPU_PARTITION:-}" ]; then
-            gpu_partition="$BENCH_GPU_PARTITION"
-            echo "Using pre-selected bench partition: $gpu_partition (PR/master consistency)"
+        if [ "$job_type" = "bench" ]; then
+            # Benchmarks compare PR against master, so both jobs must land on the
+            # SAME GPU type or the comparison is meaningless. That rules out a
+            # partition list (SLURM could place PR and master on different
+            # hardware); instead a single partition is picked and pinned across
+            # both jobs via BENCH_GPU_PARTITION. See run_parallel_benchmarks.sh.
+            if [ -n "${BENCH_GPU_PARTITION:-}" ]; then
+                gpu_partition="$BENCH_GPU_PARTITION"
+                echo "Using pre-selected bench partition: $gpu_partition (PR/master consistency)"
+            else
+                source "${SCRIPT_DIR}/select-gpu-partition.sh"
+                gpu_partition="$SELECTED_GPU_PARTITION"
+            fi
         else
-            source "${SCRIPT_DIR}/select-gpu-partition.sh"
-            gpu_partition="$SELECTED_GPU_PARTITION"
+            # Tests (and build+test) don't compare across hardware, so submit to a
+            # partition LIST and let SLURM start on whichever frees first instead
+            # of pinning one partition and queueing behind it. This restores the
+            # multi-partition backfill that #1299 dropped when it unified test and
+            # bench onto the single-partition bench selector. gpu-l40s (bad
+            # hardware) and gpu-rtx6000 (too slow for the test time limit) are
+            # intentionally omitted.
+            gpu_partition="gpu-h200,gpu-h100,gpu-a100,gpu-v100"
+            echo "Using GPU partition list for test job: $gpu_partition"
         fi
     fi
 


### PR DESCRIPTION
## What

Phoenix GPU **test** jobs now submit to a partition list

```
#SBATCH -p gpu-h200,gpu-h100,gpu-a100,gpu-v100
```

instead of a single partition chosen at submit time by `select-gpu-partition.sh`. **Benchmark** jobs are unchanged — they still pick and pin one partition via `BENCH_GPU_PARTITION`.

## Why

Before #1299, Phoenix test jobs already used a partition list (`-p gpu-v100,gpu-a100,gpu-h100,gpu-l40s,gpu-h200`), so SLURM could start the job on whichever partition freed first. #1299 unified test + bench submission onto the single-partition `select-gpu-partition.sh` selector. That selector exists for **benchmarks**, which must run PR and master on the *same* GPU type to be comparable — a constraint tests don't have.

The side effect was that test jobs lost multi-partition backfill: each job is now pinned to one partition and queues behind everything else there. In practice CI has been landing on `gpu-a100` and sitting behind ~80 higher-priority jobs while idle nodes existed on other partitions (e.g. `gpu-v100`). This PR restores the old backfill behavior for tests while keeping the bench selector intact.

## Notes

- `gpu-l40s` is intentionally omitted (out of rotation for bad hardware; 4/10 nodes currently drained by PACE) and `gpu-rtx6000` is omitted (too slow for the test time limit, deep queue), matching the current selector's rotation.
- Bench PR/master consistency is preserved: the `job_type = "bench"` branch is unchanged.
- No change to the per-node `--exclude` seed logic or the preflight resubmit path.