### PR TITLE
ci: add --bind-to none to Phoenix syscheck smoke-test (fixes GPU-node MPI bind failure)

### DIFF
--- a/.github/workflows/common/build.sh
+++ b/.github/workflows/common/build.sh
@@ -41,9 +41,16 @@ source .github/scripts/retry-build.sh
 # aborts in MPI_Init ("OPAL ERROR: Unreachable in file ext3x_client.c"). mpirun
 # is unaffected, and it is how MFC launches every binary anyway. Output is left
 # on stdout so a future failure is diagnosable from the CI log.
+#
+# --bind-to none is required, not cosmetic: on a busy GPU node SLURM hands the job
+# an offset/partial cpuset (e.g. cores 32-47), and Open MPI's default --bind-to
+# core then dies with "hwloc_set_cpubind Error for bitmap" before the binary even
+# starts. The run templates, coverage_build.py and preflight.sh all already pass
+# it; this smoke-test was the lone launch that did not, and it red-crossed jobs
+# that backfilled onto shared GPU nodes.
 validate_cmd=""
 if [ "$job_cluster" = "phoenix" ]; then
-    validate_cmd='syscheck_bin=$(find build/install -name syscheck -type f 2>/dev/null | head -1); [ -z "$syscheck_bin" ] || mpirun -np 1 "$syscheck_bin"'
+    validate_cmd='syscheck_bin=$(find build/install -name syscheck -type f 2>/dev/null | head -1); [ -z "$syscheck_bin" ] || mpirun --bind-to none -np 1 "$syscheck_bin"'
 fi
 
 # --- Variant selection ---


### PR DESCRIPTION
## Symptom

Post-merge, Phoenix `Test Suite` jobs began failing (runs `926a3a5`, `5829daf`) with:

```
hwloc_set_cpubind returned "Error" for bitmap "0"   (orte/mca/rtc/hwloc/rtc_hwloc.c:382)
Open MPI tried to bind a new process ... process was killed without launching
Application name: build/install/gpu-acc-*/bin/syscheck
```

## Root cause

`build.sh`'s post-build syscheck smoke-test launched `mpirun -np 1 "$syscheck_bin"` **without `--bind-to none`**. On a busy GPU node SLURM hands the job an offset/partial cpuset (e.g. cores `32-47`), and Open MPI's default `--bind-to core` then fails at `hwloc_set_cpubind` before the binary starts.

This was a **latent bug**: every other MPI launch already passes `--bind-to none` — the `.mako` run templates, `coverage_build.py`, and `preflight.sh`. This smoke-test was the lone omission. It stayed hidden while test jobs landed on idle nodes; #1833's partition-list change let them backfill onto shared GPU nodes with awkward cpusets, exposing it.

## Evidence

The failing CI job already contains the perfect A/B — same node, same binary, `-np 1`:

| Launch | Command | Result |
|--------|---------|--------|
| preflight.sh | `mpirun --bind-to none -np 1 syscheck` | **passed** |
| build.sh smoke-test | `mpirun -np 1 syscheck` | **failed** (`hwloc_set_cpubind`) |

Reproduced directly on **multiple, distinct** GPU nodes (h100-HGX `atl1-1-03-008-22-0`, h200 `atl1-1-02-012-23-0` — neither is a CI node), confirming it is **not node-specific**:

```
mpirun -np 2/4 hostname            (default)   -> rc=131 "binding generic error"
mpirun --bind-to none -np 2/4 …    (suppressed) -> rc=0
```
A CPU node with an equally fragmented cpuset did **not** reproduce — it is specific to the GPU-node topology.

## Fix

Add `--bind-to none` to the smoke-test `mpirun`, matching every other launch in the repo. One line.

## Verification

- `bash -n` and `python3 toolchain/mfc/lint_source.py` pass locally.
- Grep confirms this was the only bare `mpirun` launch left in `.github/`.