### PR TITLE
Require the full inflow state when grcbc_in is enabled

### DIFF
--- a/toolchain/mfc/case_validator.py
+++ b/toolchain/mfc/case_validator.py
@@ -1793,6 +1793,14 @@ class CaseValidator:
             if grcbc_in:
                 # Check if EITHER beg OR end is set to -7
                 self.prohibit(bc_beg != -7 and bc_end != -7, f"Subsonic Inflow (grcbc_in) requires bc_{dir}%beg = -7 or bc_{dir}%end = -7")
+                # The relaxation drives the boundary towards a prescribed state, so that state has to be given in
+                # full. An unset component keeps its default sentinel and the boundary diverges over a few hundred
+                # steps rather than failing outright, which is a hard failure to read backwards from an ICFL abort.
+                num_fluids = self.get("num_fluids", 1)
+                missing = [n for n in (f"bc_{dir}%pres_in", f"bc_{dir}%vel_in(1)") if self.get(n) is None]
+                missing += [f"bc_{dir}%alpha_rho_in({i})" for i in range(1, num_fluids + 1) if self.get(f"bc_{dir}%alpha_rho_in({i})") is None]
+                missing += [f"bc_{dir}%alpha_in({i})" for i in range(1, num_fluids + 1) if self.get(f"bc_{dir}%alpha_in({i})") is None]
+                self.prohibit(len(missing) > 0, f"Subsonic Inflow (grcbc_in) needs the full inflow state; missing {', '.join(missing)}")
             if grcbc_out:
                 # Check if EITHER beg OR end is set to -8
                 self.prohibit(bc_beg != -8 and bc_end != -8, f"Subsonic Outflow (grcbc_out) requires bc_{dir}%beg = -8 or bc_{dir}%end = -8")


### PR DESCRIPTION
A GRCBC subsonic inflow relaxes the boundary towards a prescribed state, so that state has to be given in full: velocity, pressure, partial densities and volume fractions. The validator checked only that the boundary type was `-7`.

Leaving `alpha_rho_in` and `alpha_in` unset does not fail. The boundary keeps its default sentinel and the solution diverges over a few hundred steps, which surfaces as an ICFL abort a long way from the cause:

```
                    22    0.002730   0.060069   0.402081
                    42    0.002730   0.114677   0.542220
                    62    0.002730   0.169285   0.783443
                    75    0.002730   0.204780   1.008977
 ICFL is greater than 1.0. Exiting.
```

Flat, then exponential. That cost me two runs before I compared against a case that worked, which is a poor way to learn that four parameters are mandatory rather than three.

The new check accepts every example case in the tree (`./mfc.sh precheck` passes, including "Validating example cases") and rejects exactly the configuration that diverged:

| case | result |
|---|---|
| complete inflow state | accepted |
| same case with `alpha_rho_in`/`alpha_in` removed | `Subsonic Inflow (grcbc_in) needs the full inflow state; missing bc_x%alpha_rho_in(1), bc_x%alpha_in(1)` |

https://claude.ai/code/session_01HMJ7cycfo7kTFSFq5yhHLG