### PR TITLE
ci: exclude faulty Phoenix node atl1-1-01-002-28-0

### DIFF
--- a/.github/scripts/submit-slurm-job.sh
+++ b/.github/scripts/submit-slurm-job.sh
@@ -159,7 +159,7 @@ elif [ "$device" = "gpu" ]; then
 #SBATCH -p $gpu_partition
 #SBATCH --ntasks-per-node=4
 #SBATCH -G${gpu_count}"
-            node_exclude="atl1-1-03-007-29-0,atl1-1-03-007-31-0"
+            node_exclude="atl1-1-03-007-29-0,atl1-1-03-007-31-0,atl1-1-01-002-28-0"
             ;;
         frontier|frontier_amd)
             sbatch_device_opts="\


### PR DESCRIPTION
## Description

Node `atl1-1-01-002-28-0` on Phoenix is faulty. It caused two distinct CI failures, both landing on that same node:

- **Case-optimization (gpu-omp), run [34611616646](https://github.com/MFlowCode/MFC/actions/runs/34611616646)**: all 5 benchmarks (`5eq_rk3_weno3_hllc`, `viscous_weno5_sgb_acoustic`, `hypo_hll`, `ibm`, `igr`) died in `pre_process` with SIGILL ("Illegal instruction: illegal operand", exit 132) at the very first init routine (`s_assign_default_values_to_user_inputs`, `m_global_parameters.fpp:322`) — identical across unrelated cases.
- **Full Test Suite (gpu-acc), run [34673679046](https://github.com/MFlowCode/MFC/actions/runs/34673679046)**: 23 failures — tolerance mismatches plus "Pressure relaxation produced a non-physical phasic density" `MPI_ABORT` crashes.

`master` was intermittently green on the same commit lineage, so this is a bad node rather than a code regression. This PR adds the node to the static Phoenix GPU `--exclude` list. The runtime preflight doesn't catch it because the faults happen during the actual run, not preflight.

## Type of change

- [x] Something else (CI/infrastructure)

## Scope

- This PR comprises a single, focused change (one node added to the exclude list).

## How Has This Been Tested?

CI-config only; no code paths changed. The existing `$node_exclude` render (`#SBATCH --exclude=...`) is unchanged in mechanism.

## Checklist

- [x] I ran `./mfc.sh format` on modified files — N/A (shell/CI script, no Fortran/Python source changed)
- [x] This PR does not change CFD results

_Done with Claude Code._