### PR TITLE
ci: request 1 GPU for case-optimization jobs (they only use one)

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -41,9 +41,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Detect job type from submitted script basename
 script_basename="$(basename "$script_path" .sh)"
 case "$script_basename" in
-    bench*)          job_type="bench" ;;
-    build-and-test*) job_type="buildtest" ;;
-    *)               job_type="test"  ;;
+    bench*)                 job_type="bench" ;;
+    build-and-test*)        job_type="buildtest" ;;
+    run_case_optimization*) job_type="caseopt" ;;
+    *)                      job_type="test"  ;;
 esac
 
 # --- Cluster configuration ---
@@ -138,6 +139,18 @@ elif [ "$device" = "gpu" ]; then
         echo "Using GPU partition list: $gpu_partition"
     fi
 
+    # Case-optimization runs tiny single-GPU smoke cases (run_case_optimization.sh
+    # calls `mfc.sh run -n $ngpus` with ngpus falling back to 1), so it needs only
+    # ONE GPU. Requesting two forces SLURM onto a node with two *free* GPUs -- far
+    # harder to find under queue contention -- and case-opt jobs were sitting
+    # PENDING to the 8h GitHub timeout as a result. The test suite exercises
+    # multi-GPU MPI and keeps two.
+    if [ "$job_type" = "caseopt" ]; then
+        gpu_count=1
+    else
+        gpu_count=2
+    fi
+
     case "$cluster" in
         phoenix)
             # --exclude is rendered separately (see $node_exclude) so the
@@ -145,7 +158,7 @@ elif [ "$device" = "gpu" ]; then
             sbatch_device_opts="\
 #SBATCH -p $gpu_partition
 #SBATCH --ntasks-per-node=4
-#SBATCH -G2"
+#SBATCH -G${gpu_count}"
             node_exclude="atl1-1-03-007-29-0,atl1-1-03-007-31-0"
             ;;
         frontier|frontier_amd)


### PR DESCRIPTION
## Problem

Phoenix `Case Opt` GPU jobs have been red-crossing by **never getting scheduled**. Example (run [34246706326](https://github.com/MFlowCode/MFC/actions/runs/34246706326)):

```
shb-run-case-optimization  gpu-h200,gpu-h100,gpu-a100,gpu-v100
Submit 13:21   Start: None   Elapsed 00:00:00   State CANCELLED (8h GitHub timeout)
```

It sat PENDING ~7h and was killed at the job's 8h `timeout-minutes`. The GPU partitions are heavily oversubscribed (hundreds pending, 0 idle), so the scheduler couldn't place it.

## Why it's worse than it needs to be

`submit-slurm-job.sh` hardcodes `-G2` for **every** Phoenix GPU job. But `run_case_optimization.sh` runs tiny validation cases — `mfc.sh run <case> --case-optimization -n $ngpus -- --gbpp 1 --steps 10` — and `$ngpus` falls back to `1`. It uses **however many GPUs it's granted**; it does not need two.

Requesting `-G2` forces SLURM to find a node with **two free GPUs**, which is dramatically harder under contention than one. So case-opt starves while single-GPU work could have backfilled.

## Fix

Give case-optimization jobs `-G1`; keep `-G2` for everything else (the test suite exercises multi-GPU MPI; bench-pair uses 2). Implemented via a new `caseopt` job type keyed off the submitted script name:

```
run_case_optimization*) job_type="caseopt" ;;   # -> -G1
```

Render check (from the exact case logic):

| Submitted script | job_type | -G |
|---|---|---|
| run_case_optimization.sh | caseopt | **1** |
| common/test.sh | test | 2 |
| common/build-and-test.sh | buildtest | 2 |
| common/bench-pair.sh | bench | 2 |

Case-opt validates that case-optimized binaries build and run; one GPU is sufficient for that (the run becomes `-n 1` instead of `-n 2`). This does not reduce coverage of the optimization itself.

## Verification

- `bash -n` and `python3 toolchain/mfc/lint_source.py` pass.
- Only the case-opt path changes; test/buildtest/bench are byte-identical (`-G2`).

## Note

This eases scheduling but the underlying cause is GPU-cluster oversubscription; it does not create capacity. Bad/oversubscribed-cluster starvation of the 2-GPU test jobs is a separate, capacity-level issue.