### PR TITLE
Raise the probe limit from 10 to 64

### DIFF
--- a/src/common/m_constants.fpp
+++ b/src/common/m_constants.fpp
@@ -22,7 +22,7 @@ module m_constants
     integer, parameter  :: dflt_int = -100          !< Default integer value
     integer, parameter  :: fourier_rings = 5        !< Fourier filter ring limit
     integer, parameter  :: num_fluids_max = 10      !< Maximum number of fluids in the simulation
-    integer, parameter  :: num_probes_max = 10      !< Maximum number of flow probes in the simulation
+    integer, parameter  :: num_probes_max = 64      !< Maximum number of flow probes in the simulation
     integer, parameter  :: num_patches_max = 10     !< Maximum number of IC patches
     integer, parameter  :: num_ib_airfoils_max = 5  !< Maximum number of ib_airfoil instances
     integer, parameter  :: num_stl_models_max = 10

--- a/toolchain/mfc/params/definitions.py
+++ b/toolchain/mfc/params/definitions.py
@@ -27,7 +27,7 @@ def _fc(name: str, default: int) -> int:
 
 
 NF = _fc("num_fluids_max", 10)  # fluid_pp
-NPR = _fc("num_probes_max", 10)  # probe, acoustic
+NPR = _fc("num_probes_max", 64)  # probe, acoustic
 NB = _fc("num_bc_patches_max", 10)  # patch_bc
 NUM_PATCHES_MAX = _fc("num_patches_max", 10)  # patch_icpp (Fortran array bound)
 NIB = _fc("num_ib_patches_max_namelist", 54000)  # patch_ib namelist array bound


### PR DESCRIPTION
`num_probes_max` (which also bounds the acoustic source array) is 10. That is restrictive for sensor arrays: the study I am running needs 24 probes on a flapping wing and 38 on a jet — a lip ring, a lip line, a centreline rake and a near-field acoustic arc — so the current limit forces a case to be split or instrumented less than intended.

The bounded arrays hold three reals per probe, so the static cost of raising the limit is negligible. The toolchain default in `params/definitions.py` is kept in step with the Fortran constant, as the co-location check requires.

Tested on Frontier with a 24-probe 3D case: all 24 probe files are written.

https://claude.ai/code/session_01HMJ7cycfo7kTFSFq5yhHLG