### PR TITLE
Pin a baseline CPU target for Phoenix NVHPC builds

### DIFF
--- a/toolchain/modules
+++ b/toolchain/modules
@@ -45,6 +45,11 @@ p-gpu OPAL_PREFIX=$NVHPC_ROOT/comm_libs/12.9/hpcx/hpcx-2.22.1/ompi PMIX_MCA_gds=
 p-gpu PATH=$NVHPC_ROOT/comm_libs/mpi/bin:$NVHPC_ROOT/cuda/12.9/bin:$PATH
 p-gpu LD_LIBRARY_PATH=$NVHPC_ROOT/math_libs/12.9/targets/x86_64-linux/lib:$NVHPC_ROOT/cuda/12.9/targets/x86_64-linux/lib:$NVHPC_ROOT/cuda/12.9/lib64:$NVHPC_ROOT/compilers/lib:$LD_LIBRARY_PATH
 p-gpu CC=$NVHPC_ROOT/comm_libs/mpi/bin/mpicc CXX=$NVHPC_ROOT/comm_libs/mpi/bin/mpicxx FC=$NVHPC_ROOT/comm_libs/mpi/bin/mpifort
+# Phoenix's compute nodes are heterogeneous and a job's build and run can land on different ones
+# (the case-optimization lane submits the prebuild and the run as separate allocations), so a
+# natively targeted binary can meet a node that lacks an instruction it uses and die with SIGILL.
+# preflight.sh probes with syscheck, which is too small to trip it. Pin a baseline instead.
+p-gpu FFLAGS=-tp=px CFLAGS=-tp=px CXXFLAGS=-tp=px
 p-gpu-unload xalt
 
 pifx     GT Phoenix (IFX)


### PR DESCRIPTION
An experiment, not a settled fix - see the tradeoff below before merging.

## What this is chasing

#1845's Case Opt lane has failed four times over 24 hours, always the same way:

```
[atl1-1-01-002-28-0] Caught signal 4 (Illegal instruction: illegal operand)
 1  m_global_parameters_s_assign_default_values_to_user_inputs_()
 2  m_start_up_s_initialize_mpi_domain_()
pre_process failed with exit code 132
```

All four attempts ran on node `atl1-1-01-002-28-0`; no passing Case Opt job on any PR has run on that node. The change it carries cannot be the cause: `num_probes_max` appears nowhere in `src/common/` or `src/pre_process/`, the generated Fortran is byte-identical at 10 and 64, and I reproduced CI's exact build (same slug `gpu-mp-0e981924c0`, case-optimized, `--gpu mp`, MPI) under both NVHPC 24.1 and 25.5 locally, where `pre_process` runs clean. What #1845 does do is change `m_constants.fpp`, which forces a full rebuild of everything downstream.

The mechanism the repo already documents:

- `run_case_optimization.sh`: *"these scripts nuke and rebuild build/ themselves (Phoenix does so precisely because its compute nodes are heterogeneous)"*.
- `node-exclude.sh`: the preflight is meant to catch *"SIGILL from a binary built for another microarchitecture"*.
- `toolchain/modules` sets no `-tp` for `p-gpu`, so nvfortran targets the build host's native CPU.
- The case-opt lane submits `prebuild-case-optimization.sh` and `run_case_optimization.sh` as **separate** `submit-slurm-job.sh` calls, so the build and the run can land on different nodes. #1845's logs show exactly that - built on `atl1-1-02-*`, run on `atl1-1-01-002-28-0`.
- `preflight.sh` probes the node with `syscheck`, which is small enough that it does not use the instructions that differ. It passes, `MFC_FAULT_NODE` is never emitted, and the node is never excluded.

So a natively targeted binary built on a newer node meets an older one and dies in `pre_process`, and the guard that exists for precisely this cannot see it.

## The tradeoff, which is the part to decide

`-tp=px` is the fully generic x86-64 target: no AVX, AVX2 or AVX-512. For the GPU lanes the host code is not where the time goes, but `pre_process` and `post_process` are CPU-only and will get slower, and the Phoenix **Bench** numbers will move. If the benchmark series is meant to be comparable over time, that matters more than the build time does.

Two alternatives that keep vectorization, either of which I would prefer if we can get the information:

1. **Pin the lowest common denominator actually present.** If the oldest Phoenix GPU node is, say, Skylake or Zen 2, `-tp=skylake` / `-tp=zen2` is correct and costs almost nothing on the newer nodes. I do not know Phoenix's node inventory; you likely do.
2. **Unified binary.** nvfortran accepts `-tp=<a>,<b>`, emitting multiple code paths with runtime dispatch - full speed on new nodes, correct on old ones, at the cost of binary size and compile time.

There are also two fixes that leave the flags alone: make `preflight.sh` probe a real binary (`pre_process`) rather than `syscheck`, so the existing node-exclusion machinery actually fires; or run the case-opt prebuild and run in one allocation so they cannot land on different nodes. Those are better targeted but larger changes.

## How to tell whether it worked

Merging this and re-running #1845's Case Opt lane is the test. Until the lane lands on `atl1-1-01-002-28-0` again, a pass proves nothing - the failure needs that node. Worth re-running a few times, or excluding everything else, to force it there.
